### PR TITLE
サイト全体のアクセシビリティを改善

### DIFF
--- a/webapp/e2e/tests/organization.spec.ts
+++ b/webapp/e2e/tests/organization.spec.ts
@@ -66,18 +66,18 @@ test.describe("政治団体ページ", () => {
 			await page.goto("/o/sample-party");
 
 			// セレクターボタンをクリック
-			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
+			const selectorButton = page.getByRole("combobox", { name: /表示する政治団体,/ });
 			await selectorButton.click();
 
 			// ドロップダウンが開いて選択肢が表示される
-			await expect(page.getByText("表示する政治団体")).toBeVisible();
+			await expect(page.getByText("E2Eテスト団体")).toBeVisible();
 		});
 
 		test("別の政治団体を選択するとページが切り替わる", async ({ page }) => {
 			await page.goto("/o/sample-party");
 
 			// セレクターを開く
-			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
+			const selectorButton = page.getByRole("combobox", { name: /表示する政治団体,/ });
 			await selectorButton.click();
 
 			// ドロップダウン内の選択肢をクリック（E2Eテスト団体が存在する場合）
@@ -127,7 +127,7 @@ test.describe("政治団体ページ", () => {
 			await page.goto("/o/sample-party/transactions");
 
 			// セレクターを開く
-			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
+			const selectorButton = page.getByRole("combobox", { name: /表示する政治団体,/ });
 			await selectorButton.click();
 
 			// ドロップダウン内の選択肢をクリック

--- a/webapp/src/app/o/[slug]/transactions/page.tsx
+++ b/webapp/src/app/o/[slug]/transactions/page.tsx
@@ -105,9 +105,7 @@ export default async function TransactionsPage({ params, searchParams }: Transac
         <MainColumn>
           <MainColumnCard>
             <CardHeader
-              icon={
-                <Image src="/icons/icon-cashback.svg" alt="Cash move icon" width={30} height={30} />
-              }
+              icon={<Image src="/icons/icon-cashback.svg" alt="" width={30} height={30} />}
               organizationName={organization?.displayName || "未登録の政治団体"}
               title="すべての出入金"
               updatedAt={updatedAt}

--- a/webapp/src/client/components/common/ExplanationSection.tsx
+++ b/webapp/src/client/components/common/ExplanationSection.tsx
@@ -11,23 +11,23 @@ export default function ExplanationSection() {
             みらい まる見え政治資金について
           </h3>
           <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium sm:font-normal font-japanese">
-            本プロジェクトは、チームみらいによって政治資金の透明化を目的に開発されたオープンソースソフトウェアです。決済データは、クレジットカード、デビットカード、銀行口座を通じて収集され、現状不定期で更新されています。すでにオープンソースで
+            本プロジェクトは、チームみらいによって政治資金の透明化を目的に開発されたオープンソースソフトウェアです。決済データは、クレジットカード、デビットカード、銀行口座を通じて収集され、現状不定期で更新されています。すでに
             <a
               href="https://github.com/team-mirai-volunteer/marumie"
               target="_blank"
               rel="noopener noreferrer"
               className="font-bold text-[#238778] underline hover:no-underline"
             >
-              こちらのGitHub
+              GitHubにてオープンソースで無償公開中
             </a>
-            にて無償公開中であり、政党や所属を問わず利用可能な形で提供しております。開発コミュニティにご興味のある方は
+            であり、政党や所属を問わず利用可能な形で提供しております。開発コミュニティにご興味のある方は
             <a
               href="https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-3n6h3a45j-yfNpEPXFcKTcmXZlmRGsyw"
               target="_blank"
               rel="noopener noreferrer"
               className="font-bold text-[#238778] underline hover:no-underline"
             >
-              こちらのSlack
+              チームみらいのSlack
             </a>
             をご覧ください。
           </p>

--- a/webapp/src/client/components/common/TransparencySection.tsx
+++ b/webapp/src/client/components/common/TransparencySection.tsx
@@ -18,16 +18,16 @@ export default function TransparencySection({ title }: TransparencySectionProps)
           <span className="hidden sm:inline">
             <br />
           </span>
-          私たちがなぜここまでオープンにするのか、その理由は
+          私たちがなぜここまでオープンにするのか、
           <a
             href="https://note.com/team_mirai_jp/n/n58fca6f9e4e8"
             target="_blank"
             rel="noopener noreferrer"
             className="font-bold underline hover:no-underline"
           >
-            こちらのnote
+            その理由をnoteでお読みください
           </a>
-          をお読みください。
+          。
         </p>
       </div>
     </div>

--- a/webapp/src/client/components/layout/header/HeaderClient.tsx
+++ b/webapp/src/client/components/layout/header/HeaderClient.tsx
@@ -69,7 +69,7 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
                 {/* Team Mirai Logo */}
                 <Image
                   src="/logos/team-mirai-logo.svg"
-                  alt="Team Mirai Logo"
+                  alt="チームみらい"
                   fill
                   className="object-contain"
                 />
@@ -82,7 +82,7 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
               <div className="h-[45px] relative w-[126px] xl:hidden">
                 <Image
                   src="/logos/service-logo-sp.svg"
-                  alt="みらいまる見え政治資金"
+                  alt="みらいまる見え政治資金 Beta"
                   fill
                   className="object-contain object-left"
                   priority
@@ -92,7 +92,7 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
               <div className="hidden xl:block h-7 relative w-[300px]">
                 <Image
                   src="/logos/service-logo-pc.svg"
-                  alt="みらいまる見え政治資金"
+                  alt="みらいまる見え政治資金 Beta"
                   fill
                   className="object-contain object-left"
                   priority

--- a/webapp/src/client/components/top-page/BalanceSheetSection.tsx
+++ b/webapp/src/client/components/top-page/BalanceSheetSection.tsx
@@ -19,7 +19,7 @@ export default function BalanceSheetSection({
   return (
     <MainColumnCard id="balance-sheet">
       <CardHeader
-        icon={<Image src="/icons/balance.svg" alt="Balance sheet icon" width={30} height={30} />}
+        icon={<Image src="/icons/balance.svg" alt="" width={30} height={30} />}
         organizationName={organizationName || "未登録の政治団体"}
         title="現時点での貸借対照表"
         updatedAt={updatedAt}

--- a/webapp/src/client/components/top-page/CashFlowSection.tsx
+++ b/webapp/src/client/components/top-page/CashFlowSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import "client-only";
 import Image from "next/image";
-import { useState } from "react";
+import { useId, useState } from "react";
 import CardHeader from "@/client/components/layout/CardHeader";
 import MainColumnCard from "@/client/components/layout/MainColumnCard";
 import SankeyChart from "@/client/components/top-page/features/charts/SankeyChart";
@@ -26,6 +26,8 @@ export default function CashFlowSection({
 
   const currentData = activeTab === "political" ? political : friendly;
 
+  const uniqueId = useId();
+
   return (
     <MainColumnCard id="cash-flow">
       <CardHeader
@@ -40,7 +42,7 @@ export default function CashFlowSection({
       <FinancialSummarySection sankeyData={friendly ?? null} />
 
       {/* タブ */}
-      <div className="flex gap-7 border-b border-gray-300 mb-4">
+      <div className="flex gap-7 border-b border-gray-300 mb-4" role="tablist">
         <button
           type="button"
           onClick={() => setActiveTab("friendly")}
@@ -49,6 +51,10 @@ export default function CashFlowSection({
               ? "border-[#238778] text-[#238778]"
               : "border-transparent text-[#9CA3AF] hover:text-gray-600"
           }`}
+          id={`${uniqueId}-friendly-tab`}
+          role="tab"
+          aria-selected={activeTab === "friendly"}
+          aria-controls={`${uniqueId}-sankey-chart-panel`}
         >
           詳細の区分
         </button>
@@ -60,13 +66,24 @@ export default function CashFlowSection({
               ? "border-[#238778] text-[#238778]"
               : "border-transparent text-[#9CA3AF] hover:text-gray-600"
           }`}
+          id={`${uniqueId}-political-tab`}
+          role="tab"
+          aria-selected={activeTab === "political"}
+          aria-controls={`${uniqueId}-sankey-chart-panel`}
         >
           法律上の区分
         </button>
       </div>
 
       {/* サンキー図 */}
-      <div className="md:mx-0 -mx-3 mb-0">
+      <div
+        className="md:mx-0 -mx-3 mb-0"
+        id={`${uniqueId}-sankey-chart-panel`}
+        role="tabpanel"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label={`収支の流れの図: ${activeTab === "friendly" ? "詳細の区分" : "法律上の区分"}`}
+      >
         {currentData ? (
           <SankeyChart data={currentData} />
         ) : (

--- a/webapp/src/client/components/top-page/CashFlowSection.tsx
+++ b/webapp/src/client/components/top-page/CashFlowSection.tsx
@@ -29,7 +29,7 @@ export default function CashFlowSection({
   return (
     <MainColumnCard id="cash-flow">
       <CardHeader
-        icon={<Image src="/icons/icon-cashflow.svg" alt="Cash flow icon" width={30} height={31} />}
+        icon={<Image src="/icons/icon-cashflow.svg" alt="" width={30} height={31} />}
         organizationName={organizationName || "未登録の政治団体"}
         title="収支の流れ"
         updatedAt={updatedAt}

--- a/webapp/src/client/components/top-page/MonthlyTrendsSection.tsx
+++ b/webapp/src/client/components/top-page/MonthlyTrendsSection.tsx
@@ -24,7 +24,7 @@ export default function MonthlyTrendsSection({
   return (
     <MainColumnCard id="monthly-trends">
       <CardHeader
-        icon={<Image src="/icons/icon-barchart.svg" alt="Bar chart icon" width={30} height={30} />}
+        icon={<Image src="/icons/icon-barchart.svg" alt="" width={30} height={30} />}
         organizationName={organizationName || "未登録の政治団体"}
         title="月ごとの収支の推移"
         updatedAt={updatedAt}

--- a/webapp/src/client/components/top-page/TransactionsSection.tsx
+++ b/webapp/src/client/components/top-page/TransactionsSection.tsx
@@ -33,7 +33,7 @@ export default function TransactionsSection({
   return (
     <MainColumnCard id="transactions">
       <CardHeader
-        icon={<Image src="/icons/icon-cashback.svg" alt="Cash move icon" width={30} height={30} />}
+        icon={<Image src="/icons/icon-cashback.svg" alt="" width={30} height={30} />}
         organizationName={organizationName || "未登録の政治団体"}
         title="すべての出入金"
         updatedAt={updatedAt}

--- a/webapp/src/client/components/top-page/TransactionsSection.tsx
+++ b/webapp/src/client/components/top-page/TransactionsSection.tsx
@@ -51,10 +51,10 @@ export default function TransactionsSection({
 
           {/* グラデーションオーバーレイ - テーブルの一番下の部分にかかる */}
           <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-white via-white/70 to-transparent">
-            {/* もっと見るボタン - グラデーション内に配置 */}
+            {/* すべての出入金を見るボタン - グラデーション内に配置 */}
             <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2">
               <Link href={`/o/${slug}/transactions`}>
-                <MainButton>もっと見る</MainButton>
+                <MainButton>すべての出入金を見る</MainButton>
               </Link>
             </div>
           </div>

--- a/webapp/src/client/components/ui/Selector.tsx
+++ b/webapp/src/client/components/ui/Selector.tsx
@@ -109,7 +109,7 @@ export default function Selector({
               onClick={() => closeMenu()}
               ref={(el) => el?.focus()}
               role="combobox"
-              aria-haspopup="menu"
+              aria-haspopup="listbox"
               aria-controls={`${uniqueId}-options-list`}
               aria-expanded={isOpen}
             >
@@ -124,15 +124,15 @@ export default function Selector({
             </button>
 
             {/* Options List */}
-            <div className="px-2 lg:px-4 space-y-1" id={`${uniqueId}-options-list`} role="menu">
+            <div className="px-2 lg:px-4 space-y-1" id={`${uniqueId}-options-list`} role="listbox">
               {options.map((option) => (
                 <button
                   key={option.value}
                   type="button"
                   className="flex items-start gap-2 w-full cursor-pointer hover:bg-gray-50 px-1 py-2 rounded"
                   onClick={() => handleSelect(option.value)}
-                  role="menuitemradio"
-                  aria-checked={currentValue === option.value}
+                  role="option"
+                  aria-selected={currentValue === option.value}
                 >
                   {/* Checkbox */}
                   <div className="flex items-center justify-center w-[18px] h-[18px] mt-0.5">

--- a/webapp/src/client/components/ui/Selector.tsx
+++ b/webapp/src/client/components/ui/Selector.tsx
@@ -77,7 +77,7 @@ export default function Selector({
         onClick={() => toggleMenu()}
         ref={openButtonRef}
         role="combobox"
-        aria-haspopup="menu"
+        aria-haspopup="listbox"
         aria-controls={`${uniqueId}-options-list`}
         aria-expanded={isOpen}
         aria-label={selectedOption ? `${title}, 現在の選択: ${selectedOption.label}` : title}


### PR DESCRIPTION
このサイトを実際にスクリーンリーダで閲覧してみたところ、残念ながら現状では支援技術によるアクセスが非常に難しいと感じました。

それを受けて、文書やナビゲーションの表現でいくつか気になった部分を最低限アクセスできるように改善しました。動作確認は手元でAndroidのTalkBackおよびMacのVoiceOverにて行いました。

メインコンテンツのひとつである図の部分は依然としてアクセス不能ですので、実際にスクリーンリーダを使用し人間によるテストを行うようにして改善を進められるとよいかと思います。

なお、mainブランチへの直PR( #1139 )によってdevelopと前後しているようですが、よくわからないのでとりあえずそのままdevelopに向けておきました。1139はSlackのリンクを変えているので多分このPRとぶつかると思います。

## 修正点

- 06624c92444486cf24643068d438df6351c4c3c9: ヘッダタイトルの代替テキストを改善
  全体で`Team Mirai Logo みらいまる見え政治資金`となっていましたが、このサイトは日本語であり、また画像にある「Beta」の情報が欠落していましたので、`チームみらい みらいまる見え政治資金 Beta`としました。
- 5e354685bc78671a55d2cf7e1faff05fb703a7da: それ自体に意味のないアイコンの代替テキストを空に修正
- 39eccf48a14ad1f6c36f51844e807977c0891c35: 右上の政治団体セレクタで使われている`Selector`コンポーネントについて、[`combobox`](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role)として表現するように改善
  ただし、comboboxにあたるボタンが2つあるなど、コンポーネント自体がかなりトリッキーな実装になっていたため、標準的ではない作りになっています。また、利用者がこのコンポーネントをコンボボックスとして認識できる最低限の対応となっています。例えば、上下キーでの選択ができません。
  コンポーネント自体の実装の見直しも含めて追加の対応を検討していただくとよいかと思います。
- e30a0f9416485992b6a1fb99fe9cf7d908d1d445: 収支の図の詳細な区分と法律上の区分を切り替えるタブのようなボタンが単なるボタンとなっており、支援技術で意味が認識しにくかったため、[`tablist`](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Reference/Roles/tablist_role)として表現するように改善
  こちらも最低限の対応となっており、意味付けのみとなっています。タブによる表現が最適かどうかも含めて追加の対応を検討していただくとよいかと思います。
- 18a21c2fee3775c84d6752a8c1671d1e5e7d505d: noteへのリンクの表現を改善
  コミットメッセージで説明している通り、「こちらのnote」では意味が通りません。
  リンク先で「私たちがなぜここまでオープンにするのか」を説明していることがリンクテキストでわかるようにできればベストですが、元の文章の意図を汲んで大きな書き換えは行わず、「その理由」をリンクに含めることで直前の「私たちがなぜここまでオープンにするのか」との関連性が読み取れるようにしました。
  [デジタル庁デザインシステムによるリンクテキストに関する留意点](https://design.digital.go.jp/dads/foundations/link-text/accessibility/)も参考になります。
- 051dbe179a30ae6c3cb2ca03c143e10e77fe2929: すべての入出金の「もっと見る」を「すべての入出金を見る」に変更
  「もっと見る」ではリンクとして意味が薄いため、明確に「すべての入出金を見る」と書くようにしました。
- eacf7fdfc4a401d796af46a2b7950c58a0b5cca5: こちらリンク
  意味の通じるリンクに直しました。AIエージェントが書いたのだろうと思いますが、このレベルの単純なミスはガイドライン的なもので防げるのではないかなと思います。

## 副次的な変更

- 1ad1bd4c012e3dc6292780dfaec60ee54010dbd6: セレクタコンポーネント内のアクセシブルネームが変わったので、それに対応するようにテストを更新


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * セレクタとタブのキーボード操作性を強化し、スクリーンリーダー向けのARIA対応（combobox/listbox/tabpanel等）を追加しました

* **スタイル／文言**
  * 説明・透明性セクションの表示文言を調整しました
  * ヘッダーや各セクションの画像代替テキストを見直しました（いくつかを空文字化）
  * トランザクション一覧のボタン文言を「すべての出入金を見る」に更新しました

* **テスト**
  * E2Eテストの選択操作をcomboboxベースに更新し、表示名・選択肢表記を調整しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->