### PR TITLE
fix(report): 収支総括表（SYUUSHI07_02）の支出総額に人件費を含める

### DIFF
--- a/admin/src/server/contexts/report/domain/models/report-data.ts
+++ b/admin/src/server/contexts/report/domain/models/report-data.ts
@@ -429,8 +429,9 @@ export const ReportData = {
     // 収入総額 = 前年繰越額 + 本年収入額
     const syunyuSgk = zennenKksGk + honnenSyunyuGk;
 
-    // 経常経費（SYUUSHI07_14）
+    // 経常経費（人件費 + SYUUSHI07_14 の3区分）
     const regularExpenseAmount =
+      Math.round(data.expenses.personnelExpenses.totalAmount) +
       Math.round(data.expenses.utilityExpenses.totalAmount) +
       Math.round(data.expenses.suppliesExpenses.totalAmount) +
       Math.round(data.expenses.officeExpenses.totalAmount);

--- a/admin/tests/server/contexts/report/domain/models/report-data.test.ts
+++ b/admin/tests/server/contexts/report/domain/models/report-data.test.ts
@@ -502,6 +502,7 @@ describe("ReportData", () => {
 
       // 支出総額 = 経常経費(1038000) + 政治活動費(100000)
       expect(summary.sisyutuSgk).toBe(1138000);
+      expect(summary.sisyutuSgk).toBe(expenseSummary.totalAmount);
       expect(expenseSummary.regularExpenses.subtotal.amount).toBe(1038000);
       expect(expenseSummary.politicalActivityExpenses.subtotal.amount).toBe(100000);
       // 翌年繰越額 = 収入総額 - 支出総額

--- a/admin/tests/server/contexts/report/domain/models/report-data.test.ts
+++ b/admin/tests/server/contexts/report/domain/models/report-data.test.ts
@@ -6,6 +6,7 @@ import {
   type ExpenseData as ExpenseDataType,
   type ReportData as ReportDataType,
 } from "@/server/contexts/report/domain/models/report-data";
+import { ExpenseSummaryData } from "@/server/contexts/report/domain/models/expense-summary";
 import { ValidationErrorCode } from "@/server/contexts/report/domain/types/validation";
 
 describe("ExpenseData", () => {
@@ -446,6 +447,7 @@ describe("ReportData", () => {
     it("全ての支出項目を合計して支出総額を計算する", () => {
       const data = createEmptyReportData();
       // 経常経費
+      data.expenses.personnelExpenses.totalAmount = 5000;
       data.expenses.utilityExpenses.totalAmount = 10000;
       data.expenses.suppliesExpenses.totalAmount = 20000;
       data.expenses.officeExpenses.totalAmount = 30000;
@@ -480,8 +482,30 @@ describe("ReportData", () => {
 
       const summary = ReportData.getSummary(data, 0);
 
-      // 支出総額 = 経常経費(60000) + 政治活動費(720000)
-      expect(summary.sisyutuSgk).toBe(780000);
+      // 支出総額 = 経常経費(65000) + 政治活動費(720000)
+      expect(summary.sisyutuSgk).toBe(785000);
+    });
+
+    it("人件費を支出総額に含め、シート13の経常経費小計と整合する", () => {
+      const data = createEmptyReportData();
+      data.donations.personalDonations.totalAmount = 1000000;
+      data.expenses.personnelExpenses.totalAmount = 250000; // シート14に明細は出ないが支出には含まれる
+      data.expenses.utilityExpenses.totalAmount = 135000;
+      data.expenses.suppliesExpenses.totalAmount = 270000;
+      data.expenses.officeExpenses.totalAmount = 383000;
+      data.expenses.organizationExpenses = [
+        { himoku: "", totalAmount: 100000, underThresholdAmount: 0, rows: [] },
+      ];
+
+      const summary = ReportData.getSummary(data, 0);
+      const expenseSummary = ExpenseSummaryData.fromExpenseData(data.expenses);
+
+      // 支出総額 = 経常経費(1038000) + 政治活動費(100000)
+      expect(summary.sisyutuSgk).toBe(1138000);
+      expect(expenseSummary.regularExpenses.subtotal.amount).toBe(1038000);
+      expect(expenseSummary.politicalActivityExpenses.subtotal.amount).toBe(100000);
+      // 翌年繰越額 = 収入総額 - 支出総額
+      expect(summary.yokunenKksGk).toBe(1000000 - 1138000);
     });
 
     it("翌年繰越額を正しく計算する", () => {


### PR DESCRIPTION
Closes #1247

## 検知した事象

本OSSの報告書エクスポートで書き出したXMLをそのまま提出すると、支出総額から人件費が抜けた収支報告書を提出してしまうおそれがあります。

報告書エクスポートで書き出すXMLの中で、**収支総括表（SYUUSHI07_02）の支出総額 `SISYUTU_SGK` に人件費が入っていません**。支出項目別の総括表（SYUUSHI07_13）は人件費を `JINKENHI_GK` として出し、経常経費小計 `KEIHI_SKEI_GK` にも含めているので、同じXMLの中で「その2の支出総額」と「その13の経常経費小計＋政治活動費小計」が人件費のぶんだけ食い違います。翌年繰越額 `YOKUNEN_KKS_GK` もそのぶん多く出ます。

原因は `admin/src/server/contexts/report/domain/models/report-data.ts` の `getSummary` で、経常経費を光熱水費・備品消耗品費・事務所費の3つだけで合算していることです（`ExpenseData` には `personnelExpenses` があり、「シート13の総括表に必要」とコメントされていますが、ここでは使われていません）。

## あるべき姿

政治資金規正法12条1項2号は「すべての支出について、その総額及び総務省令で定める項目別の金額」を求めていて、人件費や光熱水費が除かれるのは、そのあとに続く明細（支出を受けた者の氏名・住所）のほうです。手引きでも経常経費は「総額を記載し、領収書は不要」です。総務省の収支報告書作成ソフトでは、その2の `SISYUTU_SGK` は「その13を参照する数式」になっています（このリポジトリの `docs/reference/reference_syushi-soft-vba-code.txt` 13855〜13858行）。したがって、その2の支出総額は人件費を含む経常経費＋政治活動費であるべきで、その13の小計の和と一致するべきです。

## 再現手順（修正前）

コミット `61572cf3` の main を `docs/getting-started.md` の手順で起動し、同梱シード（サンプル党・2025年）をそのまま使いました。シードには人件費 `T2025-0034`（250,000円）が入っています。

1. 管理画面 → 報告書エクスポート → 政治団体「サンプル党」・報告年「2025」
2. 表形式プレビューの「収支総括表 (SYUUSHI07_02)」を見る → 支出総額 **¥3,491,000**
3. XMLプレビュー（または「XMLをダウンロード」）で `SYUUSHI07_02` → `SISYUTU_SGK` = **3491000**
4. 同じXMLの `SYUUSHI07_13` → `JINKENHI_GK` = 250000、`KEIHI_SKEI_GK` = **1038000**、`KATUDOU_SKEI_GK` = **2703000**
5. 1,038,000 + 2,703,000 = **3,741,000** で、その2の 3,491,000 と **250,000 円（＝人件費）** ずれる

表形式プレビューの収支総括表（修正前）:

![表形式プレビュー 収支総括表 支出総額 ¥3,491,000](https://github.com/user-attachments/assets/0233e84c-27a1-499b-8211-23ed08659ddc)

XML その2（修正前）:

![XML SYUUSHI07_02 SISYUTU_SGK=3491000](https://github.com/user-attachments/assets/2a355c5b-5201-4566-9798-1d9d30d7ef2d)

XML その13（人件費 250,000 が載り、経常経費小計は 1,038,000）:

![XML SYUUSHI07_13 JINKENHI_GK=250000 KEIHI_SKEI_GK=1038000](https://github.com/user-attachments/assets/8fec041e-d9b4-42e9-a1f8-c1622f94fb02)

## 修正内容

- `report-data.ts` `getSummary`: 経常経費の合算に `personnelExpenses.totalAmount` を加える（実質1行。コメントは「経常経費（人件費 + SYUUSHI07_14 の3区分）」に差し替え）
- `report-data.test.ts`:
  - 既存の「全ての支出項目を合計して支出総額を計算する」に人件費 5,000 円を混ぜ、期待値を 785,000 に更新
  - 「人件費を支出総額に含め、シート13の経常経費小計と整合する」を追加。人件費 250,000 を含むデータで `ReportData.getSummary` の `sisyutuSgk` が 1,138,000 になり、同じデータから `ExpenseSummaryData.fromExpenseData` が作る経常経費小計 1,038,000 と政治活動費小計 100,000 の和に一致することを見る

## 修正後の確認

同じ手順で書き出した `SISYUTU_SGK` = **3741000**（= 1,038,000 + 2,703,000）、`YOKUNEN_KKS_GK` = 8,139,000。

表形式プレビューの収支総括表（修正後）:

![表形式プレビュー 収支総括表 修正後 支出総額 ¥3,741,000](https://github.com/user-attachments/assets/6ee20dd5-cf03-4904-a506-eb160f909359)

XML その2（修正後）:

![XML SYUUSHI07_02 修正後 SISYUTU_SGK=3741000](https://github.com/user-attachments/assets/ce184597-ac04-4590-939f-be93c688ee16)

- `pnpm --filter admin test`: 824 passed（1 skipped は既存の integration）
- `pnpm --filter admin type-check`, `biome check`: エラーなし

## 補足

政治資金規正法や収支報告書の実務には詳しくないため、条文・手引き・総務省の収支報告書作成ソフトのVBAを読んだ範囲で書いています。認識に誤りがあればこの PR はクローズしてください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 経常経費の集計に人件費が正しく反映されるようになりました。
  - これに伴い、支出総額および翌年繰越額が正確に計算されます。
  - 人件費を含む支出集計の整合性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->