### PR TITLE
chore: リポジトリ内に残る develop ブランチへの言及を main に置き換える

### DIFF
--- a/.claude/commands/e2e.md
+++ b/.claude/commands/e2e.md
@@ -15,7 +15,7 @@ $ARGUMENTS
 - 引数が指定されている場合: その機能を対象とする
 - 引数がない場合: 以下の順で対象を特定する
   1. unstaged の変更ファイル (`git diff --name-only`)
-  2. develop ブランチからの差分 (`git diff --name-only develop...HEAD`)
+  2. main ブランチからの差分 (`git diff --name-only main...HEAD`)
 
 対象ファイルから `app/` 配下のページコンポーネントを抽出し、E2Eテストが必要な機能を特定する。
 

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -83,7 +83,7 @@ reviews:
     enabled: true
     drafts: true
     base_branches:
-      - develop
+      - main
       - '^epic.*'
   labeling_instructions: []
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![CI](https://github.com/team-mirai/marumie/actions/workflows/ci.yml/badge.svg)](https://github.com/team-mirai/marumie/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/team-mirai/marumie/branch/develop/graph/badge.svg)](https://codecov.io/gh/team-mirai/marumie)
+[![codecov](https://codecov.io/gh/team-mirai/marumie/branch/main/graph/badge.svg)](https://codecov.io/gh/team-mirai/marumie)
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Next.js](https://img.shields.io/badge/Next.js-000000?logo=next.js&logoColor=white)](https://nextjs.org/)
 [![Prisma](https://img.shields.io/badge/Prisma-2D3748?logo=prisma&logoColor=white)](https://www.prisma.io/)


### PR DESCRIPTION
## 目的（Why）

ブランチ運用を develop / main の2本立てから main 単一に移行済みのため、開発者や AI エージェントが誤った基準ブランチで作業してしまう状態を解消する。

## 変更内容

- `README.md`: codecov バッジの URL を `branch/develop` → `branch/main` に変更
- `.coderabbit.yml`: `reviews.auto_review.base_branches` の `develop` → `main` に変更
- `.claude/commands/e2e.md`: 引数なし実行時の差分取得基準を `develop...HEAD` → `main...HEAD` に変更

単語単位の全文検索で確認し、残る `develop` への言及はスコープ外の日付付き設計メモ（`docs/`・`docs/old/`）のみ。

Closes #1266

## ローカルCI

`pnpm verify` ✅（test 960件 pass / typecheck / lint / knip / depcruise すべて成功。lint の警告は既存のもので本変更とは無関係）

E2E に影響する変更（導線・認証・フォーム・ルーティング）はないため E2E は未実施。

## スコープアウトしたIssue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)