### PR TITLE
refactor(report): 寄附者CSVの寄附者照合ロジックの重複を解消する

### DIFF
--- a/admin/src/server/contexts/report/application/usecases/import-donor-csv-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/import-donor-csv-usecase.ts
@@ -7,11 +7,13 @@ import type {
   PreviewDonorCsvRow,
   TransactionForDonorCsv,
 } from "@/server/contexts/report/domain/models/preview-donor-csv-row";
-import type {
-  DonorType,
-  CreateDonorInput,
-  Donor,
+import {
+  buildDonorMatchKey,
+  type DonorType,
+  type CreateDonorInput,
+  type Donor,
 } from "@/server/contexts/report/domain/models/donor";
+import { enrichRowsWithMatchingDonors } from "@/server/contexts/report/domain/services/donor-matcher";
 import type { IDonorRepository } from "@/server/contexts/report/domain/repositories/donor-repository.interface";
 import type { ITransactionWithDonorRepository } from "@/server/contexts/report/domain/repositories/transaction-with-donor-repository.interface";
 import type { ITransactionDonorRepository } from "@/server/contexts/report/domain/repositories/transaction-donor-repository.interface";
@@ -63,7 +65,7 @@ export class ImportDonorCsvUsecase {
       transactions.map((t) => [t.transactionNo, t]),
     );
 
-    const rowsWithMatchingDonor = await this.enrichWithMatchingDonors(rows);
+    const rowsWithMatchingDonor = await enrichRowsWithMatchingDonors(rows, this.donorRepository);
 
     const validatedRows = this.validator.validate(rowsWithMatchingDonor, transactionMap);
 
@@ -85,53 +87,6 @@ export class ImportDonorCsvUsecase {
       return {
         importedCount: deduplicatedRows.length,
         createdDonorCount: createdDonors.length,
-      };
-    });
-  }
-
-  private getDonorMatchKey(name: string, address: string | null, donorType: DonorType): string {
-    return JSON.stringify({ name, address: address ?? "", donorType });
-  }
-
-  private async enrichWithMatchingDonors(
-    rows: PreviewDonorCsvRow[],
-  ): Promise<PreviewDonorCsvRow[]> {
-    const searchKeys = new Map<
-      string,
-      { name: string; address: string | null; donorType: DonorType }
-    >();
-
-    for (const row of rows) {
-      if (row.donorType === null) continue;
-      const key = this.getDonorMatchKey(row.name, row.address, row.donorType);
-      if (!searchKeys.has(key)) {
-        searchKeys.set(key, { name: row.name, address: row.address, donorType: row.donorType });
-      }
-    }
-
-    const uniqueCriteria = [...searchKeys.values()];
-    const donors = await this.donorRepository.findByMatchCriteriaBatch(uniqueCriteria);
-
-    const donorMap = new Map<string, Donor>(
-      donors.map((d) => [this.getDonorMatchKey(d.name, d.address, d.donorType), d]),
-    );
-
-    return rows.map((row) => {
-      if (row.donorType === null) return row;
-
-      const key = this.getDonorMatchKey(row.name, row.address, row.donorType);
-      const matchingDonor = donorMap.get(key);
-
-      return {
-        ...row,
-        matchingDonor: matchingDonor
-          ? {
-              id: matchingDonor.id,
-              name: matchingDonor.name,
-              donorType: matchingDonor.donorType,
-              address: matchingDonor.address,
-            }
-          : null,
       };
     });
   }
@@ -175,7 +130,7 @@ export class ImportDonorCsvUsecase {
 
     const uniqueDonorMap = new Map<string, CreateDonorInput>();
     for (const row of rowsNeedingNewDonor) {
-      const key = this.getDonorMatchKey(row.name, row.address, row.donorType);
+      const key = buildDonorMatchKey(row.name, row.address, row.donorType);
       if (!uniqueDonorMap.has(key)) {
         uniqueDonorMap.set(key, {
           name: row.name,
@@ -194,13 +149,13 @@ export class ImportDonorCsvUsecase {
 
     for (const row of rows) {
       if (row.matchingDonor) {
-        const key = this.getDonorMatchKey(row.name, row.address, row.donorType);
+        const key = buildDonorMatchKey(row.name, row.address, row.donorType);
         donorIdMap.set(key, row.matchingDonor.id);
       }
     }
 
     for (const created of createdDonors) {
-      const key = this.getDonorMatchKey(created.name, created.address, created.donorType);
+      const key = buildDonorMatchKey(created.name, created.address, created.donorType);
       donorIdMap.set(key, created.id);
     }
 
@@ -212,7 +167,7 @@ export class ImportDonorCsvUsecase {
     donorIdMap: Map<string, string>,
   ): { transactionId: bigint; donorId: bigint }[] {
     return rows.map((row) => {
-      const key = this.getDonorMatchKey(row.name, row.address, row.donorType);
+      const key = buildDonorMatchKey(row.name, row.address, row.donorType);
       const donorId = donorIdMap.get(key);
       if (!donorId) {
         throw new Error(`Donor not found for key: ${key}`);

--- a/admin/src/server/contexts/report/application/usecases/preview-donor-csv-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/preview-donor-csv-usecase.ts
@@ -7,7 +7,7 @@ import type {
   PreviewDonorCsvRow,
   TransactionForDonorCsv,
 } from "@/server/contexts/report/domain/models/preview-donor-csv-row";
-import type { DonorType, Donor } from "@/server/contexts/report/domain/models/donor";
+import { enrichRowsWithMatchingDonors } from "@/server/contexts/report/domain/services/donor-matcher";
 import {
   calculateDonorPreviewSummary,
   type PreviewDonorCsvSummary,
@@ -57,7 +57,7 @@ export class PreviewDonorCsvUsecase {
         transactions.map((t) => [t.transactionNo, t]),
       );
 
-      const rowsWithMatchingDonor = await this.enrichWithMatchingDonors(rows);
+      const rowsWithMatchingDonor = await enrichRowsWithMatchingDonors(rows, this.donorRepository);
 
       const validatedRows = this.validator.validate(rowsWithMatchingDonor, transactionMap);
 
@@ -69,52 +69,5 @@ export class PreviewDonorCsvUsecase {
         `プレビュー処理に失敗しました: ${error instanceof Error ? error.message : "不明なエラー"}`,
       );
     }
-  }
-
-  private getDonorMatchKey(name: string, address: string | null, donorType: DonorType): string {
-    return JSON.stringify({ name, address: address ?? "", donorType });
-  }
-
-  private async enrichWithMatchingDonors(
-    rows: PreviewDonorCsvRow[],
-  ): Promise<PreviewDonorCsvRow[]> {
-    const searchKeys = new Map<
-      string,
-      { name: string; address: string | null; donorType: DonorType }
-    >();
-
-    for (const row of rows) {
-      if (row.donorType === null) continue;
-      const key = this.getDonorMatchKey(row.name, row.address, row.donorType);
-      if (!searchKeys.has(key)) {
-        searchKeys.set(key, { name: row.name, address: row.address, donorType: row.donorType });
-      }
-    }
-
-    const uniqueCriteria = [...searchKeys.values()];
-    const donors = await this.donorRepository.findByMatchCriteriaBatch(uniqueCriteria);
-
-    const donorMap = new Map<string, Donor>(
-      donors.map((d) => [this.getDonorMatchKey(d.name, d.address, d.donorType), d]),
-    );
-
-    return rows.map((row) => {
-      if (row.donorType === null) return row;
-
-      const key = this.getDonorMatchKey(row.name, row.address, row.donorType);
-      const matchingDonor = donorMap.get(key);
-
-      return {
-        ...row,
-        matchingDonor: matchingDonor
-          ? {
-              id: matchingDonor.id,
-              name: matchingDonor.name,
-              donorType: matchingDonor.donorType,
-              address: matchingDonor.address,
-            }
-          : null,
-      };
-    });
   }
 }

--- a/admin/src/server/contexts/report/domain/models/donor.ts
+++ b/admin/src/server/contexts/report/domain/models/donor.ts
@@ -63,6 +63,26 @@ export function parseDonorType(value: string): DonorType | null {
   return isValidDonorType(normalized) ? normalized : null;
 }
 
+/**
+ * 同一寄付者とみなすためのキーを生成する
+ *
+ * 政治資金報告書では同一寄付者の寄付を合算して判定する必要があるため、
+ * 「どの寄付者を同一とみなすか」は寄付者そのもののルールとしてここに集約する。
+ * 現在の同一性判定は (name, address, donorType) の完全一致。
+ *
+ * @param name 寄付者名
+ * @param address 住所（null は空文字と同一視する）
+ * @param donorType 寄付者種別
+ * @returns 同一性判定に使うキー文字列
+ */
+export function buildDonorMatchKey(
+  name: string,
+  address: string | null,
+  donorType: DonorType,
+): string {
+  return JSON.stringify({ name, address: address ?? "", donorType });
+}
+
 export function validateDonorInput(input: CreateDonorInput): string[] {
   const errors: string[] = [];
   const trimmedName = input.name?.trim() ?? "";

--- a/admin/src/server/contexts/report/domain/services/donor-matcher.ts
+++ b/admin/src/server/contexts/report/domain/services/donor-matcher.ts
@@ -1,0 +1,61 @@
+import type { PreviewDonorCsvRow } from "@/server/contexts/report/domain/models/preview-donor-csv-row";
+import {
+  buildDonorMatchKey,
+  type Donor,
+  type DonorType,
+} from "@/server/contexts/report/domain/models/donor";
+import type { IDonorRepository } from "@/server/contexts/report/domain/repositories/donor-repository.interface";
+
+/**
+ * CSV行に既存 Donor との一致情報（matchingDonor）を付与する
+ *
+ * 寄付者CSVのプレビューと取り込みは同じ照合結果でなければならないため、
+ * 照合処理はここに一本化する。
+ *
+ * @param rows 照合対象のCSV行
+ * @param donorRepository 既存 Donor の検索に使うリポジトリ
+ * @returns matchingDonor を付与した行（donorType が未確定の行はそのまま返す）
+ */
+export async function enrichRowsWithMatchingDonors(
+  rows: PreviewDonorCsvRow[],
+  donorRepository: IDonorRepository,
+): Promise<PreviewDonorCsvRow[]> {
+  const searchKeys = new Map<
+    string,
+    { name: string; address: string | null; donorType: DonorType }
+  >();
+
+  for (const row of rows) {
+    if (row.donorType === null) continue;
+    const key = buildDonorMatchKey(row.name, row.address, row.donorType);
+    if (!searchKeys.has(key)) {
+      searchKeys.set(key, { name: row.name, address: row.address, donorType: row.donorType });
+    }
+  }
+
+  const uniqueCriteria = [...searchKeys.values()];
+  const donors = await donorRepository.findByMatchCriteriaBatch(uniqueCriteria);
+
+  const donorMap = new Map<string, Donor>(
+    donors.map((d) => [buildDonorMatchKey(d.name, d.address, d.donorType), d]),
+  );
+
+  return rows.map((row) => {
+    if (row.donorType === null) return row;
+
+    const key = buildDonorMatchKey(row.name, row.address, row.donorType);
+    const matchingDonor = donorMap.get(key);
+
+    return {
+      ...row,
+      matchingDonor: matchingDonor
+        ? {
+            id: matchingDonor.id,
+            name: matchingDonor.name,
+            donorType: matchingDonor.donorType,
+            address: matchingDonor.address,
+          }
+        : null,
+    };
+  });
+}

--- a/admin/tests/server/contexts/report/domain/services/donor-matcher.test.ts
+++ b/admin/tests/server/contexts/report/domain/services/donor-matcher.test.ts
@@ -1,0 +1,121 @@
+import { enrichRowsWithMatchingDonors } from "@/server/contexts/report/domain/services/donor-matcher";
+import type { IDonorRepository } from "@/server/contexts/report/domain/repositories/donor-repository.interface";
+import type { PreviewDonorCsvRow } from "@/server/contexts/report/domain/models/preview-donor-csv-row";
+import type { Donor } from "@/server/contexts/report/domain/models/donor";
+
+describe("enrichRowsWithMatchingDonors", () => {
+  const mockDonorRepository: jest.Mocked<IDonorRepository> = {
+    findByMatchCriteriaBatch: jest.fn(),
+  } as unknown as jest.Mocked<IDonorRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createRow = (overrides: Partial<PreviewDonorCsvRow> = {}): PreviewDonorCsvRow => ({
+    rowNumber: 1,
+    transactionNo: "T2025-0001",
+    name: "テスト太郎",
+    donorType: "individual",
+    address: "東京都渋谷区",
+    occupation: "会社員",
+    status: "valid",
+    errors: [],
+    transaction: null,
+    matchingDonor: null,
+    ...overrides,
+  });
+
+  const createDonor = (overrides: Partial<Donor> = {}): Donor => ({
+    id: "donor-1",
+    name: "テスト太郎",
+    donorType: "individual",
+    address: "東京都渋谷区",
+    occupation: "会社員",
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-01-01"),
+    ...overrides,
+  });
+
+  it("name・address・donorType が一致する既存Donorを matchingDonor に設定する", async () => {
+    const donor = createDonor();
+    mockDonorRepository.findByMatchCriteriaBatch.mockResolvedValue([donor]);
+
+    const result = await enrichRowsWithMatchingDonors([createRow()], mockDonorRepository);
+
+    expect(result[0].matchingDonor).toEqual({
+      id: "donor-1",
+      name: "テスト太郎",
+      donorType: "individual",
+      address: "東京都渋谷区",
+    });
+  });
+
+  it("一致する既存Donorが無い行の matchingDonor は null になる", async () => {
+    mockDonorRepository.findByMatchCriteriaBatch.mockResolvedValue([]);
+
+    const result = await enrichRowsWithMatchingDonors([createRow()], mockDonorRepository);
+
+    expect(result[0].matchingDonor).toBeNull();
+  });
+
+  it("address のみが異なる場合は別人として扱う", async () => {
+    mockDonorRepository.findByMatchCriteriaBatch.mockResolvedValue([
+      createDonor({ address: "大阪府大阪市" }),
+    ]);
+
+    const result = await enrichRowsWithMatchingDonors([createRow()], mockDonorRepository);
+
+    expect(result[0].matchingDonor).toBeNull();
+  });
+
+  it("address が null の行は address が null の既存Donorと一致する", async () => {
+    mockDonorRepository.findByMatchCriteriaBatch.mockResolvedValue([
+      createDonor({ id: "donor-2", address: null }),
+    ]);
+
+    const result = await enrichRowsWithMatchingDonors(
+      [createRow({ address: null })],
+      mockDonorRepository,
+    );
+
+    expect(result[0].matchingDonor?.id).toBe("donor-2");
+  });
+
+  it("donorType が null の行は照合対象にも検索条件にもしない", async () => {
+    mockDonorRepository.findByMatchCriteriaBatch.mockResolvedValue([]);
+
+    const row = createRow({ donorType: null, status: "invalid" });
+    const result = await enrichRowsWithMatchingDonors([row], mockDonorRepository);
+
+    expect(result[0]).toBe(row);
+    expect(mockDonorRepository.findByMatchCriteriaBatch).toHaveBeenCalledWith([]);
+  });
+
+  it("同一の照合キーを持つ行は検索条件を1件に集約する", async () => {
+    mockDonorRepository.findByMatchCriteriaBatch.mockResolvedValue([]);
+
+    await enrichRowsWithMatchingDonors(
+      [createRow(), createRow({ rowNumber: 2, transactionNo: "T2025-0002" })],
+      mockDonorRepository,
+    );
+
+    expect(mockDonorRepository.findByMatchCriteriaBatch).toHaveBeenCalledWith([
+      { name: "テスト太郎", address: "東京都渋谷区", donorType: "individual" },
+    ]);
+  });
+
+  it("照合キーが異なる行はそれぞれ検索条件に含める", async () => {
+    mockDonorRepository.findByMatchCriteriaBatch.mockResolvedValue([]);
+
+    await enrichRowsWithMatchingDonors(
+      [createRow(), createRow({ rowNumber: 2, name: "テスト花子" })],
+      mockDonorRepository,
+    );
+
+    expect(mockDonorRepository.findByMatchCriteriaBatch).toHaveBeenCalledWith([
+      { name: "テスト太郎", address: "東京都渋谷区", donorType: "individual" },
+      { name: "テスト花子", address: "東京都渋谷区", donorType: "individual" },
+    ]);
+  });
+});


### PR DESCRIPTION
## 目的（Why）

寄附者CSVを取り込む担当者が、**プレビューで見た結果と実際に取り込まれた結果がずれる**事故に遭わないようにするため。

「取り込み」と「プレビュー」の2つのユースケースに、寄附者の照合キー生成（`getDonorMatchKey`）と既存Donorとの照合処理（`enrichWithMatchingDonors`）が丸ごと同じ形で重複しており、片方だけ修正すると両者の挙動が黙って乖離する状態だった。

また「どの寄附者を同一とみなすか」は寄附者そのもののルールであり、ユースケース側に置く理由がない。

## 変更内容

- 同一性判定のキー生成を `domain/models/donor.ts` の `buildDonorMatchKey()` に集約
  （単一エンティティのルールなので Domain Model へ）
- 既存Donorとの照合処理を `domain/services/donor-matcher.ts` の `enrichRowsWithMatchingDonors()` に切り出し
  （既存データとの照合なので Domain Service へ。リポジトリは domain のインターフェースを引数で受け取る）
- `ImportDonorCsvUsecase` / `PreviewDonorCsvUsecase` の両方から共通実装を呼ぶよう変更（重複コード 105 行削除）
- 切り出した照合処理のユニットテストを追加（一致／不一致、address が null のケース、donorType 未確定行の除外、検索条件の集約）

挙動は変更していません。Usecase のコンストラクタシグネチャも変えていないため、**既存のテストは 1 行も修正せずに通ります**（Issue の完了条件どおり）。

## ローカルCIの実行結果

`pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ パス

- 寄附者関連テスト: 5 suites / 45 tests すべてパス（既存2つの Usecase テストを無修正で含む）
- depcruise: 違反なし（623 modules）
- lint に `suppressions/unused` の警告が4件出ますが、これは main 時点で既に発生している別件です（下記でIssue化）

E2E は未実行です。画面の導線・認証・フォーム・ルーティングに影響しないサーバー内部のリファクタのみのためです。

## スコープアウトして起票したIssue

- #1281 chore(admin): 効果のない biome-ignore コメントを削除する

Closes #1277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 寄付者CSVのインポートおよびプレビューで、既存寄付者との照合処理を共通化しました。
  - 氏名・住所・寄付者種別に基づく照合が一貫して行われるようになりました。
  - 住所が未設定の場合も、同じ条件の寄付者を正しく照合できるようになりました。
  - 寄付者種別が未確定の行は、照合対象外として適切に処理されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->