### PR TITLE
fix: admin の Client 層 dep-cruiser ルールを実際に発火するよう修正する

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -8,14 +8,14 @@ module.exports = {
       name: "no-client-to-infrastructure",
       comment: "Client層からInfrastructure層への依存は禁止",
       severity: "error",
-      from: { path: "^src/client" },
+      from: { path: "^admin/src/client" },
       to: { path: "infrastructure" },
     },
     {
       name: "no-client-to-application",
       comment: "Client層からApplication層への依存は禁止",
       severity: "error",
-      from: { path: "^src/client" },
+      from: { path: "^admin/src/client" },
       to: { path: "application" },
     },
 
@@ -26,8 +26,11 @@ module.exports = {
       name: "no-presentation-to-client",
       comment: "Presentation層からClient層への依存は禁止",
       severity: "error",
-      from: { path: "presentation" },
-      to: { path: "^src/client" },
+      from: { path: "^admin/src/server/contexts/.*/presentation" },
+      // depcruise はリポジトリルートの tsconfig で実行されるため admin の `@/*` エイリアスは
+      // 解決できず、依存先は生の import 指定子（`@/client/...`）として記録される。
+      // 解決済みパス（`admin/src/client/...`）と両方にマッチさせる必要がある。
+      to: { path: "^(admin/src|@)/client" },
     },
 
     // ===========================================


### PR DESCRIPTION
## 目的（Why）

`docs/backend-architecture-guide.md` 3.2.1 が定める「Client → Infrastructure / Application 禁止」が、
admin では **dep-cruiser ルールのパス不一致により1件も機械強制されていなかった**。
アーキテクチャ境界を壊す import が CI をすり抜けてしまう状態を解消する。

## 変更内容

`.dependency-cruiser.cjs` の admin Client 層ルール3件を修正:

- `no-client-to-infrastructure` / `no-client-to-application`
  `from` を `^src/client` → `^admin/src/client` に修正。
  depcruise はリポジトリルートから `depcruise admin/src` を実行するため、
  扱われるパスは `admin/src/client/...` であり、先頭固定の `^src/client` はマッチしなかった。

- `no-presentation-to-client`
  `to` 側は単なる prefix 修正では直らなかった。depcruise はルートの `tsconfig.json`
  （`@/*` → `./*`）で動くため admin の `@/*` エイリアスが解決できず、依存先は
  生の import 指定子（`@/client/...`）として記録されるため。
  解決済みパスと未解決エイリアスの両方にマッチする `^(admin/src|@)/client` に修正した。
  あわせて `from` を `presentation`（未固定）から `^admin/src/server/contexts/.*/presentation` に
  限定し、webapp 側の cruise に混入しないようにした（他の admin ルールと同じ書き方に揃えた）。

## 動作確認

3ルールすべてについて、違反 import を1行入れると `pnpm depcruise` が失敗することを確認:

```
error no-client-to-infrastructure: admin/src/client/components/counterparts/AddressInput.tsx → @/server/contexts/shared/infrastructure/prisma
error no-client-to-application:    admin/src/client/components/counterparts/AddressInput.tsx → @/server/contexts/auth/application/usecases/login-usecase
error no-presentation-to-client:   admin/src/server/contexts/report/presentation/loaders/counterpart-detail-loader.ts → @/client/components/counterparts/AddressInput
```

修正後のベースラインは違反0件（既存コードに顕在化した違反はなかった）。

## ローカルCI

`pnpm verify` ✅ 通過（test / typecheck / lint / knip / depcruise）
※ biome の warning 4件は本PRと無関係の既存のもの（#1281 で対応予定）

## スコープアウトして起票したIssue

- #1283 fix: webapp の no-presentation-to-client ルールがエイリアス未解決で発火しない

Closes #1278