### PR TITLE
chore(admin): 効果のない biome-ignore コメントを削除する

### DIFF
--- a/admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts
+++ b/admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts
@@ -27,7 +27,6 @@ export const COUNTERPART_REQUIRED_INCOME_CATEGORIES = [
 export const ROUTINE_EXPENSE_CATEGORIES = [
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   PL_CATEGORIES["光熱水費"].key,
-  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   PL_CATEGORIES["備品・消耗品費"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   PL_CATEGORIES["事務所費"].key,
@@ -51,7 +50,6 @@ export const POLITICAL_ACTIVITY_EXPENSE_CATEGORIES = [
   PL_CATEGORIES["その他の事業費"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   PL_CATEGORIES["調査研究費"].key,
-  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   PL_CATEGORIES["寄附・交付金"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   PL_CATEGORIES["その他の経費"].key,

--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
@@ -50,7 +50,6 @@ const CATEGORY_KEYS = {
   OTHER: PL_CATEGORIES["その他の収入"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   UTILITIES: PL_CATEGORIES["光熱水費"].key,
-  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   EQUIPMENT_SUPPLIES: PL_CATEGORIES["備品・消耗品費"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   OFFICE_EXPENSES: PL_CATEGORIES["事務所費"].key,
@@ -69,7 +68,6 @@ const CATEGORY_KEYS = {
   OTHER_BUSINESS_EXPENSES: PL_CATEGORIES["その他の事業費"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   RESEARCH_EXPENSES: PL_CATEGORIES["調査研究費"].key,
-  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   DONATIONS_GRANTS_EXPENSES: PL_CATEGORIES["寄附・交付金"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   POLITICAL_ACTIVITY_OTHER_EXPENSES: PL_CATEGORIES["その他の経費"].key,


### PR DESCRIPTION
## 目的（Why）

開発者が `pnpm verify` / `pnpm lint` の出力を毎回 `suppressions/unused` の警告つきで読まされ、本当に見るべき警告が埋もれてしまう状態を解消するため。

## 変更内容

効果のない `biome-ignore lint/complexity/useLiteralKeys` コメント4件を削除しました。

| ファイル | 対象キー |
|---|---|
| `admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts` | `備品・消耗品費` / `寄附・交付金` |
| `admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts` | `備品・消耗品費` / `寄附・交付金` |

### なぜこの4件だけが効いていなかったか

`useLiteralKeys` は「ブラケット記法をドット記法に書き換えられる」場合にのみ発火します。
この2キーに含まれる `・`（U+30FB KATAKANA MIDDLE DOT）は識別子として使えない文字のため、ドット記法に変換できず、そもそもルールが発火しません。
結果、抑制コメントだけが宙に浮き `suppressions/unused` になっていました。

他の日本語キー（`光熱水費` など）は識別子として有効な文字のみで構成されており、ルールが実際に発火するため抑制コメントはそのまま残しています。

ロジックの変更はありません（コメント行の削除のみ）。

## ローカルCI

```
pnpm verify   # exit 0
  ├ test / typecheck  ✅
  ├ lint:admin        ✅ Checked 331 files — 警告0（修正前は suppressions/unused ×4）
  ├ knip              ✅
  └ depcruise         ✅ admin / webapp ともに violations なし
```

E2Eは未実行（サーバー側の定数定義のコメント削除のみで、画面の導線・認証・フォーム・ルーティングに影響しないため）。

## スコープアウトして起票したIssue

- #1285 chore(webapp): webapp lint の残存警告2件を解消する — `pnpm verify` に残る webapp 側の警告2件。main 時点で既に発生しており本PRとは無関係のため分離しました。

Closes #1281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 内部コードの注記を整理しました。
  - カテゴリ定義、処理フロー、エラーハンドリングなどの機能に変更はありません。
  - エンドユーザー向けの動作や表示への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->