### PR TITLE
fix: webapp の no-presentation-to-client ルールを実際に発火するよう修正する

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -188,7 +188,10 @@ module.exports = {
       comment: "webapp: Presentation層からClient層への依存は禁止",
       severity: "error",
       from: { path: "webapp/src/server/contexts/.*/presentation" },
-      to: { path: "^webapp/src/client" },
+      // depcruise はリポジトリルートの tsconfig で実行されるため webapp の `@/*` エイリアスは
+      // 解決できず、依存先は生の import 指定子（`@/client/...`）として記録される。
+      // 解決済みパス（`webapp/src/client/...`）と両方にマッチさせる必要がある。
+      to: { path: "^(webapp/src|@)/client" },
     },
     // Presentation層からInfrastructure層へのDI（リポジトリのインスタンス化）は許可
 


### PR DESCRIPTION
## 目的（Why）

`webapp-no-presentation-to-client` は「Presentation層からClient層への依存は禁止」を守らせるためのルールだが、**1件も発火しない状態**だった。
そのため webapp の開発者が Presentation 層から誤って Client 層へ依存させても CI が素通りしてしまい、レイヤー境界が守られているという誤った安心感が生じていた。これを解消する。

depcruise はリポジトリルートの `tsconfig.json`（`@/*` → `./*`）で実行されるため webapp の `@/*` エイリアスは解決できず、依存先は生の import 指定子（`@/client/...`）として記録される。
`to` が解決済みパス前提の `^webapp/src/client` だったため、どちらの表記にもマッチしていなかった。

## 変更内容

- `.dependency-cruiser.cjs` の `webapp-no-presentation-to-client` の `to` を `^webapp/src/client` → `^(webapp/src|@)/client` に修正
- 経緯が再び失われないよう、#1284 の admin 側ルールと同じ形式で理由コメントを追記

`from` 側（`^webapp/src/client` で始まる Client 層ルール4件）は cruise 対象の実ファイルパスなので解決済みで、`to` も `contexts/.*/infrastructure` のような部分一致のためエイリアス文字列にもマッチする。よって影響を受けておらず、変更不要。

## 動作確認

`webapp/src/server/contexts/public-finance/presentation/loaders/load-organizations.ts` に `import { formatDate } from "@/client/lib/format-date";` を一時的に追加して確認した。

- **修正前**: `✔ no dependency violations found` （検知できていない）
- **修正後**: `error webapp-no-presentation-to-client: webapp/src/server/contexts/public-finance/presentation/loaders/load-organizations.ts → @/client/lib/format-date` で `pnpm depcruise` が失敗

確認後、一時的な import は元に戻してある。

顕在化した既存違反は **0件**（`pnpm depcruise:webapp` が修正後もクリーンに通過）。

## ローカルCI

`pnpm verify`（test / typecheck / lint / knip / depcruise）が通過。
webapp lint の警告2件は本PRとは無関係な既存のもので、#1285 で対応予定。

## スコープアウト

- ルートの tsconfig を分けてエイリアス解決自体を直す根本対応（Issue の Out of scope 記載どおり）
- 新規に起票したIssueはなし

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)