### PR TITLE
chore(webapp): webapp lint の残存警告2件を解消する

### DIFF
--- a/webapp/src/client/components/top-page/features/charts/MonthlyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/MonthlyChart.tsx
@@ -111,11 +111,11 @@ export default function MonthlyChart({ data }: MonthlyChartProps) {
         enabled: false,
       },
       events: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        beforeMount: (chart: any) => {
+        beforeMount: (chart) => {
           // チャートコンテナのタッチイベントを親要素に委譲
           if (typeof window !== "undefined" && "ontouchstart" in window) {
-            const chartEl = chart.el as HTMLElement;
+            // ApexCharts の型定義に el は無いが、実体はチャートのルート要素を持つ
+            const chartEl = (chart as unknown as { el: HTMLElement }).el;
             chartEl.style.touchAction = "pan-x pan-y";
           }
         },

--- a/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
@@ -499,7 +499,7 @@ export default function SankeyChart({ data }: SankeyChartProps) {
   const { sortNodes, sortLinks } = useSankeySorting(safeData);
 
   // データが空または不正な場合の早期リターン
-  if (!data || !data.nodes || !data.links || data.nodes.length === 0 || data.links.length === 0) {
+  if (!data?.nodes || !data.links || data.nodes.length === 0 || data.links.length === 0) {
     return (
       <div
         style={{


### PR DESCRIPTION
## 目的（Why）

開発者が `pnpm verify` の出力から本当に見るべき警告を見つけられるようにするため。
`pnpm --filter webapp lint` が警告2件を常時出しており、「lint の出力は読まなくてよい」状態になっていた。

## 変更内容

- `MonthlyChart.tsx`: `events.beforeMount` の `chart: any` を削除。`const options: ApexOptions` による文脈型で `ApexCharts` が推論されるため型注釈自体が不要。型定義に含まれない `el` へのアクセスのみ局所的にキャストし、理由をコメントで残した
- `MonthlyChart.tsx`: 効果のない `// eslint-disable-next-line @typescript-eslint/no-explicit-any` コメントを削除（本リポジトリは biome を使用）
- `SankeyChart.tsx`: 早期リターン条件 `!data || !data.nodes` をオプショナルチェーン `!data?.nodes` に書き換え（`useOptionalChain` の提案どおり。判定結果は等価）

ロジック・見た目の変更はなし。

Closes #1285

## ローカルCI

`pnpm verify`（test / typecheck / lint / knip / depcruise）exit 0。
webapp / admin ともに lint 警告 0 件。

E2E は未実行（描画ロジック・導線の変更を含まないため）。

## スコープアウトして起票したIssue

なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)