### PR TITLE
docs(admin): 管理画面リデザインのデザインハンドオフを追加

### DIFF
--- a/docs/reference/design_handoff_admin_redesign/Marumie Admin.dc.html
+++ b/docs/reference/design_handoff_admin_redesign/Marumie Admin.dc.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="_ds/team-mirai-design-system-remix-2a300789-1a0e-4f29-8893-6e06fbf24d63/colors_and_type.css">
+  <link rel="stylesheet" href="https://unpkg.com/@phosphor-icons/web@2.1.1/src/regular/style.css">
+  <script src="_ds/team-mirai-design-system-remix-2a300789-1a0e-4f29-8893-6e06fbf24d63/_ds_bundle.js"></script>
+  <style>
+    html, body { margin: 0; padding: 0; }
+    body { font-family: var(--tm-font-jp); color: var(--tm-fg); background: var(--tm-gray-50); -webkit-font-smoothing: antialiased; }
+    a { color: var(--tm-teal-deep); text-decoration: none; }
+    a:hover { color: var(--tm-teal-hover); text-decoration: underline; }
+    input::placeholder { color: var(--tm-gray-300); }
+    button { font-family: var(--tm-font-jp); }
+  </style>
+</helmet>
+<div style="display: grid; grid-template-columns: 236px minmax(0, 1fr); min-height: 100vh; background: var(--tm-gray-50); font-size: 14px; letter-spacing: 0.02em; line-height: 1.7; grid-template-columns: {{ gridCols }};">
+  <aside style="background: {{ sidebarBg }}; border-right: 1px solid var(--tm-gray-150); display: flex; flex-direction: column; padding: 24px 14px 20px; position: sticky; top: 0; height: 100vh; box-sizing: border-box; overflow-y: auto;">
+    <div style="display: flex; align-items: center; justify-content: {{ headJustify }}; gap: 8px; padding: 0 6px 20px;">
+      <div style="min-width: 0; display: {{ labelDisplay }};">
+        <div style="font-size: 13px; font-weight: 700; letter-spacing: 0.06em; white-space: nowrap;">みらいまる見え政治資金</div>
+        <div style="font-family: var(--tm-font-latin); font-size: 10px; font-weight: 600; letter-spacing: 0.14em; color: var(--tm-teal-hover); margin-top: 2px;">ADMIN CONSOLE</div>
+      </div>
+      <button onClick="{{ toggleSidebar }}" title="{{ toggleTitle }}" style="width: 26px; height: 26px; border-radius: 50%; border: none; background: transparent; color: var(--tm-gray-300); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; padding: 0; transition: color 150ms ease-out;" style-hover="color: var(--tm-gray-500); background: var(--tm-gray-50);"><i class="ph {{ toggleIcon }}" style="font-size: 13px;"></i></button>
+    </div>
+    <nav style="display: flex; flex-direction: column; gap: 20px; flex: 1;">
+      <sc-for list="{{ navSections }}" as="sec" hint-placeholder-count="3">
+        <div>
+          <div style="font-size: 11px; font-weight: 600; letter-spacing: 0.12em; color: var(--tm-gray-400); margin: 0 12px 6px; display: {{ labelDisplay }};">{{ sec.title }}</div>
+          <div style="display: flex; flex-direction: column; gap: 2px;">
+            <sc-for list="{{ sec.items }}" as="it" hint-placeholder-count="4">
+              <div onClick="{{ it.go }}" title="{{ it.label }}" style="cursor: pointer; padding: {{ navPad }}; border-radius: 9999px; font-size: 13px; font-weight: {{ it.weight }}; background: {{ it.bg }}; color: {{ it.color }}; transition: background 150ms ease-out; display: flex; align-items: center; gap: 10px; justify-content: {{ navJustify }}; white-space: nowrap;" style-hover="background: var(--tm-teal-100);"><i class="ph {{ it.icon }}" style="font-size: 16px; flex-shrink: 0;"></i><span style="display: {{ labelDisplay }};">{{ it.label }}</span></div>
+            </sc-for>
+          </div>
+        </div>
+      </sc-for>
+    </nav>
+    <div style="border-top: 1px solid var(--tm-gray-150); padding-top: 16px; margin-top: 16px; display: flex; flex-direction: column; gap: 10px;">
+      <div style="display: flex; align-items: center; gap: 8px; padding: 0 10px; justify-content: {{ navJustify }};">
+        <i class="ph ph-user-circle" style="font-size: 20px; color: var(--tm-teal-deep); flex-shrink: 0;" title="admin@team-mir.ai"></i>
+        <span style="font-family: var(--tm-font-latin); font-size: 12px; color: var(--tm-gray-500); overflow: hidden; text-overflow: ellipsis; display: {{ labelDisplay }};">admin@team-mir.ai</span>
+      </div>
+      <button title="ログアウト" style="border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); color: var(--tm-black); font-size: 13px; font-weight: 700; letter-spacing: 0.06em; padding: {{ logoutPad }}; cursor: pointer; transition: all 150ms ease-out; display: inline-flex; align-items: center; justify-content: center; gap: 8px; white-space: nowrap;" style-hover="background: var(--tm-gray-50);"><i class="ph ph-sign-out" style="font-size: 15px;"></i><span style="display: {{ labelDisplay }};">ログアウト</span></button>
+    </div>
+  </aside>
+  <main style="padding: 36px 40px 60px; box-sizing: border-box;">
+    <div style="max-width: 1120px;">
+      <sc-if value="{{ showTransactions }}" hint-placeholder-val="{{ true }}">
+        <div>
+          <div style="font-family: var(--tm-font-latin); font-size: 13px; font-weight: 600; letter-spacing: 0.1em; color: var(--tm-teal-hover);">Transactions</div>
+          <h1 style="margin: 2px 0 24px; font-family: var(--tm-font-jp-display); font-size: 26px; font-weight: 700; letter-spacing: 0.06em; line-height: 1.4;"><span style="text-decoration: underline; text-decoration-color: var(--tm-teal-soft); text-decoration-thickness: 3px; text-underline-offset: 6px;">取引一覧</span></h1>
+          <div style="background: var(--tm-white); border: 1px solid var(--tm-black); border-radius: 8px; padding: 24px;">
+            <div style="display: flex; justify-content: space-between; align-items: center; gap: 16px; flex-wrap: wrap; margin-bottom: 18px;">
+              <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+                <select style="font-family: var(--tm-font-jp); font-size: 13px; padding: 9px 36px 9px 16px; border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); cursor: pointer; appearance: none; background-image: url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2210%22 height=%226%22><path d=%22M1 1l4 4 4-4%22 stroke=%22black%22 stroke-width=%221.5%22 fill=%22none%22/></svg>'); background-repeat: no-repeat; background-position: right 14px center;">
+                  <option>チームみらい</option>
+                  <option>デジタル政策研究会</option>
+                </select>
+                <span style="font-size: 13px; color: var(--tm-gray-500);">全 1,248 件中 1 - 8 件を表示</span>
+              </div>
+              <div style="display: flex; gap: 8px;">
+                <button style="border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); font-size: 12px; font-weight: 700; padding: 8px 16px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px;" style-hover="background: var(--tm-gray-50);"><i class="ph ph-arrows-clockwise"></i>キャッシュクリア</button>
+                <button style="border-radius: 9999px; border: 1.5px solid var(--tm-red); background: var(--tm-white); color: var(--tm-red); font-size: 12px; font-weight: 700; padding: 8px 16px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px;" style-hover="background: #FDF0F1;"><i class="ph ph-trash"></i>全件削除</button>
+              </div>
+            </div>
+            <div style="overflow-x: auto;">
+              <table style="width: 100%; border-collapse: collapse; min-width: 980px;">
+                <thead>
+                  <tr style="border-bottom: 1.5px solid var(--tm-black);">
+                    <th style="padding: {{ cellPad }}; text-align: left; font-size: 12px; font-weight: 700; letter-spacing: 0.04em; white-space: nowrap;">取引No</th>
+                    <th style="padding: {{ cellPad }}; text-align: left; font-size: 12px; font-weight: 700; white-space: nowrap;">取引日</th>
+                    <th style="padding: {{ cellPad }}; text-align: left; font-size: 12px; font-weight: 700; white-space: nowrap;">借方勘定科目</th>
+                    <th style="padding: {{ cellPad }}; text-align: right; font-size: 12px; font-weight: 700; white-space: nowrap;">借方金額</th>
+                    <th style="padding: {{ cellPad }}; text-align: left; font-size: 12px; font-weight: 700; white-space: nowrap;">貸方勘定科目</th>
+                    <th style="padding: {{ cellPad }}; text-align: right; font-size: 12px; font-weight: 700; white-space: nowrap;">貸方金額</th>
+                    <th style="padding: {{ cellPad }}; text-align: left; font-size: 12px; font-weight: 700; white-space: nowrap;">種別</th>
+                    <th style="padding: {{ cellPad }}; text-align: left; font-size: 12px; font-weight: 700; white-space: nowrap;">カテゴリ</th>
+                    <th style="padding: {{ cellPad }}; text-align: left; font-size: 12px; font-weight: 700; white-space: nowrap;">摘要</th>
+                    <th style="padding: {{ cellPad }}; text-align: center; font-size: 12px; font-weight: 700; white-space: nowrap;">操作</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <sc-for list="{{ transactions }}" as="tx" hint-placeholder-count="6">
+                    <tr style="border-bottom: 1px solid var(--tm-gray-150); background: {{ tx.rowBg }};">
+                      <td style="padding: {{ cellPad }}; font-family: var(--tm-font-latin); font-size: 12px; color: var(--tm-gray-500); white-space: nowrap;">{{ tx.no }}</td>
+                      <td style="padding: {{ cellPad }}; font-family: var(--tm-font-latin); font-size: 13px; white-space: nowrap;">{{ tx.date }}</td>
+                      <td style="padding: {{ cellPad }}; font-size: 13px; white-space: nowrap;">{{ tx.debit }}</td>
+                      <td style="padding: {{ cellPad }}; font-family: var(--tm-font-latin); font-size: 13px; font-weight: 600; text-align: right; white-space: nowrap;">{{ tx.debitAmount }}</td>
+                      <td style="padding: {{ cellPad }}; font-size: 13px; white-space: nowrap;">{{ tx.credit }}</td>
+                      <td style="padding: {{ cellPad }}; font-family: var(--tm-font-latin); font-size: 13px; font-weight: 600; text-align: right; white-space: nowrap;">{{ tx.creditAmount }}</td>
+                      <td style="padding: {{ cellPad }}; white-space: nowrap;"><span style="display: inline-block; padding: 3px 12px; border-radius: 9999px; border: 1.5px solid {{ tx.typeBorder }}; color: {{ tx.typeColor }}; background: {{ tx.typeBg }}; font-size: 11px; font-weight: 700; letter-spacing: 0.04em;">{{ tx.type }}</span></td>
+                      <td style="padding: {{ cellPad }}; white-space: nowrap;"><span style="display: inline-block; padding: 2px 12px; border-radius: 9999px; border: 1px solid {{ tx.catBorder }}; background: {{ tx.catBg }}; color: {{ tx.catColor }}; font-size: 12px; font-weight: 500; line-height: 1.67;">{{ tx.category }}</span></td>
+                      <td style="padding: {{ cellPad }}; font-size: 12px; color: var(--tm-gray-500); max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{{ tx.note }}</td>
+                      <td style="padding: {{ cellPad }}; text-align: center;"><i class="ph ph-trash" style="font-size: 16px; color: var(--tm-gray-400); cursor: pointer;"></i></td>
+                    </tr>
+                  </sc-for>
+                </tbody>
+              </table>
+            </div>
+            <div style="display: flex; justify-content: center; align-items: center; gap: 10px; margin-top: 22px;">
+              <button style="border-radius: 9999px; border: 1.5px solid var(--tm-gray-250); background: var(--tm-white); color: var(--tm-gray-300); font-size: 12px; font-weight: 700; padding: 7px 16px; cursor: not-allowed;">前へ</button>
+              <span style="font-family: var(--tm-font-latin); font-size: 13px; font-weight: 600;">1 / 25</span>
+              <button style="border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); font-size: 12px; font-weight: 700; padding: 7px 16px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px;" style-hover="background: var(--tm-gray-50);">次へ<i class="ph ph-caret-right" style="font-size: 12px;"></i></button>
+            </div>
+          </div>
+        </div>
+      </sc-if>
+      <sc-if value="{{ showOrgs }}" hint-placeholder-val="{{ false }}">
+        <div>
+          <div style="display: flex; justify-content: space-between; align-items: flex-end; gap: 16px; flex-wrap: wrap; margin-bottom: 24px;">
+            <div>
+              <div style="font-family: var(--tm-font-latin); font-size: 13px; font-weight: 600; letter-spacing: 0.1em; color: var(--tm-teal-hover);">Organizations</div>
+              <h1 style="margin: 2px 0 0; font-family: var(--tm-font-jp-display); font-size: 26px; font-weight: 700; letter-spacing: 0.06em; line-height: 1.4;"><span style="text-decoration: underline; text-decoration-color: var(--tm-teal-soft); text-decoration-thickness: 3px; text-underline-offset: 6px;">政治団体一覧</span></h1>
+            </div>
+            <button style="border-radius: 9999px; border: 1.5px solid var(--tm-teal); background: var(--tm-teal); color: var(--tm-white); font-size: 13px; font-weight: 700; letter-spacing: 0.06em; padding: 11px 22px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; transition: background 150ms ease-out;" style-hover="background: var(--tm-teal-hover); border-color: var(--tm-teal-hover);"><i class="ph ph-plus"></i>新規作成</button>
+          </div>
+          <div style="display: flex; flex-direction: column; gap: 16px;">
+            <sc-for list="{{ orgs }}" as="org" hint-placeholder-count="2">
+              <div style="background: var(--tm-white); border: 1px solid var(--tm-black); border-radius: 8px; padding: 22px 26px; display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; flex-wrap: wrap;">
+                <div style="min-width: 0;">
+                  <div style="display: flex; align-items: center; gap: 10px; flex-wrap: wrap;">
+                    <h3 style="margin: 0; font-size: 17px; font-weight: 700; letter-spacing: 0.04em;">{{ org.name }}</h3>
+                    <span style="display: inline-block; padding: 2px 12px; border-radius: 9999px; background: var(--tm-teal-100); color: var(--tm-teal-deep); font-size: 11px; font-weight: 700;">{{ org.kind }}</span>
+                  </div>
+                  <p style="margin: 8px 0 0; font-size: 13px; color: var(--tm-gray-500);">{{ org.desc }}</p>
+                  <div style="margin-top: 10px; font-family: var(--tm-font-latin); font-size: 12px; color: var(--tm-gray-400);">作成日: {{ org.created }}</div>
+                </div>
+                <div style="display: flex; gap: 8px; flex-shrink: 0;">
+                  <button style="border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); font-size: 12px; font-weight: 700; padding: 8px 18px; cursor: pointer; white-space: nowrap;" style-hover="background: var(--tm-gray-50);">編集</button>
+                  <button style="border-radius: 9999px; border: 1.5px solid var(--tm-red); background: var(--tm-white); color: var(--tm-red); font-size: 12px; font-weight: 700; padding: 8px 18px; cursor: pointer; white-space: nowrap;" style-hover="background: #FDF0F1;">削除</button>
+                </div>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+      </sc-if>
+      <sc-if value="{{ showCounterparts }}" hint-placeholder-val="{{ false }}">
+        <div>
+          <div style="display: flex; justify-content: space-between; align-items: flex-end; gap: 16px; flex-wrap: wrap; margin-bottom: 24px;">
+            <div>
+              <div style="font-family: var(--tm-font-latin); font-size: 13px; font-weight: 600; letter-spacing: 0.1em; color: var(--tm-teal-hover);">Counterparts</div>
+              <h1 style="margin: 2px 0 0; font-family: var(--tm-font-jp-display); font-size: 26px; font-weight: 700; letter-spacing: 0.06em; line-height: 1.4;"><span style="text-decoration: underline; text-decoration-color: var(--tm-teal-soft); text-decoration-thickness: 3px; text-underline-offset: 6px;">取引先マスタ管理</span></h1>
+            </div>
+            <button style="border-radius: 9999px; border: 1.5px solid var(--tm-teal); background: var(--tm-teal); color: var(--tm-white); font-size: 13px; font-weight: 700; letter-spacing: 0.06em; padding: 11px 22px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px;" style-hover="background: var(--tm-teal-hover); border-color: var(--tm-teal-hover);"><i class="ph ph-plus"></i>新規作成</button>
+          </div>
+          <div style="background: var(--tm-white); border: 1px solid var(--tm-black); border-radius: 8px; padding: 24px;">
+            <div style="display: flex; gap: 8px; margin-bottom: 8px; flex-wrap: wrap;">
+              <input placeholder="名前または住所で検索..." style="font-family: var(--tm-font-jp); font-size: 13px; padding: 10px 18px; border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); flex: 1; max-width: 380px; min-width: 200px; outline: none;" style-focus="border-color: var(--tm-teal); box-shadow: 0 0 0 2px var(--tm-teal-100);">
+              <button style="border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); font-size: 13px; font-weight: 700; padding: 9px 20px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px;" style-hover="background: var(--tm-gray-50);"><i class="ph ph-magnifying-glass"></i>検索</button>
+            </div>
+            <div style="font-size: 13px; color: var(--tm-gray-500); margin-bottom: 12px;">312件の取引先</div>
+            <table style="width: 100%; border-collapse: collapse;">
+              <thead>
+                <tr style="border-bottom: 1.5px solid var(--tm-black);">
+                  <th style="padding: 10px 12px; text-align: left; font-size: 12px; font-weight: 700;">名前</th>
+                  <th style="padding: 10px 12px; text-align: left; font-size: 12px; font-weight: 700;">住所</th>
+                  <th style="padding: 10px 12px; text-align: right; font-size: 12px; font-weight: 700; white-space: nowrap;">使用数</th>
+                  <th style="padding: 10px 12px; text-align: right; font-size: 12px; font-weight: 700;">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                <sc-for list="{{ counterparts }}" as="cp" hint-placeholder-count="5">
+                  <tr style="border-bottom: 1px solid var(--tm-gray-150);">
+                    <td style="padding: 12px;"><a href="#" style="font-size: 13px; font-weight: 600;">{{ cp.name }}</a></td>
+                    <td style="padding: 12px; font-size: 13px; color: var(--tm-gray-500);">{{ cp.address }}</td>
+                    <td style="padding: 12px; font-family: var(--tm-font-latin); font-size: 13px; font-weight: 600; text-align: right;">{{ cp.usage }}件</td>
+                    <td style="padding: 12px; text-align: right;">
+                      <div style="display: flex; gap: 6px; justify-content: flex-end;">
+                        <button style="border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); font-size: 11px; font-weight: 700; padding: 5px 14px; cursor: pointer; white-space: nowrap; flex-shrink: 0;" style-hover="background: var(--tm-gray-50);">編集</button>
+                        <button style="border-radius: 9999px; border: 1.5px solid var(--tm-red); background: var(--tm-white); color: var(--tm-red); font-size: 11px; font-weight: 700; padding: 5px 14px; cursor: pointer; white-space: nowrap; flex-shrink: 0;" style-hover="background: #FDF0F1;">削除</button>
+                      </div>
+                    </td>
+                  </tr>
+                </sc-for>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </sc-if>
+      <sc-if value="{{ showUpload }}" hint-placeholder-val="{{ false }}">
+        <div>
+          <div style="font-family: var(--tm-font-latin); font-size: 13px; font-weight: 600; letter-spacing: 0.1em; color: var(--tm-teal-hover);">Data Import</div>
+          <h1 style="margin: 2px 0 24px; font-family: var(--tm-font-jp-display); font-size: 26px; font-weight: 700; letter-spacing: 0.06em; line-height: 1.4;"><span style="text-decoration: underline; text-decoration-color: var(--tm-teal-soft); text-decoration-thickness: 3px; text-underline-offset: 6px;">CSVアップロード</span></h1>
+          <div style="background: var(--tm-white); border: 1px solid var(--tm-black); border-radius: 8px; padding: 28px; max-width: 720px;">
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-bottom: 24px;">
+              <label style="display: flex; flex-direction: column; gap: 6px;">
+                <span style="font-size: 12px; font-weight: 700;">政治団体 <span style="color: var(--tm-red);">*</span></span>
+                <select style="font-family: var(--tm-font-jp); font-size: 13px; padding: 10px 16px; border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); cursor: pointer;">
+                  <option>チームみらい</option>
+                  <option>デジタル政策研究会</option>
+                </select>
+              </label>
+              <label style="display: flex; flex-direction: column; gap: 6px;">
+                <span style="font-size: 12px; font-weight: 700;">データソース <span style="color: var(--tm-red);">*</span></span>
+                <select style="font-family: var(--tm-font-jp); font-size: 13px; padding: 10px 16px; border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); cursor: pointer;">
+                  <option>MFクラウド会計</option>
+                  <option>freee会計</option>
+                </select>
+              </label>
+            </div>
+            <div style="border: 1.5px dashed var(--tm-teal); border-radius: 8px; background: var(--tm-teal-100); padding: 48px 24px; text-align: center;">
+              <i class="ph ph-upload-simple" style="font-size: 36px; color: var(--tm-teal-deep);"></i>
+              <div style="font-size: 14px; font-weight: 700; margin-top: 10px;">CSVファイルをドラッグ＆ドロップ</div>
+              <div style="font-size: 12px; color: var(--tm-gray-500); margin-top: 4px;">または</div>
+              <button style="margin-top: 14px; border-radius: 9999px; border: 1.5px solid var(--tm-black); background: var(--tm-white); font-size: 13px; font-weight: 700; padding: 10px 24px; cursor: pointer;" style-hover="background: var(--tm-gray-50);">ファイルを選択</button>
+              <div style="font-family: var(--tm-font-latin); font-size: 11px; color: var(--tm-gray-400); margin-top: 14px;">UTF-8 / Shift-JIS ・ 最大 10MB</div>
+            </div>
+            <div style="display: flex; justify-content: flex-end; margin-top: 24px;">
+              <button style="border-radius: 9999px; border: 1.5px solid var(--tm-teal); background: var(--tm-teal); color: var(--tm-white); font-size: 13px; font-weight: 700; letter-spacing: 0.06em; padding: 11px 26px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px;" style-hover="background: var(--tm-teal-hover); border-color: var(--tm-teal-hover);">プレビューを表示<i class="ph ph-arrow-right"></i></button>
+            </div>
+          </div>
+        </div>
+      </sc-if>
+      <sc-if value="{{ showPlaceholder }}" hint-placeholder-val="{{ false }}">
+        <div>
+          <h1 style="margin: 0 0 20px; font-family: var(--tm-font-jp-display); font-size: 26px; font-weight: 700; letter-spacing: 0.06em; line-height: 1.4;"><span style="text-decoration: underline; text-decoration-color: var(--tm-teal-soft); text-decoration-thickness: 3px; text-underline-offset: 6px;">{{ placeholderTitle }}</span></h1>
+          <div style="background: var(--tm-white); border: 1px solid var(--tm-black); border-radius: 8px; padding: 60px 24px; text-align: center;">
+            <i class="ph ph-squares-four" style="font-size: 32px; color: var(--tm-teal);"></i>
+            <p style="margin: 12px 0 0; font-size: 13px; color: var(--tm-gray-500);">このモックでは省略しています（同じスタイルで展開します）</p>
+          </div>
+        </div>
+      </sc-if>
+    </div>
+  </main>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{
+  &quot;sidebarTone&quot;: {&quot;editor&quot;: &quot;enum&quot;, &quot;options&quot;: [&quot;white&quot;, &quot;mint&quot;], &quot;default&quot;: &quot;white&quot;, &quot;tsType&quot;: &quot;string&quot;, &quot;section&quot;: &quot;レイアウト&quot;},
+  &quot;compact&quot;: {&quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: false, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;レイアウト&quot;},
+  &quot;zebraRows&quot;: {&quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: false, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;レイアウト&quot;}
+}">
+class Component extends DCLogic {
+  state = { screen: "transactions", collapsed: false };
+  renderVals() {
+    const compact = this.props.compact ?? false;
+    const zebra = this.props.zebraRows ?? false;
+    const sidebarTone = this.props.sidebarTone ?? "white";
+    const s = this.state.screen;
+    const built = ["transactions", "orgs", "counterparts", "upload"];
+    const sections = [
+      { title: "基本情報", items: [["user-info", "ユーザー情報"], ["orgs", "政治団体"], ["users", "ユーザー管理"]] },
+      { title: "データ取り込み", items: [["transactions", "取引一覧"], ["bulk-delete", "取引一括削除"], ["upload", "CSVアップロード"], ["balance", "残高登録"]] },
+      { title: "報告書", items: [["counterparts", "取引先マスタ"], ["assign-cp", "取引先紐付け"], ["donors", "寄付者マスタ"], ["assign-donors", "寄付者紐付け"], ["export", "報告書エクスポート"]] },
+    ];
+    const icons = { "user-info": "ph-user", orgs: "ph-bank", users: "ph-users", transactions: "ph-list-bullets", "bulk-delete": "ph-trash", upload: "ph-upload-simple", balance: "ph-coins", counterparts: "ph-address-book", "assign-cp": "ph-link", donors: "ph-hand-heart", "assign-donors": "ph-link-simple", export: "ph-export" };
+    const titles = { "user-info": "ユーザー情報", users: "ユーザー管理", "bulk-delete": "取引一括削除", balance: "残高登録", "assign-cp": "取引先紐付け", donors: "寄付者マスタ", "assign-donors": "寄付者紐付け", export: "報告書エクスポート" };
+    const navSections = sections.map((sec) => ({
+      title: sec.title,
+      items: sec.items.map(([key, label]) => {
+        const active = s === key;
+        return {
+          label, key, icon: icons[key],
+          go: () => this.setState({ screen: key }),
+          bg: active ? "var(--tm-teal-100)" : "transparent",
+          color: active ? "var(--tm-teal-deep)" : "var(--tm-ink)",
+          weight: active ? 700 : 500,
+        };
+      }),
+    }));
+    const typeStyles = {
+      income: { typeBorder: "var(--tm-teal-deep)", typeColor: "var(--tm-teal-deep)", typeBg: "var(--tm-teal-100)" },
+      expense: { typeBorder: "var(--tm-red)", typeColor: "var(--tm-red)", typeBg: "var(--tm-white)" },
+      journal: { typeBorder: "var(--tm-gray-400)", typeColor: "var(--tm-gray-500)", typeBg: "var(--tm-gray-50)" },
+    };
+    // shared/accounting/account-category.ts の PL_CATEGORIES と同じ色・略称
+    const PL = {
+      "個人の負担する党費又は会費": ["#FED7AA", "党費・会費", "income"],
+      "個人からの寄附": ["#BBF7D0", "個人寄附", "income"],
+      "法人その他の団体からの寄附": ["#FECACA", "法人寄附", "income"],
+      "政治団体からの寄附": ["#A5F3FC", "政党寄附", "income"],
+      "機関紙誌の発行その他の事業による収入": ["#FDE68A", "機関紙誌", "income"],
+      "借入金": ["#FECDD3", "借入金", "income"],
+      "本部又は支部から供与された交付金に係る収入": ["#99F6E4", "交付金", "income"],
+      "政治資金パーティーの対価に係る収入": ["#DDD6FE", "パーティー収入", "income"],
+      "その他の収入": ["#E2E8F0", "その他", "income"],
+      "人件費": ["#0369A1", "人件費", "expense"],
+      "光熱水費": ["#126C81", "光熱水費", "expense"],
+      "備品・消耗品費": ["#4D7C0F", "備品消耗品費", "expense"],
+      "事務所費": ["#047857", "事務所費", "expense"],
+      "組織活動費": ["#C2410C", "組織活動費", "expense"],
+      "選挙関係費": ["#DC2626", "選挙関係費", "expense"],
+      "機関紙誌の発行事業費": ["#A16207", "機関紙誌費", "expense"],
+      "宣伝事業費": ["#3856B1", "宣伝事業費", "expense"],
+      "政治資金パーティー開催事業費": ["#6D28D9", "政治資金パーティ費", "expense"],
+      "その他の事業費": ["#334155", "その他事業費", "expense"],
+      "調査研究費": ["#047857", "調査研究費", "expense"],
+      "寄附・交付金": ["#BE185D", "寄附・交付金", "expense"],
+      "その他の経費": ["#334155", "その他経費", "expense"],
+    };
+    const raw = [
+      ["2025-0142", "2025.02.05", "組織活動費", 4320, "普通預金", 4320, "現金支出", "expense", "組織活動費", "地方遊説 交通費"],
+      ["2025-0141", "2025.02.03", "普通預金", 30000, "個人からの寄附", 30000, "現金収入", "income", "個人からの寄附", "個人寄附（クレジット決済）"],
+      ["2025-0140", "2025.02.01", "事務所費", 150000, "未払金", 150000, "非現金仕訳", "journal", null, "2月分事務所賃料 計上"],
+      ["2025-0139", "2025.01.28", "宣伝事業費", 88000, "普通預金", 88000, "現金支出", "expense", "宣伝事業費", "SNS広告出稿（1月）"],
+      ["2025-0138", "2025.01.25", "普通預金", 500000, "機関紙誌の発行その他の事業による収入", 500000, "現金収入", "income", "機関紙誌の発行その他の事業による収入", "パンフレット頒布"],
+      ["2025-0137", "2025.01.22", "備品・消耗品費", 12540, "普通預金", 12540, "現金支出", "expense", "備品・消耗品費", "事務用品購入"],
+      ["2025-0136", "2025.01.18", "普通預金", 10000, "個人からの寄附", 10000, "現金収入", "income", "個人からの寄附", "個人寄附（銀行振込）"],
+      ["2025-0135", "2025.01.15", "人件費", 250000, "普通預金", 250000, "現金支出", "expense", "人件費", "1月分給与"],
+    ];
+    const yen = (n) => "¥" + n.toLocaleString("ja-JP");
+    const transactions = raw.map((r, i) => {
+      const cat = r[8] ? PL[r[8]] : null;
+      return {
+        no: r[0], date: r[1], debit: r[2], debitAmount: yen(r[3]), credit: r[4], creditAmount: yen(r[5]),
+        type: r[6], note: r[9],
+        // front（webapp TransactionTableRow）と同じルール: 収入=色塗り+#47474C文字 / 支出=白抜き+色文字色枠
+        category: cat ? cat[1] : "-",
+        catBg: cat ? (cat[2] === "income" ? cat[0] : "#FFFFFF") : "#FFFFFF",
+        catBorder: cat ? cat[0] : "var(--tm-gray-250)",
+        catColor: cat ? (cat[2] === "income" ? "#47474C" : cat[0]) : "var(--tm-gray-500)",
+        rowBg: zebra && i % 2 === 1 ? "var(--tm-gray-50)" : "transparent",
+        ...typeStyles[r[7]],
+      };
+    });
+    const collapsed = this.state.collapsed;
+    return {
+      navSections,
+      gridCols: collapsed ? "72px minmax(0, 1fr)" : "236px minmax(0, 1fr)",
+      labelDisplay: collapsed ? "none" : "block",
+      navPad: collapsed ? "9px 0" : "8px 14px",
+      navJustify: collapsed ? "center" : "flex-start",
+      headJustify: collapsed ? "center" : "space-between",
+      logoutPad: collapsed ? "9px 0" : "9px 18px",
+      toggleIcon: collapsed ? "ph-caret-double-right" : "ph-caret-double-left",
+      toggleTitle: collapsed ? "サイドバーを開く" : "サイドバーを折りたたむ",
+      toggleSidebar: () => this.setState((st) => ({ collapsed: !st.collapsed })),
+      cellPad: compact ? "6px 10px" : "10px 12px",
+      sidebarBg: sidebarTone === "mint" ? "var(--tm-teal-100)" : "var(--tm-white)",
+      showTransactions: s === "transactions",
+      showOrgs: s === "orgs",
+      showCounterparts: s === "counterparts",
+      showUpload: s === "upload",
+      showPlaceholder: !built.includes(s),
+      placeholderTitle: titles[s] || "",
+      transactions,
+      orgs: [
+        { name: "チームみらい", kind: "政党", desc: "国政政党。本部会計。", created: "2025.05.08" },
+        { name: "チームみらい東京都連合", kind: "政治団体", desc: "東京都内の支部会計。", created: "2025.06.12" },
+      ],
+      counterparts: [
+        { name: "株式会社みらい印刷", address: "東京都千代田区永田町1-2-3", usage: 42 },
+        { name: "合同会社シビックデザイン", address: "東京都渋谷区神南1-4-5", usage: 18 },
+        { name: "オフィスサポート株式会社", address: "東京都新宿区西新宿2-8-1", usage: 11 },
+        { name: "山田 太郎", address: "神奈川県横浜市中区日本大通1", usage: 6 },
+        { name: "株式会社データワークス", address: "大阪府大阪市北区梅田3-1-3", usage: 3 },
+      ],
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/reference/design_handoff_admin_redesign/README.md
+++ b/docs/reference/design_handoff_admin_redesign/README.md
@@ -1,0 +1,169 @@
+# Handoff: 管理画面（/admin）Team Mirai デザインシステム適用
+
+marumie（team-mirai/marumie）の管理画面を、Team Mirai デザインシステム（team-mir.ai のブランド）に合わせてリスタイルするためのハンドオフです。
+
+## Overview
+
+現状の admin はダーク系の shadcn デフォルトに近い見た目で、ブランドとの一貫性がない。
+このハンドオフは「白ベース + Mirai Teal + 黒1pxボーダー + ピル形状」というブランド言語を admin 全体に適用するためのデザインリファレンスと実装指針をまとめたもの。
+
+## About the Design Files
+
+同梱の `Marumie Admin.dc.html` は **HTMLで作ったデザインリファレンス（モック）** であり、そのまま使うプロダクションコードではない。
+実装タスクは、このモックの見た目・挙動を **admin の既存環境（Next.js 16 / React 19 / Tailwind CSS v4 / Radix ベースの ui コンポーネント群）で再現すること**。既存の `admin/src/client/components/ui/*`（button, input, select, table, dialog…）と `admin/src/app/globals.css` のトークンを書き換える方針を推奨（各画面のクラスを個別に書き換えるより、トークンと ui/* の変更で大半が波及する）。
+
+モックはブラウザで直接開けば動く（フォントTTFは同梱していないため Noto Sans はシステムフォールバックになる。トークン・レイアウトの確認には支障なし）。
+
+## Fidelity
+
+**中〜高フィデリティ。** 色・タイポ・形状・状態（hover等）のトークンは確定値として扱ってよい。
+一方、画面は代表4画面のみで、余白の細部やレスポンシブはラフ。「完璧にせず大まかに反映」という前提で、既存レイアウトを大きく変えずトークンとコンポーネントスタイルを差し替えるのが趣旨。
+
+## デザイン原則（Team Mirai ブランドの要点）
+
+- ブランド色は **Mirai Teal `#30BCA7` のみ**。青・紫・オレンジは使わない（現状の `bg-primary`(青) / `hover:bg-blue-600` は全廃）。
+- **ダークUI → 白ベース** に反転。ページ背景 `#F8F8F8`、カード白。
+- デフォルトボーダーは **黒 `#000` の 1px（強調は1.5px）**。カードは黒1px枠 + 角丸8px。影はほぼ使わない。
+- **ピル（border-radius: 9999px）が署名形状**：ボタン・入力・selectはすべてピル。カード類の角丸は4–8pxの小さめ。
+- 日本語: Hiragino Kaku Gothic（fallback Noto Sans）/ 数字・英字・日付: **Poppins**。
+- 日付表記は `YYYY.MM.DD`（スラッシュでなくピリオド）。
+- アイコンは **Phosphor Icons（regular weight）**。絵文字・グラデーションは使わない。
+- hover は 120–200ms ease-out の色変化のみ（スケールやバウンスなし）。
+- 見出しの署名的装飾：teal-soft の下線（`text-decoration: underline; text-decoration-color: #64D8C6; text-decoration-thickness: 3px; text-underline-offset: 6px`）。
+
+## Design Tokens
+
+`_ds/.../colors_and_type.css` に全トークン（CSS変数 `--tm-*`）あり。実装では `admin/src/app/globals.css` の Tailwind テーマ変数へ移植する。主要値:
+
+| Token | 値 | 用途 |
+|---|---|---|
+| teal (primary) | `#30BCA7` | プライマリボタン、アクセント |
+| teal-hover | `#089781` | primary hover、英字セクションラベル文字 |
+| teal-deep | `#0F8472` | pressed、アクティブnav文字、リンク |
+| teal-soft | `#64D8C6` | 見出し下線 |
+| teal-100 | `#E2F6F3` | アクティブnav背景、ドロップゾーン背景、収入バッジ背景 |
+| red | `#E63946` | 破壊的操作（削除）、必須マーク |
+| black | `#000000` | 文字、ボーダー |
+| ink | `#1F2937` | nav等のやや柔らかい文字 |
+| gray ramp | `#F8F8F8 / #F0F0F0 / #E5E5E5 / #D9D9D9 / #CCC / #B1B1B1 / #939393 / #666 / #4C4C4C / #333` | 背景・罫線・補助文字 |
+| radius | pill `9999px` / card `8px` / chip `4px` | |
+| font-jp | Hiragino Kaku Gothic ProN → Noto Sans | 本文 |
+| font-latin | Poppins | 数字・日付・英字ラベル |
+| 罫線 | 黒1px（強調1.5px）、表の行罫線は `#E5E5E5` | |
+| hover transition | `120–200ms ease-out`（色のみ） | |
+
+### globals.css への移植例（Tailwind v4 `@theme` 変数の差し替え目安）
+
+```
+--background: #F8F8F8;      --foreground: #000000;
+--card: #FFFFFF;            --card-foreground: #000000;
+--primary: #30BCA7;         --primary-foreground: #FFFFFF;
+--secondary: #F8F8F8;       --secondary-foreground: #000000;
+--muted: #F0F0F0;           --muted-foreground: #666666;
+--destructive: #E63946;
+--border: #000000;          /* 表の行罫線など弱い線は #E5E5E5 を別途 */
+--input: #FFFFFF;           --ring: #30BCA7;
+--radius: 8px;              /* ボタン・入力は rounded-full を明示 */
+```
+
+## Screens / Views
+
+モックは左サイドバー + 4画面（サイドバーのクリックで切替。未実装メニューはプレースホルダー表示）。
+
+### 1. サイドバー（全画面共通）
+対応コード: `admin/src/client/components/layout/Sidebar.tsx`, `admin/src/app/(auth)/layout.tsx`
+
+- レイアウト: grid `236px + 1fr`、サイドバーは白背景・右罫線 `1px #E5E5E5`・sticky（`height: 100vh`）。
+- ヘッダー: 「みらいまる見え政治資金」(13px/700) + 「ADMIN CONSOLE」(Poppins 10px/600/letter-spacing 0.14em/色 #089781)。**ロゴ画像は置かない**（ブランドガイド上、ロゴの改変・多用を避けるため文字のみ）。
+- セクション見出し（基本情報/データ取り込み/報告書）: 11px/600、`#939393`、letter-spacing 0.12em。
+- navアイテム: ピル形。アイコン(Phosphor 16px) + ラベル13px。
+  - 通常: 文字 `#1F2937`、weight 500、背景透過。hover: 背景 `#E2F6F3`。
+  - アクティブ: 背景 `#E2F6F3`、文字 `#0F8472`、weight 700。
+  - アイコン対応: ユーザー情報 `ph-user` / 政治団体 `ph-bank` / ユーザー管理 `ph-users` / 取引一覧 `ph-list-bullets` / 取引一括削除 `ph-trash` / CSVアップロード `ph-upload-simple` / 残高登録 `ph-coins` / 取引先マスタ `ph-address-book` / 取引先紐付け `ph-link` / 寄付者マスタ `ph-hand-heart` / 寄付者紐付け `ph-link-simple` / 報告書エクスポート `ph-export`。
+- 折りたたみ: ヘッダー右の控えめなアイコンボタン（枠なし、`#B1B1B1`、hoverで `#666`）。折りたたみ時は幅72pxのアイコンレール（各項目 `title` ツールチップ、中央寄せ）。
+- フッター: 上罫線 `1px #E5E5E5`、`ph-user-circle`(teal-deep) + メールアドレス(Poppins 12px `#666`)、ログアウトは**黒1.5px枠の白ピル**（`ph-sign-out` + 13px/700、hover `#F8F8F8`）。現状の `variant="destructive"` はやめる（破壊的操作ではないため）。
+
+### 2. 取引一覧（/transactions）
+対応コード: `TransactionsClient.tsx`, `TransactionRow.tsx`
+
+- ページヘッダー: 英字ラベル「Transactions」(Poppins 13px/600/ls 0.1em/#089781) + h1「取引一覧」(26px/700/ls 0.06em、teal-soft 3px下線 offset 6px)。
+- コンテンツカード: 白、黒1px枠、radius 8px、padding 24px。
+- ツールバー: 左に団体select（ピル、黒1.5px枠、13px）+ 件数表示（13px `#666`「全 N 件中 x - y 件を表示」）。右に「キャッシュクリア」(黒1.5px枠白ピル 12px/700 + `ph-arrows-clockwise`) と「全件削除」(**赤枠白地赤文字**ピル + `ph-trash`、hover `#FDF0F1`)。
+- テーブル: ヘッダー行下罫線 **黒1.5px**、th 12px/700。行罫線 `1px #E5E5E5`。セルpadding `10px 12px`。
+  - 取引No: Poppins 12px `#666` / 取引日: Poppins 13px（`YYYY.MM.DD`）/ 金額: Poppins 13px/600 右寄せ `¥1,234,567`。
+  - 種別バッジ（ピル 11px/700、1.5px枠）: 現金収入=枠・文字 `#0F8472`・背景 `#E2F6F3` / 現金支出=枠・文字 `#E63946`・背景白 / 非現金仕訳=枠 `#939393`・文字 `#666`・背景 `#F8F8F8`。
+  - **カテゴリピル: webapp（front）と完全に同一ルール**（下記「カテゴリピル」参照）。
+  - 摘要: 12px `#666`、max-width 200px ellipsis。操作: `ph-trash` アイコンのみ（16px `#939393`）。
+- ページネーション: 中央寄せ。「前へ/次へ」黒1.5px枠白ピル（無効時は `#CCC` 枠・`#B1B1B1` 文字・not-allowed）、中央に Poppins「1 / 25」。
+
+### カテゴリピル（front と共通化すること）
+参照: `webapp/src/client/components/top-page/features/transactions-table/TransactionTableRow.tsx` の `getCategoryColors` と `shared/accounting/account-category.ts` の `PL_CATEGORIES`。
+
+- 形状: `rounded-full`、`border 1px`、padding 目安 `2px 12px`、12px/500。
+- 収入: 背景=カテゴリ色、枠=カテゴリ色、文字 `#47474C`。
+- 支出: 背景白、枠=カテゴリ色、文字=カテゴリ色。
+- 非現金仕訳: 背景白、枠 `#CCC`、文字 `#666`、ラベル「-」。
+- 色・略称は `PL_CATEGORIES` の `color` / `shortLabel` をそのまま使う（admin独自の色分岐 `getCategoryColor` 系は front のルールに揃えて共通化するのが望ましい）。
+
+### 3. 政治団体一覧（/political-organizations）
+対応コード: `admin/src/app/(auth)/political-organizations/page.tsx`
+
+- ヘッダー行: 左に英字ラベル「Organizations」+ h1「政治団体一覧」（下線付き）。右に「新規作成」= **teal塗りピル**（`#30BCA7`、白文字13px/700、`ph-plus`、hover `#089781`）。
+- 団体カード: 白、黒1px枠、radius 8px、padding `22px 26px`。
+  - 団体名 17px/700 + 種別ピル（背景 `#E2F6F3`、文字 `#0F8472`、11px/700）。
+  - 説明 13px `#666`、作成日 Poppins 12px `#939393`（`作成日: YYYY.MM.DD`）。
+  - 右に「編集」黒1.5px枠白ピル / 「削除」赤枠白地赤文字ピル（12px/700、`white-space: nowrap`）。
+
+### 4. 取引先マスタ（/counterparts）
+対応コード: `CounterpartMasterClient.tsx`, `CounterpartTable.tsx`
+
+- ヘッダー行: 「Counterparts」+ h1「取引先マスタ管理」+ 右に teal「新規作成」ピル。
+- カード内: 検索input（ピル、黒1.5px枠、placeholder `#B1B1B1`、focusで枠teal + `box-shadow: 0 0 0 2px #E2F6F3`）+「検索」黒枠ピル（`ph-magnifying-glass`）。
+- 件数「312件の取引先」13px `#666`。
+- テーブル: 取引一覧と同じ罫線ルール。名前セルはリンク（`#0F8472`、hover `#089781` + 下線）。使用数は Poppins 右寄せ「N件」。操作列に小ピル「編集」（黒枠）/「削除」（赤枠）11px/700 `white-space: nowrap`。
+
+### 5. CSVアップロード（/upload-csv）
+対応コード: `CsvUploadClient.tsx`（モックはレイアウト推定を含む）
+
+- 「Data Import」+ h1「CSVアップロード」。カードは max-width 720px。
+- フォーム: 政治団体 / データソース の2 select（ラベル12px/700 + 赤 `*`、ピルselect）。
+- ドロップゾーン: `1.5px dashed #30BCA7`、背景 `#E2F6F3`、radius 8px、padding `48px 24px` 中央寄せ。`ph-upload-simple` 36px `#0F8472`、「CSVファイルをドラッグ＆ドロップ」14px/700、「ファイルを選択」黒枠白ピル、注記「UTF-8 / Shift-JIS ・ 最大 10MB」Poppins 11px `#939393`。
+- 右下に「プレビューを表示」teal塗りピル + `ph-arrow-right`。
+
+### 6. その他の画面（紐付け・報告書エクスポート等）
+モックでは未作成。上記と同じ語彙で展開する:
+ページヘッダー（英字ラベル+下線付きh1）/ 白カード黒枠 / ピルボタン（primary=teal塗り、secondary=黒枠白、destructive=赤枠白地）/ ピル入力・select / テーブル罫線ルール。ダイアログ（Radix Dialog）は白背景・黒1px枠・radius 8px・タイトル墨文字に置き換え。
+
+## Interactions & Behavior
+
+- hover: 色のみ 150ms ease-out。teal塗り→ `#089781`、白ピル→ `#F8F8F8`、赤枠→ `#FDF0F1`、navアイテム→背景 `#E2F6F3`。
+- focus-visible: `2px solid #30BCA7` リング（offset 2px）。入力は枠teal + `0 0 0 2px #E2F6F3`。
+- 無効ボタン: 枠 `#CCC`、文字 `#B1B1B1`、cursor not-allowed（opacityトリックは使わない）。
+- サイドバー折りたたみ: 幅 236px ↔ 72px。折りたたみ状態はローカル（persist不要、してもよい）。
+- ローディング/スピナー: 既存挙動を踏襲しつつ色を teal に（`border-t-transparent` のスピナーは `#30BCA7`）。
+- アニメーション: バウンス・スケール・パララックス禁止。
+
+## State Management
+
+既存のまま（このハンドオフは見た目の差し替えが主）。モック固有の状態は `screen`（表示画面）と `collapsed`（サイドバー）のみで、実装では Next.js のルーティングと置き換わる。
+
+## Assets
+
+- Phosphor Icons regular: CDN `https://unpkg.com/@phosphor-icons/web@2.1.1/src/regular/style.css`（React なら `@phosphor-icons/react` を regular weight で。**lucide-react から置き換え推奨**、少なくとも新規はPhosphor）。
+- フォント: Poppins（Google Fonts等から）。日本語は Hiragino → Noto Sans fallback のスタック指定のみでよい。
+- ロゴ画像: admin では不使用。
+
+## Files
+
+- `Marumie Admin.dc.html` — モック本体（ブラウザで直接開ける。サイドバーのメニューで画面切替）
+- `support.js` — モックのランタイム（参照不要）
+- `_ds/.../colors_and_type.css` — デザイントークン一式（`--tm-*` CSS変数。実装時の正）
+- `_ds/.../_ds_bundle.js` — モック用バンドル（参照不要）
+
+## 実装順の提案
+
+1. `admin/src/app/globals.css` のテーマ変数をライト+tealに差し替え（上記移植例）
+2. `ui/button.tsx` `ui/input.tsx` `ui/select.tsx` を ピル形状 + 黒枠/teal塗り/赤枠 の3バリアントへ
+3. `Sidebar.tsx`（白背景・ピルnav・アイコン・折りたたみ）と `(auth)/layout.tsx`（背景 `#F8F8F8`）
+4. 各画面の `text-white` / `bg-blue-600` 等のハードコードをトークン参照へ置換、ページヘッダー（英字ラベル+下線h1）を共通コンポーネント化
+5. カテゴリピルを front とルール共通化（shared に移すのが理想）

--- a/docs/reference/design_handoff_admin_redesign/_ds/team-mirai-design-system-remix-2a300789-1a0e-4f29-8893-6e06fbf24d63/_ds_bundle.js
+++ b/docs/reference/design_handoff_admin_redesign/_ds/team-mirai-design-system-remix-2a300789-1a0e-4f29-8893-6e06fbf24d63/_ds_bundle.js
@@ -1,0 +1,11 @@
+/* @ds-bundle: {"format":4,"namespace":"TeamMiraiDesignSystemRemix_2a3007","components":[],"sourceHashes":{},"inlinedExternals":[],"unexposedExports":[]} */
+
+(() => {
+
+const __ds_ns = (window.TeamMiraiDesignSystemRemix_2a3007 = window.TeamMiraiDesignSystemRemix_2a3007 || {});
+
+const __ds_scope = {};
+
+(__ds_ns.__errors = __ds_ns.__errors || []);
+
+})();

--- a/docs/reference/design_handoff_admin_redesign/_ds/team-mirai-design-system-remix-2a300789-1a0e-4f29-8893-6e06fbf24d63/colors_and_type.css
+++ b/docs/reference/design_handoff_admin_redesign/_ds/team-mirai-design-system-remix-2a300789-1a0e-4f29-8893-6e06fbf24d63/colors_and_type.css
@@ -1,0 +1,264 @@
+/* ==========================================================================
+   Team Mirai — Design Tokens
+   ========================================================================== */
+
+/* ---------- Fonts ----------
+   Hiragino Kaku Gothic (used in production) is an Apple system font; we ship
+   Noto Sans as a near-equivalent fallback for non-Apple environments. Use the
+   stack — Hiragino will be picked up automatically on macOS/iOS.
+*/
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("fonts/NotoSans-Light.ttf") format("truetype");
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Noto Sans";
+  src: url("fonts/NotoSans-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Noto Sans";
+  src: url("fonts/NotoSans-Medium.ttf") format("truetype");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Noto Sans";
+  src: url("fonts/NotoSans-SemiBold.ttf") format("truetype");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Noto Sans";
+  src: url("fonts/NotoSans-Bold.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Noto Sans";
+  src: url("fonts/NotoSans-ExtraBold.ttf") format("truetype");
+  font-weight: 800;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Noto Sans";
+  src: url("fonts/NotoSans-Black.ttf") format("truetype");
+  font-weight: 900;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Poppins";
+  src: url("fonts/Poppins-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Poppins";
+  src: url("fonts/Poppins-Medium.ttf") format("truetype");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Poppins";
+  src: url("fonts/Poppins-SemiBold.ttf") format("truetype");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Poppins";
+  src: url("fonts/Poppins-Bold.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Poppins";
+  src: url("fonts/Poppins-Black.ttf") format("truetype");
+  font-weight: 900;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ---------- Tokens ---------- */
+:root {
+  /* Primary teal — "Mirai Teal". The single brand colour. */
+  --tm-teal:        #30BCA7;   /* rgb(48,188,167)  — primary fill */
+  --tm-teal-hover:  #089781;   /* rgb(8,151,129)   — hover / strong text on white */
+  --tm-teal-deep:   #0F8472;   /* rgb(15,132,114)  — pressed / dense text */
+  --tm-teal-soft:   #64D8C6;   /* rgb(100,216,198) — accent / illustrations */
+  --tm-teal-200:    #BCECD3;   /* rgb(188,236,211) — subdued borders / dividers */
+  --tm-teal-100:    #E2F6F3;   /* rgb(226,246,243) — section backgrounds (most common) */
+  --tm-teal-50:     #EEF6E2;   /* rgb(238,246,226) — alt mint-leaning surface */
+
+  /* Highlight accents */
+  --tm-yellow:      #F7F741;   /* rgb(247,247,65) — highlight pill ("手ぶらでもOK") */
+  --tm-yellow-pure: #FFFF00;   /* type marker behind characters */
+  --tm-red:         #E63946;   /* day-of-week badge (日) and urgent badges */
+
+  /* Neutrals */
+  --tm-black:       #000000;   /* primary text + borders. Yes, true black. */
+  --tm-ink:         #1F2937;   /* deep-ink for body where pure black is too harsh */
+  --tm-ink-2:       #1E2939;   /* alt ink (figma value) */
+  --tm-ink-3:       #101828;   /* near-black for large display copy */
+  --tm-gray-700:    #333333;
+  --tm-gray-600:    #4C4C4C;
+  --tm-gray-500:    #666666;   /* secondary copy */
+  --tm-gray-400:    #939393;   /* tertiary, dates */
+  --tm-gray-300:    #B1B1B1;   /* placeholder text, inactive icons */
+  --tm-gray-250:    #CCCCCC;   /* hairlines, disabled fills */
+  --tm-gray-200:    #D9D9D9;
+  --tm-gray-150:    #E5E5E5;   /* card borders */
+  --tm-gray-100:    #F0F0F0;   /* header border */
+  --tm-gray-50:     #F8F8F8;   /* surface tint, chips */
+  --tm-white:       #FFFFFF;
+
+  /* Surface roles */
+  --tm-bg:          var(--tm-white);
+  --tm-bg-alt:      var(--tm-teal-100);    /* the signature mint section bg */
+  --tm-bg-muted:    var(--tm-gray-50);
+  --tm-fg:          var(--tm-black);
+  --tm-fg-muted:    var(--tm-gray-500);
+  --tm-fg-faint:    var(--tm-gray-400);
+  --tm-fg-on-teal:  var(--tm-white);
+  --tm-border:      var(--tm-black);       /* 1px solid black is the default */
+  --tm-border-soft: var(--tm-gray-150);
+
+  /* Type families */
+  --tm-font-jp: "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Std",
+                "Noto Sans", "Noto Sans JP", -apple-system, BlinkMacSystemFont,
+                "Segoe UI", system-ui, sans-serif;
+  --tm-font-jp-display: "Hiragino Kaku Gothic Std", "Hiragino Kaku Gothic ProN",
+                        "Noto Sans", "Noto Sans JP", system-ui, sans-serif;
+  --tm-font-latin: "Poppins", "Montserrat", "Lexend Deca", "Noto Sans",
+                   system-ui, sans-serif;   /* dates, numbers, ENGLISH section labels */
+  --tm-font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Scale — type. Production uses many granular sizes; these are the
+     canonical six-step ramp that covers 99% of work. */
+  --tm-size-display:  clamp(36px, 6vw, 64px);  /* hero "未来のために。" */
+  --tm-size-h1:       clamp(28px, 3.6vw, 42px);
+  --tm-size-h2:       clamp(22px, 2.4vw, 28px);
+  --tm-size-h3:       18px;
+  --tm-size-body:     15px;                    /* dominant body in figma */
+  --tm-size-body-sm:  13px;
+  --tm-size-caption:  11px;
+  --tm-size-label-en: 15px;                    /* "Facts", "Vision" English labels */
+
+  /* Letter-spacing — production uses generous tracking on Japanese display */
+  --tm-track-display: 0.06em;
+  --tm-track-heading: 0.04em;
+  --tm-track-body:    0.04em;
+  --tm-track-label:   0.10em;                  /* uppercase English labels */
+
+  /* Line height */
+  --tm-lh-tight:   1.2;   /* @kind font */
+  --tm-lh-display: 1.4;   /* @kind font */
+  --tm-lh-body:    1.8;   /* @kind font */
+  --tm-lh-loose:   2.0;   /* @kind font */
+
+  /* Weights */
+  --tm-w-light:     300;  /* @kind font */
+  --tm-w-regular:   400;  /* @kind font */
+  --tm-w-medium:    500;  /* @kind font */
+  --tm-w-semi:      600;  /* @kind font */
+  --tm-w-bold:      700;  /* @kind font */
+  --tm-w-xbold:     800;  /* @kind font */
+  --tm-w-black:     900;  /* @kind font */
+
+  /* Radius — pill is the signature; cards have small radius or none */
+  --tm-radius-pill:  9999px;
+  --tm-radius-lg:    24px;
+  --tm-radius-md:    12px;
+  --tm-radius-sm:    8px;
+  --tm-radius-xs:    4px;
+
+  /* Spacing — 4px base */
+  --tm-space-1:  4px;
+  --tm-space-2:  8px;
+  --tm-space-3:  12px;
+  --tm-space-4:  16px;
+  --tm-space-5:  20px;
+  --tm-space-6:  24px;
+  --tm-space-8:  32px;
+  --tm-space-10: 40px;
+  --tm-space-12: 48px;
+  --tm-space-16: 64px;
+
+  /* Shadow — used very sparingly. The signature is offset stack, not blur. */
+  --tm-shadow-card:    0 8px 24px rgba(0,0,0,0.08);
+  --tm-shadow-elev:    0 12px 32px rgba(0,0,0,0.12);
+
+  /* Stroke — borders are usually 1px solid black */
+  --tm-stroke-hair:   1px;
+  --tm-stroke-thick:  1.5px;
+}
+
+/* ---------- Semantic / element defaults ----------
+   Apply to <body> or a wrapper to inherit Team Mirai defaults.
+*/
+.tm-root,
+.tm-typography {
+  font-family: var(--tm-font-jp);
+  color: var(--tm-fg);
+  background: var(--tm-bg);
+  font-size: var(--tm-size-body);
+  line-height: var(--tm-lh-body);
+  letter-spacing: var(--tm-track-body);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.tm-typography :is(h1,h2,h3,h4) { font-family: var(--tm-font-jp-display); }
+.tm-typography h1 { font-size: var(--tm-size-h1); font-weight: var(--tm-w-bold); letter-spacing: var(--tm-track-display); line-height: var(--tm-lh-display); margin: 0; }
+.tm-typography h2 { font-size: var(--tm-size-h2); font-weight: var(--tm-w-bold); letter-spacing: var(--tm-track-heading); line-height: 1.4; margin: 0; }
+.tm-typography h3 { font-size: var(--tm-size-h3); font-weight: var(--tm-w-bold); line-height: 1.6; margin: 0; }
+.tm-typography p  { margin: 0 0 1em; }
+.tm-typography small { font-size: var(--tm-size-body-sm); color: var(--tm-fg-muted); }
+
+/* English section label, e.g. "Facts", "Vision", "JOIN US!" */
+.tm-label-en {
+  font-family: var(--tm-font-latin);
+  font-weight: var(--tm-w-semi);
+  font-size: var(--tm-size-label-en);
+  letter-spacing: var(--tm-track-label);
+  color: var(--tm-teal-hover);
+  text-transform: none; /* labels appear in source case, not upper */
+}
+
+/* Big numeric (used in Facts: "3,813,750 票") */
+.tm-stat {
+  font-family: var(--tm-font-latin);
+  font-weight: var(--tm-w-bold);
+  font-size: 40px;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  color: var(--tm-fg);
+}
+.tm-stat-unit { font-size: 0.5em; font-weight: var(--tm-w-bold); margin-left: 4px; }
+
+/* Mint underline below display copy — the official treatment is a teal
+   border-bottom that sits with a small gap below the glyphs, NOT a marker
+   swipe behind the characters.
+   <span class="tm-mint-underline">未来のために。</span>
+*/
+.tm-mint-underline {
+  text-decoration: underline;
+  text-decoration-color: var(--tm-teal-soft);
+  text-decoration-thickness: 3px;
+  text-underline-offset: -2px;
+}

--- a/docs/reference/design_handoff_admin_redesign/support.js
+++ b/docs/reference/design_handoff_admin_redesign/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,8 @@
   ],
   "workspaces": {
     ".": {
-      "entry": ["shared/**/*.ts"]
+      "entry": ["shared/**/*.ts"],
+      "ignore": ["docs/**"]
     },
     "webapp": {
       "entry": [


### PR DESCRIPTION
## 概要

Team Mirai デザインシステムを admin に適用するためのデザインハンドオフを `docs/reference/design_handoff_admin_redesign/` に追加する。

- `README.md`: デザイン原則・トークン・画面ごとの仕様・実装順の提案
- `Marumie Admin.dc.html` / `support.js`: ブラウザで直接開けるモック
- `_ds/.../colors_and_type.css`: デザイントークン一式（`--tm-*`）

あわせて、docs 配下のモック用 JS を knip が「未使用ファイル」として検出しないよう、root workspace で `docs/**` を ignore に追加した。

## 背景

管理画面のリデザインをループエンジニアリングで進めるため、#1300 → #1289 → #1290〜#1299 の Issue を起票済み。各 Issue はこのハンドオフを正として参照するので、先に main に入れておく。

## 影響範囲

ドキュメントと knip 設定のみ。アプリケーションコードの変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)