### PR TITLE
fix(ci): e2e ジョブ復元後に .next/cache の fetch-cache を削除してラン間の Data Cache 持ち越しを防ぐ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
 
+      # .next/cache にはコンパイラキャッシュに加えて Data Cache（fetch-cache、
+      # unstable_cache のエントリを含む）が永続化される。DB は毎ラン db:reset で
+      # リセットされ ID が再割り当てされるため、前ランの fetch-cache が残っていると
+      # キャッシュキーが衝突して前ランのデータが画面に表示されてしまう。
+      # コンパイラキャッシュだけを持ち越すよう、ビルド前に必ず削除する。
+      - name: Remove restored Next.js Data Cache
+        run: rm -rf admin/.next/cache/fetch-cache webapp/.next/cache/fetch-cache
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## 目的（Why）

main の CI（e2e ジョブ）が連続で failure しており、後続のリデザイン系タスク（#1289〜#1299）の PR の CI を不安定にしているため、ループ全体のブロッカーとして修理する。

e2e ジョブは `admin/.next/cache` / `webapp/.next/cache` を actions/cache でラン間復元しているが、このディレクトリには Next.js の Data Cache（`fetch-cache`、`unstable_cache` のエントリを含む）も永続化される。DB は毎ラン `db:reset` でリセットされ BigInt autoincrement の ID が再割り当てされるため、前ランのキャッシュエントリとキーが衝突し、前ランで保存されたデータが今ランの画面に表示されて e2e（report-profile.spec.ts）が落ちていた。

## 変更内容

- CI の e2e ジョブに、キャッシュ復元後・ビルド前に `admin/.next/cache/fetch-cache` と `webapp/.next/cache/fetch-cache` を削除するステップを追加
- コンパイラキャッシュ（ビルド高速化に有効な部分）はそのまま持ち越す

Closes #1303

## ローカルCI

`pnpm verify` ✅（test 1013 passed / typecheck / lint / knip / depcruise すべて成功）
※ アプリコードの変更はないため E2E のローカル実行は省略（この修正の検証対象は CI 環境のキャッシュ挙動そのもの）

## スコープアウトした Issue

なし（関連の #1304 unstable_cache 見直しは既に起票済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)