### PR TITLE
docs(admin): admin はライトモードのみ（ダークモード非対応）であることをガイドラインと CLAUDE.md に明記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ webapp / admin のバックエンド実装に関する詳細なルールは [doc
 ## admin UI コンポーネント
 
 admin で UI コンポーネントを使用する際は [docs/admin-ui-guidelines.md](docs/admin-ui-guidelines.md) を参照すること。
+admin はライトモードのみ（ダークモード非対応）。
 
 ## ループエンジニアリング（AIによる自律実装）
 

--- a/docs/admin-ui-guidelines.md
+++ b/docs/admin-ui-guidelines.md
@@ -4,6 +4,7 @@ admin アプリケーションで shadcn UI を使用する際のルールを定
 
 ## 原則
 
+- **admin はライトモードのみ**（ダークモードは提供しない）
 - **shadcn UI コンポーネントを使用する**（カスタム実装は非推奨）
 - **import は index.ts 経由**で行う
 - **CSS 変数と cn() を使う**（直書きスタイル禁止）
@@ -60,25 +61,18 @@ import { cn } from "@/client/lib";
    export { Tooltip, TooltipTrigger, TooltipContent } from "@/client/components/ui/tooltip";
    ```
 
-3. ダークモード対応を確認（後述）
+3. テーマ方針への適合を確認（後述）
 
 利用可能なコンポーネント一覧: https://ui.shadcn.com/docs/components
 
-### ダークモード対応
+### テーマ方針（ライトモードのみ）
 
-admin は **Dark Blue テーマ（ダークモード固定）** を採用している。
-テーマ定義は `admin/src/app/globals.css` の `@theme` ブロックにある。
+admin は **ライトモードのみ** で提供する。ダークモードは提供せず、
+`dark:` バリアントや `prefers-color-scheme` による切り替えは実装しない。
 
-shadcn コンポーネントの `dark:` プレフィックス付きクラスは自動適用されないため、
-コンポーネント追加時は `dark:` の値をデフォルトとして適用する。
-
-```tsx
-// 公式の定義
-"bg-transparent dark:bg-input/30"
-
-// admin での適用（dark: を除去してデフォルトに）
-"bg-input/30"
-```
+- shadcn コンポーネント追加時、公式定義に含まれる `dark:` プレフィックス付きクラスは削除する
+- 色・形状（デザイントークン、コンポーネントの見た目）の正は
+  デザインハンドオフ [docs/reference/design_handoff_admin_redesign/README.md](reference/design_handoff_admin_redesign/README.md) を参照する
 
 ## Toast 通知
 


### PR DESCRIPTION
## 目的（Why）

admin を Team Mirai ブランド（白ベース + Mirai Teal）にリデザインする一連の作業（#1289 以降）を実装するループが、旧テーマ前提（Dark Blue・ダークモード固定）の記述を正本として読んで逆方向に進むのを防ぐため。モード方針の宣言だけを先行して明記する。

## 変更内容

- docs/admin-ui-guidelines.md
  - 原則に「admin はライトモードのみ（ダークモードは提供しない）」を追加
  - 「ダークモード対応」節を「テーマ方針（ライトモードのみ）」に置き換え、`dark:` バリアントや `prefers-color-scheme` による切り替えを実装しないことを明記
  - 色・形状の正はデザインハンドオフ（docs/reference/design_handoff_admin_redesign/README.md）を参照するよう記載
- CLAUDE.md の admin UI コンポーネント節に「admin はライトモードのみ（ダークモード非対応）」を一行追記

コード（globals.css、ui コンポーネント、各画面）の変更は含まない（#1289 以降で実施）。

Closes #1300

## ローカルCI

`pnpm verify`（test / typecheck / lint / knip / depcruise）すべて通過。

## スコープアウトした Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)