### PR TITLE
perf(ci): webapp E2E を webapp ジョブへ移し、admin E2E のログインを storageState に共通化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,19 @@ jobs:
             ${{ runner.os }}-nextjs-webapp-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-nextjs-webapp-
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      # .next/cache には Data Cache（fetch-cache）が永続化されるため、
+      # 前ランのデータ持ち越しを防ぐようビルド前に必ず削除する（e2e ジョブと同様）
+      - name: Remove restored Next.js Data Cache
+        run: rm -rf webapp/.next/cache/fetch-cache
+
       - name: Install dependencies
         run: pnpm install
 
@@ -166,11 +179,33 @@ jobs:
       - name: Run type check for webapp
         run: pnpm --filter webapp run type-check
 
+      - name: Install Playwright browsers
+        run: pnpm --filter webapp exec playwright install chromium --with-deps
+
+      - name: Run database migrations and seed
+        run: |
+          pnpm db:migrate:deploy
+          pnpm db:seed
+
+      - name: Build webapp
+        run: pnpm build:webapp
+
+      - name: Run E2E tests for webapp
+        run: pnpm --filter webapp test:e2e
+
       - name: Upload webapp coverage
         uses: actions/upload-artifact@v6
         with:
           name: webapp-coverage
           path: webapp/coverage/lcov.info
+
+      - name: Upload webapp E2E test results
+        uses: actions/upload-artifact@v6
+        if: ${{ !cancelled() }}
+        with:
+          name: webapp-e2e-report
+          path: webapp/e2e/.output/
+          retention-days: 7
 
   knip:
     runs-on: ubuntu-latest
@@ -259,15 +294,6 @@ jobs:
             ${{ runner.os }}-nextjs-admin-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-nextjs-admin-
 
-      - name: Cache Next.js build (webapp)
-        uses: actions/cache@v5
-        with:
-          path: webapp/.next/cache
-          key: ${{ runner.os }}-nextjs-webapp-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('webapp/**/*.ts', 'webapp/**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-webapp-${{ hashFiles('pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-webapp-
-
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         with:
@@ -282,7 +308,7 @@ jobs:
       # キャッシュキーが衝突して前ランのデータが画面に表示されてしまう。
       # コンパイラキャッシュだけを持ち越すよう、ビルド前に必ず削除する。
       - name: Remove restored Next.js Data Cache
-        run: rm -rf admin/.next/cache/fetch-cache webapp/.next/cache/fetch-cache
+        run: rm -rf admin/.next/cache/fetch-cache
 
       - name: Install dependencies
         run: pnpm install
@@ -339,17 +365,11 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ env.SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ steps.supabase-keys.outputs.SUPABASE_ANON_KEY }}
 
-      - name: Build webapp
-        run: pnpm build:webapp
-
       - name: Run E2E tests for admin
         run: pnpm --filter admin test:e2e
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ env.SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ steps.supabase-keys.outputs.SUPABASE_ANON_KEY }}
-
-      - name: Run E2E tests for webapp
-        run: pnpm --filter webapp test:e2e
 
       - name: Upload admin E2E test results
         uses: actions/upload-artifact@v6
@@ -357,14 +377,6 @@ jobs:
         with:
           name: admin-e2e-report
           path: admin/e2e/.output/
-          retention-days: 7
-
-      - name: Upload webapp E2E test results
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: webapp-e2e-report
-          path: webapp/e2e/.output/
           retention-days: 7
 
   # main のブランチ保護で必須にする唯一のチェック。

--- a/admin/e2e/tests/auth.setup.ts
+++ b/admin/e2e/tests/auth.setup.ts
@@ -1,0 +1,12 @@
+import { expect, test as setup } from "@playwright/test";
+import { STORAGE_STATE } from "../../playwright.config";
+
+setup("ログインして storageState を保存する", async ({ page }) => {
+	await page.goto("/login");
+	await page.getByLabel("Email").fill("foo@example.com");
+	await page.getByLabel("Password").fill("foo@example.com");
+	await page.getByRole("button", { name: "ログイン" }).click();
+	await expect(page).toHaveURL("/");
+
+	await page.context().storageState({ path: STORAGE_STATE });
+});

--- a/admin/e2e/tests/counterparts.spec.ts
+++ b/admin/e2e/tests/counterparts.spec.ts
@@ -1,14 +1,6 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("取引先マスタ管理", () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto("/login");
-		await page.getByLabel("Email").fill("foo@example.com");
-		await page.getByLabel("Password").fill("foo@example.com");
-		await page.getByRole("button", { name: "ログイン" }).click();
-		await expect(page).toHaveURL("/");
-	});
-
 	test.describe("読み込み", () => {
 		test("取引先マスタページが正常に表示される", async ({ page }) => {
 			await page.goto("/counterparts");

--- a/admin/e2e/tests/dashboard.spec.ts
+++ b/admin/e2e/tests/dashboard.spec.ts
@@ -2,11 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("ダッシュボード", () => {
 	test.beforeEach(async ({ page }) => {
-		await page.goto("/login");
-		await page.getByLabel("Email").fill("foo@example.com");
-		await page.getByLabel("Password").fill("foo@example.com");
-		await page.getByRole("button", { name: "ログイン" }).click();
-		await expect(page).toHaveURL("/");
+		await page.goto("/");
 	});
 
 	test.describe("読み込み", () => {

--- a/admin/e2e/tests/import-donors.spec.ts
+++ b/admin/e2e/tests/import-donors.spec.ts
@@ -2,14 +2,6 @@ import { test, expect } from "@playwright/test";
 import path from "node:path";
 
 test.describe("寄付者一括インポート", () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto("/login");
-		await page.getByLabel("Email").fill("foo@example.com");
-		await page.getByLabel("Password").fill("foo@example.com");
-		await page.getByRole("button", { name: "ログイン" }).click();
-		await expect(page).toHaveURL("/");
-	});
-
 	test.describe("読み込み", () => {
 		test("寄付者一括インポートページが正常に表示される", async ({ page }) => {
 			await page.goto("/import-donors");

--- a/admin/e2e/tests/login.spec.ts
+++ b/admin/e2e/tests/login.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "@playwright/test";
 
+// ログイン自体を検証するため、共通の認証済み storageState は使わない
+test.use({ storageState: { cookies: [], origins: [] } });
+
 test.describe("ログインページ", () => {
 	test("ログインページが正常に表示される", async ({ page }) => {
 		const response = await page.goto("/login");

--- a/admin/e2e/tests/political-organizations.spec.ts
+++ b/admin/e2e/tests/political-organizations.spec.ts
@@ -1,14 +1,6 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("政治団体管理", () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto("/login");
-		await page.getByLabel("Email").fill("foo@example.com");
-		await page.getByLabel("Password").fill("foo@example.com");
-		await page.getByRole("button", { name: "ログイン" }).click();
-		await expect(page).toHaveURL("/");
-	});
-
 	test.describe("読み込み", () => {
 		test("政治団体一覧ページが正常に表示される", async ({ page }) => {
 			await page.goto("/political-organizations");

--- a/admin/e2e/tests/report-profile.spec.ts
+++ b/admin/e2e/tests/report-profile.spec.ts
@@ -1,14 +1,6 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("報告書プロフィール", () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto("/login");
-		await page.getByLabel("Email").fill("foo@example.com");
-		await page.getByLabel("Password").fill("foo@example.com");
-		await page.getByRole("button", { name: "ログイン" }).click();
-		await expect(page).toHaveURL("/");
-	});
-
 	test.describe("年度切り替え", () => {
 		test("年度を切り替えてもフォームが正しく同期し、他の年度を上書きしない", async ({ page }) => {
 			// 既存シードや他テストと干渉しないよう、テスト専用の政治団体を作成

--- a/admin/e2e/tests/transactions.spec.ts
+++ b/admin/e2e/tests/transactions.spec.ts
@@ -1,14 +1,6 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("取引一覧", () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto("/login");
-		await page.getByLabel("Email").fill("foo@example.com");
-		await page.getByLabel("Password").fill("foo@example.com");
-		await page.getByRole("button", { name: "ログイン" }).click();
-		await expect(page).toHaveURL("/");
-	});
-
 	test.describe("読み込み", () => {
 		test("取引一覧ページが正常に表示される", async ({ page }) => {
 			await page.goto("/transactions");

--- a/admin/e2e/tests/user-info.spec.ts
+++ b/admin/e2e/tests/user-info.spec.ts
@@ -1,14 +1,6 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("ユーザー情報", () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto("/login");
-		await page.getByLabel("Email").fill("foo@example.com");
-		await page.getByLabel("Password").fill("foo@example.com");
-		await page.getByRole("button", { name: "ログイン" }).click();
-		await expect(page).toHaveURL("/");
-	});
-
 	test.describe("読み込み", () => {
 		test("ユーザー情報ページが正常に表示される", async ({ page }) => {
 			await page.goto("/user-info");

--- a/admin/playwright.config.ts
+++ b/admin/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// setup プロジェクトで 1 回だけ UI ログインし、各テストは保存した
+// storageState を使い回す（spec ごとの beforeEach ログインを廃止）
+export const STORAGE_STATE = "e2e/.output/.auth/user.json";
+
 export default defineConfig({
   testDir: "./e2e/tests",
   outputDir: "./e2e/.output/test-results",
@@ -14,8 +18,13 @@ export default defineConfig({
   },
   projects: [
     {
+      name: "setup",
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: { ...devices["Desktop Chrome"], storageState: STORAGE_STATE },
+      dependencies: ["setup"],
     },
   ],
   webServer: {


### PR DESCRIPTION
## 目的（Why）

PR を出す開発者が CI の完了を約 4 分待たされる状態を解消するため。CI 全体の所要時間はほぼ e2e ジョブに等しく、その大半がインフラセットアップと重複ログインに費やされていた。

## 変更内容

Issue #1263 の対応案 1・2 を実施（Issue 内で「まず 1 と 2 だけで PR を切ると安全」と推奨されている範囲）。

### 1. webapp の E2E を webapp ジョブへ移動

- webapp は Supabase 非依存（seed の users も `SUPABASE_SERVICE_ROLE_KEY` が無ければスキップされる）ため、postgres サービスを持つ webapp ジョブで migrate + seed + build + E2E まで実行する
- e2e ジョブは admin 専用になり、webapp のビルド（約30秒）と E2E 実行（15秒）が並列側へ逃げる
- webapp ジョブにも Data Cache（fetch-cache）削除を追加し、e2e ジョブと同じくラン間のデータ持ち越しを防ぐ（#1305 と同様の対策）

### 2. admin のログインを storageState に共通化

- Playwright の setup プロジェクトで 1 回だけ UI ログインし、保存した storageState を全テストで使い回す
- 各 spec の beforeEach ログイン（計 36 回）を廃止
- `login.spec.ts` はログイン自体を検証するため、空の storageState を明示して非認証状態を維持

Closes #1263

## ローカルCIの実行結果

- `pnpm verify`: ✅ 通過（test / typecheck / lint / knip / depcruise）
- webapp E2E: ✅ 通過
- admin E2E: ✅ 40 テスト全通過（CI と同じ `--workers=1` で 21.3 秒。従来はテスト実行だけで約 58 秒）

## スコープアウトして起票した Issue

- #1307 fix(admin): report-profile の年度切り替え E2E の flaky を安定化する（対応案 3）
- #1308 test(e2e): 価値の薄い E2E テストを統合・削除する（対応案 4）
- #1309 ci: e2e ジョブの Supabase 起動時間（約74秒）を短縮する（対応案 5）

🤖 Generated with [Claude Code](https://claude.com/claude-code)