### PR TITLE
feat(admin): デザイントークンと共通 UI コンポーネントを Team Mirai ブランド（白ベース + Mirai Teal + ピル）に差し替える

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.2",
+    "@phosphor-icons/react": "^2.1.10",
     "@prisma/client": "^6.19.1",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -35,7 +36,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "iconv-lite": "^0.7.2",
-    "lucide-react": "^0.577.0",
     "next": "16.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/admin/src/app/(auth)/balance-snapshots/page.tsx
+++ b/admin/src/app/(auth)/balance-snapshots/page.tsx
@@ -8,7 +8,7 @@ export default async function BalanceSnapshotsPage() {
 
   return (
     <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-white mb-6">残高登録</h1>
+      <h1 className="text-2xl font-bold text-foreground mb-6">残高登録</h1>
       <BalanceSnapshotsClient organizations={organizations} />
     </div>
   );

--- a/admin/src/app/(auth)/export-report/[orgId]/[year]/page.tsx
+++ b/admin/src/app/(auth)/export-report/[orgId]/[year]/page.tsx
@@ -48,7 +48,7 @@ export default async function ExportReportDetailPage({ params }: ExportReportDet
 
   return (
     <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-white mb-1">報告書エクスポート</h1>
+      <h1 className="text-2xl font-bold text-foreground mb-1">報告書エクスポート</h1>
       <p className="text-muted-foreground mb-6">政治資金報告書をエクスポートします</p>
 
       <div className="space-y-6">

--- a/admin/src/app/(auth)/export-report/page.tsx
+++ b/admin/src/app/(auth)/export-report/page.tsx
@@ -9,7 +9,7 @@ export default async function ExportReportPage() {
   if (organizations.length === 0) {
     return (
       <div className="bg-card rounded-xl p-4">
-        <h1 className="text-2xl font-bold text-white mb-1">報告書エクスポート</h1>
+        <h1 className="text-2xl font-bold text-foreground mb-1">報告書エクスポート</h1>
         <p className="text-muted-foreground">
           政治団体が登録されていません。先に政治団体を作成してください。
         </p>

--- a/admin/src/app/(auth)/import-donors/page.tsx
+++ b/admin/src/app/(auth)/import-donors/page.tsx
@@ -10,7 +10,7 @@ export default async function ImportDonorsPage() {
 
   return (
     <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-white mb-6">寄付者一括インポート</h1>
+      <h1 className="text-2xl font-bold text-foreground mb-6">寄付者一括インポート</h1>
       <DonorCsvImportClient
         organizations={organizations}
         previewAction={previewDonorCsv}

--- a/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
@@ -48,11 +48,11 @@ export default async function EditPoliticalOrganizationPage({
       />
 
       <div className="bg-card rounded-xl p-4">
-        <h2 className="text-lg font-semibold text-white mb-3">関連機能</h2>
+        <h2 className="text-lg font-semibold text-foreground mb-3">関連機能</h2>
         <div className="flex gap-3">
           <Link
             href={`/political-organizations/${orgId}/report-profile`}
-            className="bg-secondary text-white border border-border rounded-lg px-4 py-2.5 hover:bg-primary transition-colors no-underline"
+            className="bg-secondary text-secondary-foreground border border-border rounded-lg px-4 py-2.5 hover:bg-accent transition-colors no-underline"
           >
             報告書プロフィール
           </Link>

--- a/admin/src/app/(auth)/political-organizations/[orgId]/report-profile/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/report-profile/page.tsx
@@ -45,13 +45,13 @@ export default async function ReportProfilePage({ params, searchParams }: Report
       <div className="mb-5">
         <Link
           href="/political-organizations"
-          className="text-muted-foreground no-underline hover:text-white transition-colors"
+          className="text-muted-foreground no-underline hover:text-foreground transition-colors"
         >
           ← 政治団体一覧に戻る
         </Link>
       </div>
 
-      <h1 className="text-2xl font-bold text-white mb-4">
+      <h1 className="text-2xl font-bold text-foreground mb-4">
         「{organization.displayName}」の報告書プロフィール
       </h1>
 

--- a/admin/src/app/(auth)/political-organizations/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/page.tsx
@@ -10,10 +10,10 @@ export default async function PoliticalOrganizationsPage() {
   return (
     <div className="bg-card rounded-xl p-4">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-white">政治団体一覧</h1>
+        <h1 className="text-2xl font-bold text-foreground">政治団体一覧</h1>
         <Link
           href="/political-organizations/new"
-          className="bg-primary text-white border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-blue-600 transition-colors duration-200"
+          className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-primary-hover transition-colors duration-200"
         >
           新規作成
         </Link>
@@ -24,7 +24,7 @@ export default async function PoliticalOrganizationsPage() {
           <p className="text-muted-foreground">政治団体が登録されていません</p>
           <Link
             href="/political-organizations/new"
-            className="bg-primary text-white border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-blue-600 transition-colors duration-200 mt-4 inline-block"
+            className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-primary-hover transition-colors duration-200 mt-4 inline-block"
           >
             最初の政治団体を作成
           </Link>
@@ -38,7 +38,7 @@ export default async function PoliticalOrganizationsPage() {
               <div key={org.id} className="bg-card rounded-lg p-6 border border-border">
                 <div className="flex justify-between items-start gap-4">
                   <div className="flex-1 space-y-3">
-                    <h3 className="text-lg font-medium text-white">{org.displayName}</h3>
+                    <h3 className="text-lg font-medium text-foreground">{org.displayName}</h3>
                     {org.description && <p className="text-muted-foreground">{org.description}</p>}
                     <div className="text-muted-foreground text-sm">
                       作成日: {new Date(org.createdAt).toLocaleDateString("ja-JP")}
@@ -47,7 +47,7 @@ export default async function PoliticalOrganizationsPage() {
                   <div className="flex gap-2">
                     <Link
                       href={`/political-organizations/${org.id}`}
-                      className="bg-secondary text-white no-underline text-sm px-4 py-2 rounded-lg hover:bg-secondary/80 transition-colors duration-200"
+                      className="bg-secondary text-secondary-foreground no-underline text-sm px-4 py-2 rounded-lg hover:bg-secondary/80 transition-colors duration-200"
                     >
                       編集
                     </Link>

--- a/admin/src/app/(auth)/upload-csv/page.tsx
+++ b/admin/src/app/(auth)/upload-csv/page.tsx
@@ -10,7 +10,7 @@ export default async function UploadCsvPage() {
 
   return (
     <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-white mb-6">CSVアップロード</h1>
+      <h1 className="text-2xl font-bold text-foreground mb-6">CSVアップロード</h1>
       <CsvUploadClient
         organizations={organizations}
         uploadAction={uploadCsv}

--- a/admin/src/app/(auth)/users/page.tsx
+++ b/admin/src/app/(auth)/users/page.tsx
@@ -16,7 +16,7 @@ export default async function UsersPage() {
 
   return (
     <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-white mb-4">ユーザー管理</h1>
+      <h1 className="text-2xl font-bold text-foreground mb-4">ユーザー管理</h1>
       <UserManagement
         users={users}
         availableRoles={["user", "admin"]}

--- a/admin/src/app/globals.css
+++ b/admin/src/app/globals.css
@@ -1,51 +1,67 @@
 @import "tailwindcss";
 
 @theme {
-  /* shadcn/ui Dark Blue テーマ（公式 .dark の値を変換） */
-  --color-background: oklch(0.141 0.005 285.823);
-  --color-foreground: oklch(0.985 0 0);
+  /* Team Mirai デザイントークン（docs/reference/design_handoff_admin_redesign/ が正） */
+  --color-background: #f8f8f8;
+  --color-foreground: #000000;
 
-  --color-card: oklch(0.21 0.006 285.885);
-  --color-card-foreground: oklch(0.985 0 0);
+  --color-card: #ffffff;
+  --color-card-foreground: #000000;
 
-  --color-popover: oklch(0.21 0.006 285.885);
-  --color-popover-foreground: oklch(0.985 0 0);
+  --color-popover: #ffffff;
+  --color-popover-foreground: #000000;
 
-  --color-primary: oklch(0.488 0.243 264.376);
-  --color-primary-foreground: oklch(0.97 0.014 254.604);
+  --color-primary: #30bca7;
+  --color-primary-foreground: #ffffff;
+  --color-primary-hover: #089781;
+  --color-primary-active: #0f8472;
 
-  --color-secondary: oklch(0.274 0.006 286.033);
-  --color-secondary-foreground: oklch(0.985 0 0);
+  --color-secondary: #f8f8f8;
+  --color-secondary-foreground: #000000;
 
-  --color-muted: oklch(0.274 0.006 286.033);
-  --color-muted-foreground: oklch(0.705 0.015 286.067);
+  --color-muted: #f0f0f0;
+  --color-muted-foreground: #666666;
 
-  --color-accent: oklch(0.274 0.006 286.033);
-  --color-accent-foreground: oklch(0.985 0 0);
+  --color-accent: #e2f6f3;
+  --color-accent-foreground: #0f8472;
 
-  --color-destructive: oklch(0.704 0.191 22.216);
-  --color-destructive-foreground: oklch(0.985 0 0);
+  --color-destructive: #e63946;
+  --color-destructive-foreground: #ffffff;
+  --color-destructive-hover: #fdf0f1;
 
-  --color-border: oklch(1 0 0 / 10%);
-  --color-input: oklch(1 0 0 / 15%);
-  --color-ring: oklch(0.556 0 0);
+  --color-teal-soft: #64d8c6;
+  --color-teal-100: #e2f6f3;
 
-  --color-chart-1: oklch(0.809 0.105 251.813);
-  --color-chart-2: oklch(0.623 0.214 259.815);
-  --color-chart-3: oklch(0.546 0.245 262.881);
-  --color-chart-4: oklch(0.488 0.243 264.376);
-  --color-chart-5: oklch(0.424 0.199 265.638);
+  --color-border: #000000;
+  --color-border-soft: #e5e5e5;
+  --color-input: #ffffff;
+  --color-ring: #30bca7;
+  --color-ring-soft: #e2f6f3;
 
-  --color-sidebar: oklch(0.21 0.006 285.885);
-  --color-sidebar-foreground: oklch(0.985 0 0);
-  --color-sidebar-primary: oklch(0.623 0.214 259.815);
-  --color-sidebar-primary-foreground: oklch(0.97 0.014 254.604);
-  --color-sidebar-accent: oklch(0.274 0.006 286.033);
-  --color-sidebar-accent-foreground: oklch(0.985 0 0);
-  --color-sidebar-border: oklch(0.225 0.004 286);
-  --color-sidebar-ring: oklch(0.439 0 0);
+  --color-disabled-border: #cccccc;
+  --color-disabled-foreground: #b1b1b1;
 
-  --radius: 0.5rem;
+  --color-chart-1: #30bca7;
+  --color-chart-2: #089781;
+  --color-chart-3: #0f8472;
+  --color-chart-4: #64d8c6;
+  --color-chart-5: #e2f6f3;
+
+  --color-sidebar: #ffffff;
+  --color-sidebar-foreground: #1f2937;
+  --color-sidebar-primary: #30bca7;
+  --color-sidebar-primary-foreground: #ffffff;
+  --color-sidebar-accent: #e2f6f3;
+  --color-sidebar-accent-foreground: #0f8472;
+  --color-sidebar-border: #e5e5e5;
+  --color-sidebar-ring: #30bca7;
+
+  --radius: 8px;
+
+  --font-sans:
+    "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Std", var(--font-poppins), "Noto Sans",
+    "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-latin: var(--font-poppins), "Poppins", "Noto Sans", system-ui, sans-serif;
 }
 
 html,
@@ -54,43 +70,7 @@ body {
 }
 body {
   margin: 0;
-  font-family:
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    Segoe UI,
-    Roboto,
-    Ubuntu,
-    Cantarell,
-    Noto Sans,
-    Helvetica Neue,
-    Arial,
-    "Apple Color Emoji",
-    "Segoe UI Emoji";
+  font-family: var(--font-sans);
   background: var(--color-background);
   color: var(--color-foreground);
-}
-
-.container {
-  display: grid;
-  grid-template-columns: 220px 1fr;
-  height: 100vh;
-}
-.nav {
-  display: grid;
-  gap: 8px;
-}
-.nav a {
-  color: white;
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: 8px;
-}
-.nav a.active,
-.nav a:hover {
-  background: var(--color-secondary);
-}
-.content {
-  padding: 20px;
-  overflow: auto;
 }

--- a/admin/src/app/layout.tsx
+++ b/admin/src/app/layout.tsx
@@ -1,7 +1,14 @@
 import type { Metadata } from "next";
+import { Poppins } from "next/font/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Toaster } from "@/client/components/ui";
 import "./globals.css";
+
+const poppins = Poppins({
+  weight: ["400", "500", "600", "700"],
+  subsets: ["latin"],
+  variable: "--font-poppins",
+});
 
 export const metadata: Metadata = {
   title: "政治資金ダッシュボード管理画面",
@@ -13,7 +20,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja">
+    <html lang="ja" className={poppins.variable}>
       <body>
         {children}
         <Toaster />

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotForm.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotForm.tsx
@@ -100,7 +100,7 @@ export default function BalanceSnapshotForm({
             className={`[color-scheme:dark] ${dateError ? "border-red-500 focus:ring-red-500" : ""}`}
             required
           />
-          {dateError && <p className="text-red-400 text-sm mt-1">{dateError}</p>}
+          {dateError && <p className="text-destructive text-sm mt-1">{dateError}</p>}
         </div>
 
         <div className="w-48">
@@ -123,7 +123,7 @@ export default function BalanceSnapshotForm({
         </div>
       </form>
 
-      {successMessage && <div className="mt-4 text-green-400 text-sm">{successMessage}</div>}
+      {successMessage && <div className="mt-4 text-primary-hover text-sm">{successMessage}</div>}
     </div>
   );
 }

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotList.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotList.tsx
@@ -47,19 +47,21 @@ export default function BalanceSnapshotList({ snapshots }: BalanceSnapshotListPr
       <table className="w-full border-collapse">
         <thead>
           <tr className="border-b border-border">
-            <th className="px-2 py-3 text-left text-sm font-semibold text-white">残高日付</th>
-            <th className="px-2 py-3 text-right text-sm font-semibold text-white">残高</th>
-            <th className="px-2 py-3 text-left text-sm font-semibold text-white">登録日時</th>
-            <th className="px-2 py-3 text-center text-sm font-semibold text-white w-20">操作</th>
+            <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">残高日付</th>
+            <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">残高</th>
+            <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">登録日時</th>
+            <th className="px-2 py-3 text-center text-sm font-semibold text-foreground w-20">
+              操作
+            </th>
           </tr>
         </thead>
         <tbody>
           {snapshots.map((snapshot) => (
             <tr key={snapshot.id} className="border-b border-border">
-              <td className="px-2 py-3 text-sm text-white">
+              <td className="px-2 py-3 text-sm text-foreground">
                 {new Date(snapshot.snapshot_date).toLocaleDateString("ja-JP")}
               </td>
-              <td className="px-2 py-3 text-sm text-right text-white">
+              <td className="px-2 py-3 text-sm text-right text-foreground">
                 ¥{snapshot.balance.toLocaleString()}
               </td>
               <td className="px-2 py-3 text-sm text-muted-foreground">

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotsClient.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotsClient.tsx
@@ -92,7 +92,7 @@ export default function BalanceSnapshotsClient({ organizations }: BalanceSnapsho
           <hr className="border-border" />
 
           <div>
-            <h3 className="text-lg font-medium text-white mb-4">残高を登録</h3>
+            <h3 className="text-lg font-medium text-foreground mb-4">残高を登録</h3>
             <BalanceSnapshotForm
               politicalOrganizationId={selectedOrgId}
               onSubmit={handleFormSubmit}

--- a/admin/src/client/components/balance-snapshots/CurrentBalance.tsx
+++ b/admin/src/client/components/balance-snapshots/CurrentBalance.tsx
@@ -8,7 +8,7 @@ export default function CurrentBalance({ snapshot }: CurrentBalanceProps) {
   if (!snapshot) {
     return (
       <div className="bg-card rounded-lg p-6 border border-border max-w-md">
-        <h3 className="text-lg font-medium text-white mb-4">現在有効な残高</h3>
+        <h3 className="text-lg font-medium text-foreground mb-4">現在有効な残高</h3>
         <p className="text-muted-foreground">残高スナップショットがありません</p>
       </div>
     );
@@ -16,17 +16,17 @@ export default function CurrentBalance({ snapshot }: CurrentBalanceProps) {
 
   return (
     <div className="bg-primary-card rounded-lg p-6 border border-border max-w-md">
-      <h3 className="text-lg font-medium text-white mb-4">現在有効な残高</h3>
+      <h3 className="text-lg font-medium text-foreground mb-4">現在有効な残高</h3>
       <div className="space-y-3">
         <div className="flex justify-between items-center">
           <span className="text-muted-foreground">残高</span>
-          <span className="text-2xl font-bold text-white">
+          <span className="text-2xl font-bold text-foreground">
             ¥{snapshot.balance.toLocaleString()}
           </span>
         </div>
         <div className="flex justify-between items-center">
           <span className="text-muted-foreground">残高日付</span>
-          <span className="text-white">
+          <span className="text-foreground">
             {new Date(snapshot.snapshot_date).toLocaleDateString("ja-JP")}
           </span>
         </div>

--- a/admin/src/client/components/counterpart-assignment/AssignWithCounterpartContent.tsx
+++ b/admin/src/client/components/counterpart-assignment/AssignWithCounterpartContent.tsx
@@ -86,7 +86,7 @@ export function AssignWithCounterpartContent({
   return (
     <div className="flex flex-col lg:flex-row gap-6 flex-1 min-h-0 overflow-hidden">
       <div className="lg:w-1/3 flex-shrink-0 flex flex-col min-h-0">
-        <div className="text-white font-medium mb-3">
+        <div className="text-foreground font-medium mb-3">
           {`選択中の取引 (${transactions.length}件)`}
         </div>
 
@@ -95,7 +95,7 @@ export function AssignWithCounterpartContent({
             <div key={t.id} className="px-3 py-2 text-sm border-b border-border last:border-b-0">
               <div className="flex items-center gap-2">
                 <span className="text-muted-foreground">{formatDate(t.transactionDate)}</span>
-                <span className="text-white">{formatAmount(t.debitAmount)}</span>
+                <span className="text-foreground">{formatAmount(t.debitAmount)}</span>
               </div>
               <div className="text-muted-foreground text-xs truncate">{t.description || "-"}</div>
             </div>

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
@@ -212,7 +212,9 @@ export function CounterpartAssignmentClient({
   if (organizations.length === 0) {
     return (
       <Card className="p-4">
-        <p className="text-white">政治団体が登録されていません。先に政治団体を作成してください。</p>
+        <p className="text-foreground">
+          政治団体が登録されていません。先に政治団体を作成してください。
+        </p>
       </Card>
     );
   }
@@ -221,14 +223,14 @@ export function CounterpartAssignmentClient({
     <div className="bg-card rounded-xl p-4 space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-white mb-1">取引先紐付け管理</h1>
+          <h1 className="text-2xl font-bold text-foreground mb-1">取引先紐付け管理</h1>
           <p className="text-muted-foreground">
             Transactionに対してCounterpart（取引先）を紐付けます
           </p>
         </div>
         <Link
           href="/counterparts"
-          className="bg-secondary text-white border border-border hover:bg-secondary rounded-lg px-4 py-2.5 font-medium transition-colors duration-200"
+          className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary rounded-lg px-4 py-2.5 font-medium transition-colors duration-200"
         >
           マスタ管理へ
         </Link>
@@ -282,7 +284,7 @@ export function CounterpartAssignmentClient({
         </div>
 
         <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-          <span className="text-white text-sm">
+          <span className="text-foreground text-sm">
             選択中: <span className="font-medium">{selectedTransactions.length}件</span>
           </span>
           <Button

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
@@ -2,7 +2,7 @@
 import "client-only";
 
 import { useState } from "react";
-import { CircleHelp } from "lucide-react";
+import { Question } from "@phosphor-icons/react/dist/ssr";
 import {
   Input,
   Button,
@@ -119,7 +119,7 @@ export function CounterpartAssignmentFilters({
             取引先必須のみ表示
             <Tooltip>
               <TooltipTrigger asChild onClick={(e) => e.stopPropagation()}>
-                <CircleHelp className="size-4 hover:text-foreground cursor-help" />
+                <Question className="size-4 hover:text-foreground cursor-help" />
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-sm">
                 <div className="space-y-2 text-left">

--- a/admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx
+++ b/admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx
@@ -122,7 +122,7 @@ export function TransactionWithCounterpartTable({
           <button
             type="button"
             onClick={() => onSortChange("transactionDate")}
-            className="flex items-center gap-1 hover:text-white transition-colors cursor-pointer"
+            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
           >
             日付
             {sortField === "transactionDate" && (
@@ -137,7 +137,7 @@ export function TransactionWithCounterpartTable({
           <button
             type="button"
             onClick={() => onSortChange("debitAmount")}
-            className="flex items-center gap-1 hover:text-white transition-colors cursor-pointer"
+            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
           >
             金額
             {sortField === "debitAmount" && (
@@ -165,7 +165,7 @@ export function TransactionWithCounterpartTable({
             <span>交付金</span>
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="cursor-help text-muted-foreground hover:text-white">
+                <span className="cursor-help text-muted-foreground hover:text-foreground">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="14"
@@ -214,7 +214,7 @@ export function TransactionWithCounterpartTable({
           <button
             type="button"
             onClick={() => onSortChange("categoryKey")}
-            className="flex items-center gap-1 hover:text-white transition-colors cursor-pointer"
+            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
           >
             カテゴリ
             {sortField === "categoryKey" && (
@@ -259,13 +259,13 @@ export function TransactionWithCounterpartTable({
             >
               {counterpart ? (
                 <div className="flex flex-col">
-                  <span className="text-white font-medium truncate">{counterpart.name}</span>
+                  <span className="text-foreground font-medium truncate">{counterpart.name}</span>
                   <span className="text-muted-foreground text-xs truncate">
                     {counterpart.address}
                   </span>
                 </div>
               ) : (
-                <span className="text-yellow-400">未設定</span>
+                <span className="text-yellow-600">未設定</span>
               )}
             </button>
           );
@@ -335,7 +335,7 @@ export function TransactionWithCounterpartTable({
                 <td
                   key={cell.id}
                   className={cn(
-                    "py-2 px-4 text-white",
+                    "py-2 px-4 text-foreground",
                     cell.column.id !== "description" && "whitespace-nowrap",
                   )}
                 >

--- a/admin/src/client/components/counterparts/AddressInput.tsx
+++ b/admin/src/client/components/counterparts/AddressInput.tsx
@@ -24,11 +24,11 @@ interface AddressInputProps {
 function getConfidenceLabel(confidence: AddressCandidate["confidence"]) {
   switch (confidence) {
     case "high":
-      return { text: "高確度", className: "text-green-400" };
+      return { text: "高確度", className: "text-primary-hover" };
     case "medium":
-      return { text: "中確度", className: "text-yellow-400" };
+      return { text: "中確度", className: "text-yellow-600" };
     case "low":
-      return { text: "低確度", className: "text-red-400" };
+      return { text: "低確度", className: "text-destructive" };
   }
 }
 
@@ -130,7 +130,7 @@ export function AddressInput({
                 <div key={key} className="px-4 py-3">
                   <div className="flex items-start justify-between gap-2">
                     <div className="flex-1 min-w-0">
-                      <div className="text-white font-medium">{candidate.companyName}</div>
+                      <div className="text-foreground font-medium">{candidate.companyName}</div>
                       <div className="text-muted-foreground text-sm mt-1">
                         {candidate.postalCode && (
                           <span className="mr-2">〒{candidate.postalCode.replace(/^〒/, "")}</span>

--- a/admin/src/client/components/counterparts/CounterpartDetailClient.tsx
+++ b/admin/src/client/components/counterparts/CounterpartDetailClient.tsx
@@ -186,7 +186,7 @@ export function CounterpartDetailClient({
       <div className="flex items-center gap-4">
         <Link
           href="/counterparts"
-          className="text-muted-foreground hover:text-white transition-colors"
+          className="text-muted-foreground hover:text-foreground transition-colors"
         >
           ← 一覧に戻る
         </Link>
@@ -194,7 +194,7 @@ export function CounterpartDetailClient({
 
       <Card className="p-6">
         <div className="flex justify-between items-start mb-4">
-          <h2 className="text-lg font-semibold text-white">カウンターパート情報</h2>
+          <h2 className="text-lg font-semibold text-foreground">カウンターパート情報</h2>
           <Button
             type="button"
             variant="secondary"
@@ -208,29 +208,29 @@ export function CounterpartDetailClient({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <div className="text-muted-foreground text-sm mb-1">名前</div>
-            <div className="text-white font-medium">{counterpart.name}</div>
+            <div className="text-foreground font-medium">{counterpart.name}</div>
           </div>
           <div>
             <div className="text-muted-foreground text-sm mb-1">住所</div>
-            <div className="text-white">{counterpart.address || "-"}</div>
+            <div className="text-foreground">{counterpart.address || "-"}</div>
           </div>
           <div>
             <div className="text-muted-foreground text-sm mb-1">作成日</div>
-            <div className="text-white">{formatDate(counterpart.createdAt)}</div>
+            <div className="text-foreground">{formatDate(counterpart.createdAt)}</div>
           </div>
           <div>
             <div className="text-muted-foreground text-sm mb-1">更新日</div>
-            <div className="text-white">{formatDate(counterpart.updatedAt)}</div>
+            <div className="text-foreground">{formatDate(counterpart.updatedAt)}</div>
           </div>
           <div>
             <div className="text-muted-foreground text-sm mb-1">使用回数</div>
-            <div className="text-white">{counterpart.usageCount}件</div>
+            <div className="text-foreground">{counterpart.usageCount}件</div>
           </div>
         </div>
       </Card>
 
       <Card className="p-6">
-        <h2 className="text-lg font-semibold text-white mb-4">紐づいている取引</h2>
+        <h2 className="text-lg font-semibold text-foreground mb-4">紐づいている取引</h2>
 
         <div className="flex flex-col md:flex-row md:items-end gap-4 mb-6">
           <div className="w-fit">
@@ -261,7 +261,7 @@ export function CounterpartDetailClient({
 
         {selectedTransactions.length > 0 && (
           <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-            <span className="text-white text-sm">
+            <span className="text-foreground text-sm">
               選択中: <span className="font-medium">{selectedTransactions.length}件</span>
             </span>
             <Button type="button" size="sm" onClick={handleBulkAssignClick}>

--- a/admin/src/client/components/counterparts/CounterpartMasterClient.tsx
+++ b/admin/src/client/components/counterparts/CounterpartMasterClient.tsx
@@ -54,11 +54,11 @@ export function CounterpartMasterClient({
   return (
     <div className="bg-card rounded-xl p-4">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-white">取引先マスタ管理</h1>
+        <h1 className="text-2xl font-bold text-foreground">取引先マスタ管理</h1>
         <button
           type="button"
           onClick={() => setIsCreateDialogOpen(true)}
-          className="bg-primary text-white border-0 rounded-lg px-4 py-2.5 font-medium hover:bg-blue-600 transition-colors duration-200 cursor-pointer"
+          className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium hover:bg-primary-hover transition-colors duration-200 cursor-pointer"
         >
           新規作成
         </button>
@@ -72,11 +72,11 @@ export function CounterpartMasterClient({
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder="名前または住所で検索..."
             aria-label="取引先を名前または住所で検索"
-            className="bg-input text-white border border-border rounded-lg px-3 py-2.5 flex-1 max-w-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary"
+            className="bg-input text-foreground border border-border rounded-lg px-3 py-2.5 flex-1 max-w-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary"
           />
           <button
             type="submit"
-            className="bg-secondary text-white border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
+            className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
           >
             検索
           </button>
@@ -87,7 +87,7 @@ export function CounterpartMasterClient({
                 setSearchInput("");
                 router.push("/counterparts");
               }}
-              className="bg-secondary text-white border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
+              className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
             >
               クリア
             </button>
@@ -109,13 +109,13 @@ export function CounterpartMasterClient({
             onClick={() => handlePageChange(page - 1)}
             disabled={page <= 1}
             aria-label="前のページへ"
-            className={`bg-secondary text-white border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
+            className={`bg-secondary text-secondary-foreground border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
               page <= 1 ? "opacity-50 cursor-not-allowed" : "hover:bg-secondary/80 cursor-pointer"
             }`}
           >
             前へ
           </button>
-          <span className="text-white px-4">
+          <span className="text-foreground px-4">
             {page} / {totalPages}
           </span>
           <button
@@ -123,7 +123,7 @@ export function CounterpartMasterClient({
             onClick={() => handlePageChange(page + 1)}
             disabled={page >= totalPages}
             aria-label="次のページへ"
-            className={`bg-secondary text-white border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
+            className={`bg-secondary text-secondary-foreground border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
               page >= totalPages
                 ? "opacity-50 cursor-not-allowed"
                 : "hover:bg-secondary/80 cursor-pointer"

--- a/admin/src/client/components/counterparts/CounterpartSelectorContent.tsx
+++ b/admin/src/client/components/counterparts/CounterpartSelectorContent.tsx
@@ -81,7 +81,7 @@ export function CounterpartSelectorContent({
       {selectedCounterpart && (
         <div className="bg-primary/10 border border-primary rounded-lg p-3">
           <p className="text-xs text-muted-foreground mb-1">選択中:</p>
-          <p className="text-white font-medium">{selectedCounterpart.name}</p>
+          <p className="text-foreground font-medium">{selectedCounterpart.name}</p>
           {selectedCounterpart.address && (
             <p className="text-muted-foreground text-xs">{selectedCounterpart.address}</p>
           )}
@@ -119,7 +119,7 @@ export function CounterpartSelectorContent({
                     {isSelected && <div className="w-2 h-2 rounded-full bg-primary" />}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <span className="text-white font-medium block">
+                    <span className="text-foreground font-medium block">
                       {suggestion.counterpart.name}
                     </span>
                     {suggestion.counterpart.address && (
@@ -159,7 +159,7 @@ export function CounterpartSelectorContent({
                     {isSelected && <div className="w-2 h-2 rounded-full bg-primary" />}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <span className="text-white font-medium block">{cp.name}</span>
+                    <span className="text-foreground font-medium block">{cp.name}</span>
                     {cp.address && (
                       <span className="text-muted-foreground text-xs truncate block">
                         {cp.address}

--- a/admin/src/client/components/counterparts/CounterpartTable.tsx
+++ b/admin/src/client/components/counterparts/CounterpartTable.tsx
@@ -45,13 +45,13 @@ export function CounterpartTable({ counterparts, onUpdate }: CounterpartTablePro
                 <td className="py-3 px-4">
                   <Link
                     href={`/counterparts/${counterpart.id}`}
-                    className="text-white hover:text-primary hover:underline transition-colors"
+                    className="text-foreground hover:text-primary hover:underline transition-colors"
                   >
                     {counterpart.name}
                   </Link>
                 </td>
-                <td className="py-3 px-4 text-white">{counterpart.address}</td>
-                <td className="py-3 px-4 text-white text-right">{counterpart.usageCount}件</td>
+                <td className="py-3 px-4 text-foreground">{counterpart.address}</td>
+                <td className="py-3 px-4 text-foreground text-right">{counterpart.usageCount}件</td>
                 <td className="py-3 px-4 text-right">
                   <div className="flex gap-2 justify-end">
                     <Button

--- a/admin/src/client/components/csv-import/CsvPreview.tsx
+++ b/admin/src/client/components/csv-import/CsvPreview.tsx
@@ -121,7 +121,7 @@ export default function CsvPreview({
   if (loading) {
     return (
       <div className="bg-card rounded-xl p-4 mt-4">
-        <h3 className="text-lg font-medium text-white mb-2">CSVプレビュー</h3>
+        <h3 className="text-lg font-medium text-foreground mb-2">CSVプレビュー</h3>
         <p className="text-muted-foreground">ファイルを処理中...</p>
       </div>
     );
@@ -130,7 +130,7 @@ export default function CsvPreview({
   if (error) {
     return (
       <div className="bg-card rounded-xl p-4 mt-4">
-        <h3 className="text-lg font-medium text-white mb-2">CSVプレビュー</h3>
+        <h3 className="text-lg font-medium text-foreground mb-2">CSVプレビュー</h3>
         <div className="text-red-500 mt-2">エラー: {error}</div>
       </div>
     );
@@ -161,7 +161,7 @@ export default function CsvPreview({
 
   return (
     <div className="bg-card rounded-xl p-4 mt-4">
-      <h3 className="text-lg font-medium text-white mb-4">CSVプレビュー</h3>
+      <h3 className="text-lg font-medium text-foreground mb-4">CSVプレビュー</h3>
 
       <StatisticsTable statistics={previewResult.statistics} />
 
@@ -169,9 +169,9 @@ export default function CsvPreview({
       <div className="mb-4">
         <div className="flex gap-2">
           {[
-            { key: "all" as const, label: "全件", color: "text-white" },
+            { key: "all" as const, label: "全件", color: "text-foreground" },
             { key: "insert" as const, label: "挿入", color: "text-green-500" },
-            { key: "update" as const, label: "更新", color: "text-blue-500" },
+            { key: "update" as const, label: "更新", color: "text-primary-active" },
             { key: "invalid" as const, label: "無効", color: "text-red-500" },
             {
               key: "skip" as const,
@@ -205,15 +205,25 @@ export default function CsvPreview({
         <table className="w-full border-collapse">
           <thead>
             <tr className="border-b border-border">
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">状態</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引日</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">借方勘定科目</th>
-              <th className="px-2 py-3 text-right text-sm font-semibold text-white">借方金額</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">貸方勘定科目</th>
-              <th className="px-2 py-3 text-right text-sm font-semibold text-white">貸方金額</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">種別</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">カテゴリ</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">状態</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">取引日</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                借方勘定科目
+              </th>
+              <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
+                借方金額
+              </th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                貸方勘定科目
+              </th>
+              <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
+                貸方金額
+              </th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">種別</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                カテゴリ
+              </th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
                 摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
               </th>
             </tr>

--- a/admin/src/client/components/csv-import/StatisticsTable.tsx
+++ b/admin/src/client/components/csv-import/StatisticsTable.tsx
@@ -22,24 +22,24 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
 
   return (
     <div className="mb-4">
-      <h4 className="text-md font-medium text-white mb-3">取引種別別統計</h4>
+      <h4 className="text-md font-medium text-foreground mb-3">取引種別別統計</h4>
       <div>
         <table className="border-collapse border border-border rounded-lg overflow-hidden">
           <thead>
             <tr className="bg-input">
-              <th className="border border-border px-4 py-2 text-left text-xs font-semibold text-white">
+              <th className="border border-border px-4 py-2 text-left text-xs font-semibold text-foreground">
                 状態
               </th>
-              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-white">
+              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-foreground">
                 収入
               </th>
-              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-white">
+              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-foreground">
                 支出
               </th>
-              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-white">
+              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-foreground">
                 収入（相殺）
               </th>
-              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-white">
+              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-foreground">
                 支出（相殺）
               </th>
             </tr>
@@ -49,19 +49,19 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
               <td className="border border-border px-4 py-2 text-xs text-green-500 font-medium">
                 挿入
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(statistics.insert.income.count, statistics.insert.income.amount)}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(statistics.insert.expense.count, statistics.insert.expense.amount)}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(
                   statistics.insert.offset_income.count,
                   statistics.insert.offset_income.amount,
                 )}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(
                   statistics.insert.offset_expense.count,
                   statistics.insert.offset_expense.amount,
@@ -69,22 +69,22 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
               </td>
             </tr>
             <tr>
-              <td className="border border-border px-4 py-2 text-xs text-blue-500 font-medium">
+              <td className="border border-border px-4 py-2 text-xs text-primary-active font-medium">
                 更新
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(statistics.update.income.count, statistics.update.income.amount)}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(statistics.update.expense.count, statistics.update.expense.amount)}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(
                   statistics.update.offset_income.count,
                   statistics.update.offset_income.amount,
                 )}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(
                   statistics.update.offset_expense.count,
                   statistics.update.offset_expense.amount,
@@ -95,19 +95,19 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
               <td className="border border-border px-4 py-2 text-xs text-red-500 font-medium">
                 無効
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(statistics.invalid.income.count, statistics.invalid.income.amount)}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(statistics.invalid.expense.count, statistics.invalid.expense.amount)}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(
                   statistics.invalid.offset_income.count,
                   statistics.invalid.offset_income.amount,
                 )}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(
                   statistics.invalid.offset_expense.count,
                   statistics.invalid.offset_expense.amount,
@@ -118,19 +118,19 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
               <td className="border border-border px-4 py-2 text-xs text-yellow-500 font-medium">
                 スキップ
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(statistics.skip.income.count, statistics.skip.income.amount)}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(statistics.skip.expense.count, statistics.skip.expense.amount)}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(
                   statistics.skip.offset_income.count,
                   statistics.skip.offset_income.amount,
                 )}
               </td>
-              <td className="border border-border px-4 py-2 text-xs text-white text-center">
+              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
                 {formatCell(
                   statistics.skip.offset_expense.count,
                   statistics.skip.offset_expense.amount,

--- a/admin/src/client/components/csv-import/TransactionRow.tsx
+++ b/admin/src/client/components/csv-import/TransactionRow.tsx
@@ -112,7 +112,7 @@ function getTypeBadgeClass(type: string): string {
     case "offset_expense":
       return "bg-red-600";
     case "non_cash_journal":
-      return "bg-blue-600";
+      return "bg-gray-500";
     case "invalid":
       return "bg-orange-600";
     default:
@@ -125,7 +125,7 @@ function getStatusBgClass(status: PreviewTransaction["status"]) {
     case "insert":
       return "bg-green-600";
     case "update":
-      return "bg-blue-600";
+      return "bg-gray-500";
     case "invalid":
       return "bg-red-600";
     case "skip":
@@ -179,35 +179,35 @@ export default function TransactionRow({
           </div>
         )}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {new Date(record.transaction_date).toLocaleDateString("ja-JP")}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {record.debit_account}
         {record.debit_sub_account && (
           <div className="text-muted-foreground text-xs">{record.debit_sub_account}</div>
         )}
       </td>
-      <td className="px-2 py-3 text-sm text-right text-white">
+      <td className="px-2 py-3 text-sm text-right text-foreground">
         {record.debit_amount ? `¥${record.debit_amount.toLocaleString()}` : "-"}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {record.credit_account}
         {record.credit_sub_account && (
           <div className="text-muted-foreground text-xs">{record.credit_sub_account}</div>
         )}
       </td>
-      <td className="px-2 py-3 text-sm text-right text-white">
+      <td className="px-2 py-3 text-sm text-right text-foreground">
         {record.credit_amount ? `¥${record.credit_amount.toLocaleString()}` : "-"}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         <span
           className={`px-2 py-1 rounded text-white text-xs font-medium ${getTypeBadgeClass(record.transaction_type || "unknown")}`}
         >
           {getTypeLabel(record.transaction_type || "unknown")}
         </span>
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {(() => {
           const category = getTransactionCategory(record);
           return (
@@ -222,9 +222,11 @@ export default function TransactionRow({
           );
         })()}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {record.description || "-"}
-        {record.label && <div className="text-blue-400 text-xs mt-1">ラベル: {record.label}</div>}
+        {record.label && (
+          <div className="text-muted-foreground text-xs mt-1">ラベル: {record.label}</div>
+        )}
       </td>
     </tr>
   );

--- a/admin/src/client/components/donor-assignment/AssignWithDonorContent.tsx
+++ b/admin/src/client/components/donor-assignment/AssignWithDonorContent.tsx
@@ -97,7 +97,7 @@ export function AssignWithDonorContent({
   return (
     <div className="flex flex-col lg:flex-row gap-6 flex-1 min-h-0 overflow-hidden">
       <div className="lg:w-1/3 flex-shrink-0 flex flex-col min-h-0">
-        <div className="text-white font-medium mb-3">
+        <div className="text-foreground font-medium mb-3">
           {isBulk ? `選択中の取引 (${transactions.length}件)` : "取引情報"}
         </div>
 
@@ -106,7 +106,7 @@ export function AssignWithDonorContent({
             <div key={t.id} className="px-3 py-2 text-sm border-b border-border last:border-b-0">
               <div className="flex items-center gap-2">
                 <span className="text-muted-foreground">{formatDate(t.transactionDate)}</span>
-                <span className="text-white">{formatAmount(t.debitAmount)}</span>
+                <span className="text-foreground">{formatAmount(t.debitAmount)}</span>
               </div>
               <div className="text-muted-foreground text-xs truncate">{t.description || "-"}</div>
             </div>
@@ -121,7 +121,7 @@ export function AssignWithDonorContent({
         {allowedDonorTypes.length > 0 && allowedDonorTypes.length < 3 && (
           <div className="mt-3 p-2 bg-secondary/30 rounded-lg text-xs text-muted-foreground">
             選択された取引のカテゴリでは、以下の寄付者種別のみ紐付け可能です:
-            <span className="text-white ml-1">
+            <span className="text-foreground ml-1">
               {allowedDonorTypes
                 .map((t) =>
                   t === "individual" ? "個人" : t === "corporation" ? "法人" : "政治団体",

--- a/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
@@ -197,7 +197,9 @@ export function DonorAssignmentClient({
   if (organizations.length === 0) {
     return (
       <Card className="p-4">
-        <p className="text-white">政治団体が登録されていません。先に政治団体を作成してください。</p>
+        <p className="text-foreground">
+          政治団体が登録されていません。先に政治団体を作成してください。
+        </p>
       </Card>
     );
   }
@@ -206,7 +208,7 @@ export function DonorAssignmentClient({
     <div className="bg-card rounded-xl p-4 space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-white mb-1">寄付者紐付け管理</h1>
+          <h1 className="text-2xl font-bold text-foreground mb-1">寄付者紐付け管理</h1>
           <p className="text-muted-foreground">Transactionに対してDonor（寄付者）を紐付けます</p>
         </div>
         <Button asChild variant="outline">
@@ -261,7 +263,7 @@ export function DonorAssignmentClient({
         </div>
 
         <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-          <span className="text-white text-sm">
+          <span className="text-foreground text-sm">
             選択中: <span className="font-medium">{selectedTransactions.length}件</span>
           </span>
           <Button

--- a/admin/src/client/components/donor-assignment/DonorAssignmentFilters.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentFilters.tsx
@@ -88,7 +88,7 @@ export function DonorAssignmentFilters({
             checked={values.unassignedOnly}
             onCheckedChange={(checked) => onChange({ unassignedOnly: checked === true })}
           />
-          <Label htmlFor="unassigned-only" className="text-white text-sm cursor-pointer">
+          <Label htmlFor="unassigned-only" className="text-foreground text-sm cursor-pointer">
             未紐付けのみ表示
           </Label>
         </div>

--- a/admin/src/client/components/donor-assignment/DonorSelectorContent.tsx
+++ b/admin/src/client/components/donor-assignment/DonorSelectorContent.tsx
@@ -73,7 +73,7 @@ export function DonorSelectorContent({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className="text-white font-medium">{donor.name}</span>
+            <span className="text-foreground font-medium">{donor.name}</span>
             <span className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">
               {DONOR_TYPE_LABELS[donor.donorType]}
             </span>
@@ -111,7 +111,7 @@ export function DonorSelectorContent({
         <div className="bg-primary/10 border border-primary rounded-lg p-3">
           <p className="text-xs text-muted-foreground mb-1">選択中:</p>
           <div className="flex items-center gap-2">
-            <p className="text-white font-medium">{selectedDonor.name}</p>
+            <p className="text-foreground font-medium">{selectedDonor.name}</p>
             <span className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">
               {DONOR_TYPE_LABELS[selectedDonor.donorType]}
             </span>

--- a/admin/src/client/components/donor-assignment/TransactionWithDonorTable.tsx
+++ b/admin/src/client/components/donor-assignment/TransactionWithDonorTable.tsx
@@ -85,7 +85,7 @@ export function TransactionWithDonorTable({
           <button
             type="button"
             onClick={() => onSortChange("transactionDate")}
-            className="flex items-center gap-1 hover:text-white transition-colors cursor-pointer"
+            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
           >
             日付
             {sortField === "transactionDate" && (
@@ -100,7 +100,7 @@ export function TransactionWithDonorTable({
           <button
             type="button"
             onClick={() => onSortChange("debitAmount")}
-            className="flex items-center gap-1 hover:text-white transition-colors cursor-pointer"
+            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
           >
             金額
             {sortField === "debitAmount" && (
@@ -115,7 +115,7 @@ export function TransactionWithDonorTable({
           <button
             type="button"
             onClick={() => onSortChange("categoryKey")}
-            className="flex items-center gap-1 hover:text-white transition-colors cursor-pointer"
+            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
           >
             カテゴリ
             {sortField === "categoryKey" && (
@@ -161,7 +161,7 @@ export function TransactionWithDonorTable({
               {donor ? (
                 <div className="flex flex-col">
                   <div className="flex items-center gap-2">
-                    <span className="text-white font-medium truncate">{donor.name}</span>
+                    <span className="text-foreground font-medium truncate">{donor.name}</span>
                     <span className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">
                       {DONOR_TYPE_LABELS[donor.donorType]}
                     </span>
@@ -171,7 +171,7 @@ export function TransactionWithDonorTable({
                   )}
                 </div>
               ) : (
-                <span className="text-yellow-400">未設定</span>
+                <span className="text-yellow-600">未設定</span>
               )}
             </button>
           );
@@ -234,7 +234,7 @@ export function TransactionWithDonorTable({
                 <td
                   key={cell.id}
                   className={cn(
-                    "py-2 px-4 text-white",
+                    "py-2 px-4 text-foreground",
                     cell.column.id !== "description" && "whitespace-nowrap",
                   )}
                 >

--- a/admin/src/client/components/donor-csv-import/DonorCsvPreview.tsx
+++ b/admin/src/client/components/donor-csv-import/DonorCsvPreview.tsx
@@ -2,7 +2,7 @@
 import "client-only";
 
 import { useState } from "react";
-import { Loader2 } from "lucide-react";
+import { CircleNotch } from "@phosphor-icons/react/dist/ssr";
 import type { PreviewDonorCsvResult } from "@/server/contexts/report/presentation/types/preview-donor-csv-types";
 import type {
   PreviewDonorCsvRow,
@@ -28,7 +28,7 @@ interface TabDefinition {
 }
 
 const TABS: TabDefinition[] = [
-  { key: "all", label: "全件", color: "text-white" },
+  { key: "all", label: "全件", color: "text-foreground" },
   {
     key: "valid_new",
     label: "新規寄付者",
@@ -134,7 +134,7 @@ export default function DonorCsvPreview({
                 variant="outline"
                 size="sm"
                 onClick={() => handleTabChange(key)}
-                className={isActive ? color : "text-white/60"}
+                className={isActive ? color : "text-muted-foreground"}
               >
                 {label} ({getTabCount(key)})
               </Button>
@@ -165,17 +165,25 @@ export default function DonorCsvPreview({
         <table className="w-full border-collapse">
           <thead>
             <tr className="border-b border-border">
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">行番号</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">ステータス</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引No</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">寄付者名</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">寄付者種別</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">住所</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">職業</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引日</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">カテゴリ</th>
-              <th className="px-2 py-3 text-right text-sm font-semibold text-white">金額</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">備考</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">行番号</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                ステータス
+              </th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">取引No</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                寄付者名
+              </th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                寄付者種別
+              </th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">住所</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">職業</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">取引日</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                カテゴリ
+              </th>
+              <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">金額</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">備考</th>
             </tr>
           </thead>
           <tbody>
@@ -205,7 +213,7 @@ export default function DonorCsvPreview({
           <Button type="button" onClick={onImport} disabled={validCount === 0 || isImporting}>
             {isImporting ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <CircleNotch className="mr-2 h-4 w-4 animate-spin" />
                 インポート中...
               </>
             ) : (

--- a/admin/src/client/components/donor-csv-import/DonorCsvRow.tsx
+++ b/admin/src/client/components/donor-csv-import/DonorCsvRow.tsx
@@ -38,38 +38,38 @@ export default function DonorCsvRow({ row }: DonorCsvRowProps) {
           {statusStyle.label}
         </span>
       </td>
-      <td className="px-2 py-3 text-sm text-white">{row.transactionNo || "-"}</td>
-      <td className="px-2 py-3 text-sm text-white">{row.name || "-"}</td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">{row.transactionNo || "-"}</td>
+      <td className="px-2 py-3 text-sm text-foreground">{row.name || "-"}</td>
+      <td className="px-2 py-3 text-sm text-foreground">
         {row.donorType ? DONOR_TYPE_LABELS[row.donorType] : "-"}
       </td>
-      <td className="px-2 py-3 text-sm text-white">{row.address || "-"}</td>
-      <td className="px-2 py-3 text-sm text-white">{row.occupation || "-"}</td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">{row.address || "-"}</td>
+      <td className="px-2 py-3 text-sm text-foreground">{row.occupation || "-"}</td>
+      <td className="px-2 py-3 text-sm text-foreground">
         {formatDate(row.transaction?.transactionDate)}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {row.transaction?.friendlyCategory || row.transaction?.categoryKey || "-"}
       </td>
-      <td className="px-2 py-3 text-sm text-white text-right">
+      <td className="px-2 py-3 text-sm text-foreground text-right">
         {formatAmount(row.transaction?.creditAmount)}
       </td>
       <td className="px-2 py-3 text-sm">
         {row.errors.length > 0 && (
-          <ul className="text-red-400 text-xs list-disc list-inside">
+          <ul className="text-destructive text-xs list-disc list-inside">
             {row.errors.map((error) => (
               <li key={error}>{error}</li>
             ))}
           </ul>
         )}
         {row.transaction?.existingDonor && (
-          <div className="text-yellow-400 text-xs mt-1">
+          <div className="text-yellow-600 text-xs mt-1">
             既存: {row.transaction.existingDonor.name} (
             {DONOR_TYPE_LABELS[row.transaction.existingDonor.donorType]})
           </div>
         )}
         {row.matchingDonor && (
-          <div className="text-blue-400 text-xs mt-1">一致: {row.matchingDonor.name}</div>
+          <div className="text-muted-foreground text-xs mt-1">一致: {row.matchingDonor.name}</div>
         )}
       </td>
     </tr>

--- a/admin/src/client/components/donors/DonorFormContent.tsx
+++ b/admin/src/client/components/donors/DonorFormContent.tsx
@@ -104,7 +104,7 @@ export function DonorFormContent({
           value={donorType}
           onChange={(e) => handleDonorTypeChange(e.target.value as DonorType)}
           disabled={isDisabled}
-          className="w-full bg-input text-white border border-border rounded-lg px-3 py-2.5 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full bg-input text-foreground border border-border rounded-lg px-3 py-2.5 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {VALID_DONOR_TYPES.map((type) => (
             <option key={type} value={type}>

--- a/admin/src/client/components/donors/DonorMasterClient.tsx
+++ b/admin/src/client/components/donors/DonorMasterClient.tsx
@@ -107,7 +107,7 @@ export function DonorMasterClient({
   return (
     <div className="bg-card rounded-xl p-4">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-white">寄付者マスタ管理</h1>
+        <h1 className="text-2xl font-bold text-foreground">寄付者マスタ管理</h1>
         <Button type="button" onClick={() => setIsCreateDialogOpen(true)}>
           新規作成
         </Button>
@@ -170,7 +170,7 @@ export function DonorMasterClient({
           >
             前へ
           </Button>
-          <span className="text-white px-4">
+          <span className="text-foreground px-4">
             {page} / {totalPages}
           </span>
           <Button

--- a/admin/src/client/components/donors/DonorTable.tsx
+++ b/admin/src/client/components/donors/DonorTable.tsx
@@ -44,17 +44,17 @@ export function DonorTable({ donors, onUpdate }: DonorTableProps) {
                 key={donor.id}
                 className="border-b border-border hover:bg-secondary/30 transition-colors"
               >
-                <td className="py-3 px-4 text-white">
+                <td className="py-3 px-4 text-foreground">
                   <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-secondary">
                     {DONOR_TYPE_LABELS[donor.donorType]}
                   </span>
                 </td>
-                <td className="py-3 px-4 text-white">{donor.name}</td>
-                <td className="py-3 px-4 text-white">{donor.address ?? "-"}</td>
-                <td className="py-3 px-4 text-white">
+                <td className="py-3 px-4 text-foreground">{donor.name}</td>
+                <td className="py-3 px-4 text-foreground">{donor.address ?? "-"}</td>
+                <td className="py-3 px-4 text-foreground">
                   {donor.donorType === "individual" ? (donor.occupation ?? "-") : "-"}
                 </td>
-                <td className="py-3 px-4 text-white text-right">{donor.usageCount}件</td>
+                <td className="py-3 px-4 text-foreground text-right">{donor.usageCount}件</td>
                 <td className="py-3 px-4 text-right">
                   <div className="flex gap-2 justify-end">
                     <Button

--- a/admin/src/client/components/export-report/ReportDataPreview.tsx
+++ b/admin/src/client/components/export-report/ReportDataPreview.tsx
@@ -18,7 +18,7 @@ export function ReportDataPreview({ reportData, summaryData }: ReportDataPreview
   return (
     <div className="space-y-8">
       <div>
-        <h2 className="text-lg font-medium text-white mb-1">表形式プレビュー</h2>
+        <h2 className="text-lg font-medium text-foreground mb-1">表形式プレビュー</h2>
         <p className="text-sm text-muted-foreground">報告書データを表形式で確認できます。</p>
       </div>
 

--- a/admin/src/client/components/export-report/XmlPreview.tsx
+++ b/admin/src/client/components/export-report/XmlPreview.tsx
@@ -23,7 +23,7 @@ export function XmlPreview({ xml }: XmlPreviewProps) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-medium text-white">XMLプレビュー</h2>
+        <h2 className="text-lg font-medium text-foreground">XMLプレビュー</h2>
         <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
           {copied ? "コピーしました" : "コピー"}
         </Button>

--- a/admin/src/client/components/export-report/sections/DonationSection.tsx
+++ b/admin/src/client/components/export-report/sections/DonationSection.tsx
@@ -75,7 +75,7 @@ export function DonationSection({ personalDonations }: DonationSectionProps) {
 
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-white">寄附 (SYUUSHI07_07)</h2>
+      <h2 className="text-xl font-bold text-foreground">寄附 (SYUUSHI07_07)</h2>
 
       <SectionWrapper
         title="個人からの寄附"

--- a/admin/src/client/components/export-report/sections/IncomeSection.tsx
+++ b/admin/src/client/components/export-report/sections/IncomeSection.tsx
@@ -199,7 +199,7 @@ export function IncomeSection({
 
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-white">収入の部</h2>
+      <h2 className="text-xl font-bold text-foreground">収入の部</h2>
 
       <SectionWrapper
         title="事業による収入"

--- a/admin/src/client/components/export-report/sections/PoliticalActivityExpenseSection.tsx
+++ b/admin/src/client/components/export-report/sections/PoliticalActivityExpenseSection.tsx
@@ -116,7 +116,9 @@ function ExpenseArraySubSection({ title, formId, sections }: ExpenseArraySubSect
             {sections.map((section, index) => (
               <div key={section.himoku || index}>
                 {section.himoku && (
-                  <h4 className="text-sm font-medium text-gray-300 mb-2">費目: {section.himoku}</h4>
+                  <h4 className="text-sm font-medium text-muted-foreground mb-2">
+                    費目: {section.himoku}
+                  </h4>
                 )}
                 <PoliticalActivityExpenseTable rows={section.rows} />
               </div>
@@ -145,7 +147,7 @@ export function PoliticalActivityExpenseSection({
 }: PoliticalActivityExpenseSectionProps) {
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-white">政治活動費 (SYUUSHI07_15)</h2>
+      <h2 className="text-xl font-bold text-foreground">政治活動費 (SYUUSHI07_15)</h2>
 
       <ExpenseArraySubSection title="組織活動費" formId="KUBUN1" sections={organizationExpenses} />
 

--- a/admin/src/client/components/export-report/sections/ProfileSection.tsx
+++ b/admin/src/client/components/export-report/sections/ProfileSection.tsx
@@ -77,7 +77,7 @@ export function ProfileSection({ profile }: ProfileSectionProps) {
 
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-white">団体基本情報</h2>
+      <h2 className="text-xl font-bold text-foreground">団体基本情報</h2>
 
       <div className="bg-white border border-black overflow-hidden">
         <div className="bg-gray-100 border-b border-black px-4 py-3">

--- a/admin/src/client/components/export-report/sections/RegularExpenseSection.tsx
+++ b/admin/src/client/components/export-report/sections/RegularExpenseSection.tsx
@@ -83,7 +83,7 @@ export function RegularExpenseSection({
 
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-white">経常経費 (SYUUSHI07_14)</h2>
+      <h2 className="text-xl font-bold text-foreground">経常経費 (SYUUSHI07_14)</h2>
 
       <SectionWrapper
         title="光熱水費"

--- a/admin/src/client/components/export-report/sections/SummarySection.tsx
+++ b/admin/src/client/components/export-report/sections/SummarySection.tsx
@@ -51,7 +51,7 @@ function SectionHeader({ title }: SectionHeaderProps) {
 export function SummarySection({ summaryData }: SummarySectionProps) {
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold text-white">収支総括表</h2>
+      <h2 className="text-xl font-bold text-foreground">収支総括表</h2>
 
       <div className="bg-white border border-black overflow-hidden">
         <div className="bg-gray-100 border-b border-black px-4 py-3">

--- a/admin/src/client/components/report-profile/DietMemberRelationSection.tsx
+++ b/admin/src/client/components/report-profile/DietMemberRelationSection.tsx
@@ -142,7 +142,7 @@ export function DietMemberRelationSection({
                   type: e.target.value as "0" | "1" | "2" | "3",
                 })
               }
-              className="flex h-9 w-full rounded-md border border-input bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-md"
+              className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-md"
             >
               <option value="1">1号団体</option>
               <option value="2">2号団体</option>
@@ -204,7 +204,7 @@ export function DietMemberRelationSection({
                             chamber: e.target.value as "1" | "2",
                           })
                         }
-                        className="flex h-9 w-full rounded-md border border-input bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                        className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                       >
                         <option value="1">衆議院議員</option>
                         <option value="2">参議院議員</option>
@@ -219,7 +219,7 @@ export function DietMemberRelationSection({
                             positionType: e.target.value as "1" | "2" | "3" | "4",
                           })
                         }
-                        className="flex h-9 w-full rounded-md border border-input bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                        className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                       >
                         <option value="1">現職</option>
                         <option value="2">候補者</option>

--- a/admin/src/client/components/report-profile/FundManagementSection.tsx
+++ b/admin/src/client/components/report-profile/FundManagementSection.tsx
@@ -120,7 +120,7 @@ export function FundManagementSection({ details, updateDetails }: FundManagement
                   publicPositionType: e.target.value as "1" | "2" | "3" | "4" | undefined,
                 })
               }
-              className="flex h-9 w-full rounded-md border border-input bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-md"
+              className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-md"
             >
               <option value="">選択してください</option>
               <option value="1">現職</option>

--- a/admin/src/client/components/report-profile/OrganizationTypeSection.tsx
+++ b/admin/src/client/components/report-profile/OrganizationTypeSection.tsx
@@ -38,7 +38,7 @@ export function OrganizationTypeSection({ details, updateDetails }: Organization
                 activityArea: e.target.value as "1" | "2" | undefined,
               })
             }
-            className="flex h-9 w-full rounded-md border border-input bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+            className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
           >
             <option value="">選択してください</option>
             <option value="1">二以上の都道府県の区域</option>

--- a/admin/src/client/components/report-profile/YearSelector.tsx
+++ b/admin/src/client/components/report-profile/YearSelector.tsx
@@ -18,7 +18,7 @@ export function YearSelector({ orgId, financialYear, currentYear }: YearSelector
       <Label>報告年</Label>
       <select
         key={financialYear}
-        className="flex h-9 w-32 rounded-md border border-input bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+        className="flex h-9 w-32 rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
         defaultValue={financialYear}
         onChange={(e) => {
           router.push(`/political-organizations/${orgId}/report-profile?year=${e.target.value}`);

--- a/admin/src/client/components/transactions/DeleteTransactionButton.tsx
+++ b/admin/src/client/components/transactions/DeleteTransactionButton.tsx
@@ -2,7 +2,7 @@
 import "client-only";
 
 import { useState } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash } from "@phosphor-icons/react/dist/ssr";
 import { toast } from "sonner";
 import { deleteTransactionAction } from "@/server/contexts/data-import/presentation/actions/delete-transaction";
 import {
@@ -60,7 +60,7 @@ export function DeleteTransactionButton({ transaction, onDeleted }: DeleteTransa
         className="h-8 w-8 text-muted-foreground hover:text-destructive"
         onClick={() => setOpen(true)}
       >
-        <Trash2 className="h-4 w-4" />
+        <Trash className="h-4 w-4" />
       </Button>
       <DialogContent className="max-w-md">
         <DialogHeader>

--- a/admin/src/client/components/transactions/TransactionRow.tsx
+++ b/admin/src/client/components/transactions/TransactionRow.tsx
@@ -111,7 +111,7 @@ function getTypeBadgeClass(type: string): string {
     case "offset_expense":
       return "bg-red-600";
     case "non_cash_journal":
-      return "bg-blue-600";
+      return "bg-gray-500";
     case "invalid":
       return "bg-orange-600";
     default:
@@ -126,37 +126,39 @@ export function TransactionRow({ transaction, onDeleted }: TransactionRowProps) 
 
   return (
     <tr className="border-b border-border">
-      <td className="px-2 py-3 text-sm text-white font-mono">{transaction.transaction_no}</td>
-      <td className="px-2 py-3 text-sm text-white">{formatDate(transaction.transaction_date)}</td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground font-mono">{transaction.transaction_no}</td>
+      <td className="px-2 py-3 text-sm text-foreground">
+        {formatDate(transaction.transaction_date)}
+      </td>
+      <td className="px-2 py-3 text-sm text-foreground">
         {transaction.political_organization_name || "-"}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {transaction.debit_account}
         {transaction.debit_sub_account && (
           <div className="text-muted-foreground text-xs">{transaction.debit_sub_account}</div>
         )}
       </td>
-      <td className="px-2 py-3 text-sm text-right text-white">
+      <td className="px-2 py-3 text-sm text-right text-foreground">
         ¥{transaction.debit_amount.toLocaleString()}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {transaction.credit_account}
         {transaction.credit_sub_account && (
           <div className="text-muted-foreground text-xs">{transaction.credit_sub_account}</div>
         )}
       </td>
-      <td className="px-2 py-3 text-sm text-right text-white">
+      <td className="px-2 py-3 text-sm text-right text-foreground">
         ¥{transaction.credit_amount.toLocaleString()}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         <div
           className={`inline-block px-2 py-1 rounded text-white text-xs font-medium ${getTypeBadgeClass(transaction.transaction_type)}`}
         >
           {getTypeLabel(transaction.transaction_type)}
         </div>
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {(() => {
           const category = getTransactionCategory(transaction);
           return (
@@ -164,7 +166,7 @@ export function TransactionRow({ transaction, onDeleted }: TransactionRowProps) 
               className={`inline-block px-2 py-1 rounded text-xs font-medium max-w-fit ${
                 category.type === "income" || category.type === "offset_income"
                   ? "text-black"
-                  : "text-white"
+                  : "text-foreground"
               }`}
               style={{ backgroundColor: category.color }}
             >
@@ -173,10 +175,10 @@ export function TransactionRow({ transaction, onDeleted }: TransactionRowProps) 
           );
         })()}
       </td>
-      <td className="px-2 py-3 text-sm text-white">
+      <td className="px-2 py-3 text-sm text-foreground">
         {transaction.description || "-"}
         {transaction.label && (
-          <div className="text-blue-400 text-xs mt-1">ラベル: {transaction.label}</div>
+          <div className="text-muted-foreground text-xs mt-1">ラベル: {transaction.label}</div>
         )}
       </td>
       <td className="px-2 py-3 text-sm text-center">

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -88,7 +88,7 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
   return (
     <div className="bg-card rounded-xl p-4">
       <div className="mb-4">
-        <h1 className="text-2xl font-bold text-white mb-4">取引一覧</h1>
+        <h1 className="text-2xl font-bold text-foreground mb-4">取引一覧</h1>
 
         {/* Organization Filter */}
         <div className="mb-4">
@@ -123,7 +123,7 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
       {fetching && (
         <div className="text-center py-2 mb-4">
           <div className="flex items-center justify-center gap-2">
-            <div className="w-4 h-4 border-2 border-muted border-t-transparent rounded-full animate-spin"></div>
+            <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
             <p className="text-muted-foreground text-sm">取得中...</p>
           </div>
         </div>
@@ -151,27 +151,37 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
             <table className="w-full border-collapse">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引No</th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引日</th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">政治団体</th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                    取引No
+                  </th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                    取引日
+                  </th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                    政治団体
+                  </th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
                     借方勘定科目
                   </th>
-                  <th className="px-2 py-3 text-right text-sm font-semibold text-white">
+                  <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
                     借方金額
                   </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
                     貸方勘定科目
                   </th>
-                  <th className="px-2 py-3 text-right text-sm font-semibold text-white">
+                  <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
                     貸方金額
                   </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">種別</th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">カテゴリ</th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                    種別
+                  </th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                    カテゴリ
+                  </th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
                     摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
                   </th>
-                  <th className="px-2 py-3 text-center text-sm font-semibold text-white w-16">
+                  <th className="px-2 py-3 text-center text-sm font-semibold text-foreground w-16">
                     操作
                   </th>
                 </tr>

--- a/admin/src/client/components/ui/StaticPagination.tsx
+++ b/admin/src/client/components/ui/StaticPagination.tsx
@@ -27,8 +27,8 @@ export function StaticPagination({ currentPage, totalPages, basePath }: StaticPa
           href={generatePageUrl(page)}
           className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${
             page === currentPage
-              ? "bg-primary text-white"
-              : "text-muted-foreground hover:bg-secondary hover:text-white"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground"
           }`}
         >
           {page}
@@ -83,7 +83,7 @@ export function StaticPagination({ currentPage, totalPages, basePath }: StaticPa
       {currentPage > 1 && (
         <Link
           href={generatePageUrl(currentPage - 1)}
-          className="px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-secondary hover:text-white rounded-md transition-colors"
+          className="px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground rounded-md transition-colors"
         >
           ← 前
         </Link>
@@ -94,7 +94,7 @@ export function StaticPagination({ currentPage, totalPages, basePath }: StaticPa
       {currentPage < totalPages && (
         <Link
           href={generatePageUrl(currentPage + 1)}
-          className="px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-secondary hover:text-white rounded-md transition-colors"
+          className="px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground rounded-md transition-colors"
         >
           次 →
         </Link>

--- a/admin/src/client/components/ui/button.tsx
+++ b/admin/src/client/components/ui/button.tsx
@@ -5,23 +5,23 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/client/lib/index";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-bold transition-colors duration-150 ease-out cursor-pointer disabled:cursor-not-allowed disabled:border-disabled-border disabled:text-disabled-foreground disabled:bg-card [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground border-[1.5px] border-primary hover:bg-primary-hover hover:border-primary-hover disabled:border-disabled-border",
         destructive:
-          "bg-destructive/60 text-white hover:bg-destructive/90 focus-visible:ring-destructive/40",
-        outline:
-          "border border-input bg-input/30 shadow-xs hover:bg-input/50 hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent/50 hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-card text-destructive border-[1.5px] border-destructive hover:bg-destructive-hover focus-visible:ring-destructive/40",
+        outline: "bg-card text-foreground border-[1.5px] border-border hover:bg-secondary",
+        secondary: "bg-card text-foreground border-[1.5px] border-border hover:bg-secondary",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary-active underline-offset-4 hover:underline hover:text-primary-hover",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 px-6 has-[>svg]:px-4",
         icon: "size-9",
         "icon-sm": "size-8",
         "icon-lg": "size-10",

--- a/admin/src/client/components/ui/card.tsx
+++ b/admin/src/client/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-lg border border-border py-6",
         className,
       )}
       {...props}

--- a/admin/src/client/components/ui/checkbox.tsx
+++ b/admin/src/client/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import type * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { CheckIcon } from "lucide-react";
+import { Check } from "@phosphor-icons/react/dist/ssr";
 
 import { cn } from "@/client/lib/index";
 
@@ -11,7 +11,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-border bg-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring-soft aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border transition-colors duration-150 ease-out outline-none focus-visible:ring-[2px] disabled:cursor-not-allowed disabled:border-disabled-border",
         className,
       )}
       {...props}
@@ -20,7 +20,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none"
       >
-        <CheckIcon className="size-3.5" />
+        <Check className="size-3.5" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/admin/src/client/components/ui/dialog.tsx
+++ b/admin/src/client/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import type * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { XIcon } from "lucide-react";
+import { X } from "@phosphor-icons/react/dist/ssr";
 
 import { cn } from "@/client/lib/index";
 
@@ -52,7 +52,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none",
+          "bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border p-6 duration-200 outline-none",
           className,
         )}
         {...props}
@@ -61,9 +61,9 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground text-muted-foreground hover:text-foreground absolute top-4 right-4 rounded-xs transition-colors duration-150 ease-out focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
-            <XIcon />
+            <X />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}

--- a/admin/src/client/components/ui/input.tsx
+++ b/admin/src/client/components/ui/input.tsx
@@ -8,8 +8,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground bg-input/30 border-input h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "file:text-foreground placeholder:text-disabled-foreground selection:bg-primary selection:text-primary-foreground bg-input border-border h-9 w-full min-w-0 rounded-full border px-4 py-1 text-base transition-[color,border-color,box-shadow] duration-150 ease-out outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:cursor-not-allowed disabled:border-disabled-border disabled:text-disabled-foreground md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring-soft focus-visible:ring-[2px]",
         "aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,
       )}

--- a/admin/src/client/components/ui/select.tsx
+++ b/admin/src/client/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import type * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { CaretDown, CaretUp, Check } from "@phosphor-icons/react/dist/ssr";
 
 import { cn } from "@/client/lib/index";
 
@@ -31,14 +31,14 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-input/30 hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-border data-[placeholder]:text-disabled-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring-soft aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-input hover:bg-secondary flex w-fit items-center justify-between gap-2 rounded-full border px-4 py-2 text-sm whitespace-nowrap transition-[color,border-color,box-shadow] duration-150 ease-out outline-none focus-visible:ring-[2px] disabled:cursor-not-allowed disabled:border-disabled-border disabled:text-disabled-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
+        <CaretDown className="size-4" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -56,7 +56,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-border",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,
@@ -100,7 +100,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:text-disabled-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}
@@ -110,7 +110,7 @@ function SelectItem({
         className="absolute right-2 flex size-3.5 items-center justify-center"
       >
         <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <Check className="size-4" />
         </SelectPrimitive.ItemIndicator>
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
@@ -125,7 +125,7 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      className={cn("bg-border-soft pointer-events-none -mx-1 my-1 h-px", className)}
       {...props}
     />
   );
@@ -141,7 +141,7 @@ function SelectScrollUpButton({
       className={cn("flex cursor-default items-center justify-center py-1", className)}
       {...props}
     >
-      <ChevronUpIcon className="size-4" />
+      <CaretUp className="size-4" />
     </SelectPrimitive.ScrollUpButton>
   );
 }
@@ -156,7 +156,7 @@ function SelectScrollDownButton({
       className={cn("flex cursor-default items-center justify-center py-1", className)}
       {...props}
     >
-      <ChevronDownIcon className="size-4" />
+      <CaretDown className="size-4" />
     </SelectPrimitive.ScrollDownButton>
   );
 }

--- a/admin/src/client/components/ui/sonner.tsx
+++ b/admin/src/client/components/ui/sonner.tsx
@@ -5,7 +5,7 @@ import { Toaster as Sonner, type ToasterProps } from "sonner";
 function Toaster({ ...props }: ToasterProps) {
   return (
     <Sonner
-      theme="dark"
+      theme="light"
       className="toaster group"
       style={
         {

--- a/admin/src/client/components/ui/switch.tsx
+++ b/admin/src/client/components/ui/switch.tsx
@@ -10,7 +10,7 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input/80 focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-disabled-border focus-visible:border-ring focus-visible:ring-ring-soft inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent transition-colors duration-150 ease-out outline-none focus-visible:ring-[2px] disabled:cursor-not-allowed disabled:bg-muted",
         className,
       )}
       {...props}
@@ -18,7 +18,7 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-foreground data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+          "bg-card data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
         )}
       />
     </SwitchPrimitive.Root>

--- a/admin/src/client/components/ui/table.tsx
+++ b/admin/src/client/components/ui/table.tsx
@@ -15,7 +15,13 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
 }
 
 function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return <thead data-slot="table-header" className={cn("[&_tr]:border-b", className)} {...props} />;
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b-[1.5px] [&_tr]:border-border", className)}
+      {...props}
+    />
+  );
 }
 
 function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
@@ -43,7 +49,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        "hover:bg-secondary data-[state=selected]:bg-accent border-b border-border-soft transition-colors duration-150 ease-out",
         className,
       )}
       {...props}
@@ -56,7 +62,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-10 px-3 text-left align-middle text-xs font-bold whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -69,7 +75,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-3 py-2.5 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}

--- a/admin/src/client/components/ui/tabs.tsx
+++ b/admin/src/client/components/ui/tabs.tsx
@@ -20,7 +20,7 @@ function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimi
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-full p-[3px]",
         className,
       )}
       {...props}
@@ -33,7 +33,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-input/30 data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring data-[state=active]:border-input text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer",
+        "data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:font-bold focus-visible:border-ring focus-visible:ring-ring focus-visible:outline-ring data-[state=active]:border-border text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-full border border-transparent px-3 py-1 text-sm font-medium whitespace-nowrap transition-colors duration-150 ease-out focus-visible:ring-2 focus-visible:outline-1 disabled:cursor-not-allowed disabled:text-disabled-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer",
         className,
       )}
       {...props}

--- a/admin/src/client/components/ui/textarea.tsx
+++ b/admin/src/client/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-border placeholder:text-disabled-foreground focus-visible:border-ring focus-visible:ring-ring-soft aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-input flex field-sizing-content min-h-16 w-full rounded-3xl border px-4 py-2 text-base transition-[color,border-color,box-shadow] duration-150 ease-out outline-none focus-visible:ring-[2px] disabled:cursor-not-allowed disabled:border-disabled-border disabled:text-disabled-foreground md:text-sm",
         className,
       )}
       {...props}

--- a/admin/src/client/components/user-management/UserManagement.tsx
+++ b/admin/src/client/components/user-management/UserManagement.tsx
@@ -100,7 +100,7 @@ export default function UserManagement({
     <div className="space-y-4">
       {/* Invite User Form */}
       <Card className="p-4">
-        <h2 className="text-lg font-medium text-white mb-4">新規ユーザー招待</h2>
+        <h2 className="text-lg font-medium text-foreground mb-4">新規ユーザー招待</h2>
         <form onSubmit={handleInviteUser} className="flex gap-4">
           <div className="flex-1">
             <Input
@@ -139,8 +139,10 @@ export default function UserManagement({
           <tbody className="bg-card divide-y divide-border">
             {users.map((user) => (
               <tr key={user.id}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-white">{user.email}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-white">
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
+                  {user.email}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
                   <span
                     className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
                       user.role === "admin"
@@ -159,7 +161,7 @@ export default function UserManagement({
                     value={user.role}
                     onChange={(e) => handleRoleChange(user.id, e.target.value as UserRole)}
                     disabled={isLoading}
-                    className="bg-input text-white border border-border rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    className="bg-input text-foreground border border-border rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
                   >
                     {availableRoles.map((role) => (
                       <option key={role} value={role}>

--- a/docs/admin-ui-guidelines.md
+++ b/docs/admin-ui-guidelines.md
@@ -1,11 +1,13 @@
 # admin UI コンポーネントガイドライン
 
-admin アプリケーションで shadcn UI を使用する際のルールを定めます。
+admin アプリケーションで UI コンポーネントを使用する際のルールを定めます。
 
 ## 原則
 
 - **admin はライトモードのみ**（ダークモードは提供しない）
-- **shadcn UI コンポーネントを使用する**（カスタム実装は非推奨）
+- **Team Mirai ブランド（白ベース + Mirai Teal + 黒1pxボーダー + ピル形状）に従う**
+  （正は [デザインハンドオフ](reference/design_handoff_admin_redesign/README.md)）
+- **shadcn UI ベースの `ui/*` コンポーネントを使用する**（カスタム実装は非推奨）
 - **import は index.ts 経由**で行う
 - **CSS 変数と cn() を使う**（直書きスタイル禁止）
 
@@ -13,23 +15,76 @@ admin アプリケーションで shadcn UI を使用する際のルールを定
 import { Button, Input, Label } from "@/client/components/ui";
 ```
 
+## デザイン言語
+
+- ブランド色は **Mirai Teal `#30BCA7` のみ**。青・紫・オレンジは使わない
+- ページ背景 `#F8F8F8`（`bg-background`）、カードは白（`bg-card`）+ 黒1px枠 + 角丸8px
+- **ピル（`rounded-full`）が署名形状**: ボタン・input・select はすべてピル
+- 罫線は黒1px（強調は1.5px）。テーブルの行罫線など弱い線は `border-border-soft`（`#E5E5E5`）
+- 数字・日付・英字は Poppins（`font-latin`）、日本語は Hiragino Kaku Gothic → Noto Sans（`font-sans`、body 既定）
+- 日付表記は `YYYY.MM.DD`（ピリオド区切り）
+- hover は 120〜200ms ease-out の**色変化のみ**（スケール・バウンス禁止）
+- 影はほぼ使わない
+
+### ボタン（3系統）
+
+`Button` の variant で表現する。すべてピル形状。
+
+| variant | 見た目 | 用途 |
+|---|---|---|
+| `default` | teal 塗り + 白文字（hover `#089781`） | プライマリアクション |
+| `secondary` / `outline` | 白地 + 黒1.5px枠（hover `#F8F8F8`） | セカンダリアクション |
+| `destructive` | 白地 + 赤枠 + 赤文字（hover `#FDF0F1`） | 削除などの破壊的操作 |
+
+- disabled は枠 `#CCC`・文字 `#B1B1B1`・`cursor: not-allowed`（**opacity で薄くしない**）
+
+### フォーム・フォーカスリング
+
+- input / select はピル形状・黒枠・白地。placeholder は `#B1B1B1`（`text-disabled-foreground`）
+- focus 時は枠が teal + `0 0 0 2px #E2F6F3` のリング（`focus-visible:border-ring focus-visible:ring-[2px] focus-visible:ring-ring-soft`）
+- ボタンの focus-visible は `ring-2 ring-ring ring-offset-2`
+
+### アイコン
+
+- **Phosphor Icons（regular weight）** を使用する。`lucide-react` は使用しない
+- import は `@phosphor-icons/react/dist/ssr` から行う（サーバー/クライアント両対応）
+
+```typescript
+import { Trash, MagnifyingGlass } from "@phosphor-icons/react/dist/ssr";
+```
+
+- 絵文字・グラデーションは使わない
+
+### ローディング
+
+- スピナーは teal（`border-primary border-t-transparent` または `CircleNotch` + `animate-spin`）
+
 ## リファレンス
 
 ### カラー変数
 
-shadcn UI 標準の CSS 変数を使用する。
+`admin/src/app/globals.css` の `@theme` で定義された変数を使用する。
 
 ```css
-bg-background         /* 背景色 */
-bg-card               /* カード背景 */
-text-foreground       /* テキスト色 */
-text-muted-foreground /* 補助テキスト */
-border-border         /* ボーダー */
-bg-input              /* 入力フィールド背景 */
-bg-primary            /* プライマリ色 */
-bg-secondary          /* セカンダリ色（ホバー等） */
-bg-destructive        /* 危険色（赤） */
-ring-ring             /* フォーカスリング */
+bg-background              /* ページ背景 #F8F8F8 */
+bg-card                    /* カード背景 #FFF */
+text-foreground            /* テキスト色 #000 */
+text-muted-foreground      /* 補助テキスト #666 */
+text-disabled-foreground   /* placeholder・無効文字 #B1B1B1 */
+border-border              /* 標準ボーダー #000 */
+border-border-soft         /* 弱い罫線 #E5E5E5 */
+border-disabled-border     /* 無効枠 #CCC */
+bg-input                   /* 入力フィールド背景 #FFF */
+bg-primary                 /* Mirai Teal #30BCA7 */
+bg-primary-hover           /* teal hover #089781 */
+text-primary-active        /* teal deep（リンク・アクティブ） #0F8472 */
+bg-accent                  /* teal-100 #E2F6F3（アクティブ nav・バッジ背景） */
+text-accent-foreground     /* teal deep #0F8472 */
+bg-destructive             /* 危険色 #E63946 */
+bg-destructive-hover       /* 赤枠ボタンの hover #FDF0F1 */
+ring-ring                  /* フォーカスリング teal */
+ring-ring-soft             /* 入力フォーカスリング #E2F6F3 */
+text-teal-soft             /* 見出し下線 #64D8C6 */
 ```
 
 ### クラス名の合成
@@ -71,10 +126,11 @@ admin は **ライトモードのみ** で提供する。ダークモードは�
 `dark:` バリアントや `prefers-color-scheme` による切り替えは実装しない。
 
 - shadcn コンポーネント追加時、公式定義に含まれる `dark:` プレフィックス付きクラスは削除する
+- あわせて既存の `ui/*` に倣い、ピル形状・黒枠・teal フォーカスリング・disabled ルール（opacity 不使用）へ調整する
+- アイコンが含まれる場合は lucide-react を Phosphor Icons に置き換える
 - 色・形状（デザイントークン、コンポーネントの見た目）の正は
   デザインハンドオフ [docs/reference/design_handoff_admin_redesign/README.md](reference/design_handoff_admin_redesign/README.md) を参照する
 
 ## Toast 通知
 
 `import { toast } from "sonner"` で使用。`toast.success("メッセージ")` / `toast.error("エラー")` で表示。
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.2
         version: 3.0.116(zod@4.3.6)
+      '@phosphor-icons/react':
+        specifier: ^2.1.10
+        version: 2.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@prisma/client':
         specifier: ^6.19.1
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
@@ -108,9 +111,6 @@ importers:
       iconv-lite:
         specifier: ^0.7.2
         version: 0.7.2
-      lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.3)
       next:
         specifier: 16.1.1
         version: 16.1.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.63.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1305,6 +1305,13 @@ packages:
   '@parcel/watcher@2.6.0':
     resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
     engines: {node: '>= 10.0.0'}
+
+  '@phosphor-icons/react@2.1.10':
+    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3199,11 +3206,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -5061,6 +5063,11 @@ snapshots:
       '@parcel/watcher-linux-x64-musl': 2.6.0
       '@parcel/watcher-win32-arm64': 2.6.0
       '@parcel/watcher-win32-x64': 2.6.0
+
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -7080,10 +7087,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-react@0.577.0(react@19.2.3):
-    dependencies:
-      react: 19.2.3
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
## 目的（Why）

admin が shadcn のダークテーマのままで Team Mirai ブランド（team-mir.ai）と一貫性がない状態を解消するため、デザインハンドオフ（docs/reference/design_handoff_admin_redesign/）に沿ってテーマ変数と共通 UI コンポーネントを「白ベース + Mirai Teal + 黒1pxボーダー + ピル形状」に差し替える。後続の画面別リデザイン Issue（#1290〜#1299）の土台となる。

Closes #1289

## 変更内容

- **テーマ変数（globals.css)**: ダークテーマの oklch 値をライトテーマ + Mirai Teal（`#30BCA7`）に全面差し替え。`primary-hover` / `primary-active` / `accent`（teal-100）/ `border-soft` / `disabled-*` / `ring-soft` / `teal-soft` などブランドトークンを追加
- **フォント**: Poppins を next/font で導入（`--font-poppins` → `font-latin` ユーティリティ）。日本語は Hiragino Kaku Gothic ProN → Noto Sans のスタック
- **Button**: ピル形状の 3 系統（default=teal塗り白文字 / secondary・outline=黒1.5px枠白地 / destructive=赤枠白地赤文字）。hover は 150ms の色変化のみ。disabled は枠 `#CCC`・文字 `#B1B1B1`・cursor not-allowed（opacity 不使用）
- **Input / Select / Textarea**: ピル形状・黒枠・白地。focus で枠 teal + `0 0 0 2px #E2F6F3` リング。placeholder `#B1B1B1`
- **Dialog / Card**: 白背景・黒1px枠・角丸8px（影なし）
- **Table**: ヘッダー行下罫線 黒1.5px、行罫線 `#E5E5E5`
- **アイコン**: lucide-react を @phosphor-icons/react（regular weight, `dist/ssr`）へ置き換え、admin から lucide-react への依存を削除
- **スピナー**: teal に変更（border スピナー / CircleNotch）
- **可読性スイープ**: 旧ダークテーマ前提の直書き色（`text-white` 約190箇所、`hover:bg-blue-600`、淡色 -400 系の文字色、白背景で見えなくなる `border-input` 等)を可読なトークン参照へ置換。色付きバッジ上の白文字は維持
- **ドキュメント**: docs/admin-ui-guidelines.md を新ルール（ピル・3系統ボタン・focus リング・Phosphor・カラー変数一覧）に更新

ダークモード切り替え（`dark:` / `prefers-color-scheme`）は追加していない。webapp / shared 配下は未変更。

## ローカルCI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ パス
- admin E2E（`pnpm test:e2e`）: ✅ 40 passed（ローカル supabase の auth API 無効・ポート衝突のため一時的に config を書き換えて実行。詳細は #1311）

## スコープアウトして起票した Issue

- #1311 ci(e2e): ローカルで admin E2E が手順どおり実行できない（supabase の auth API が無効・他プロジェクトとポート衝突）→ loop:unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)