### PR TITLE
feat(admin): サイドバーを白ベースのピル nav（Phosphor アイコン・折りたたみ・メール表示）にリデザインする

### DIFF
--- a/admin/e2e/tests/sidebar.spec.ts
+++ b/admin/e2e/tests/sidebar.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("サイドバー", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+	});
+
+	test("ログインユーザーのメールアドレスとログアウトボタンが表示される", async ({ page }) => {
+		const sidebar = page.getByRole("complementary");
+
+		await expect(sidebar.getByText("foo@example.com")).toBeVisible();
+		await expect(sidebar.getByRole("button", { name: "ログアウト" })).toBeVisible();
+	});
+
+	test("折りたたみボタンでアイコンレールと展開表示を切り替えられる", async ({ page }) => {
+		const sidebar = page.getByRole("complementary");
+		const transactionsLink = sidebar.getByRole("link", { name: "取引一覧" });
+
+		// 展開状態: ラベルが見えている
+		await expect(sidebar.getByText("ADMIN CONSOLE")).toBeVisible();
+		await expect(transactionsLink).toBeVisible();
+
+		// 折りたたむ: ラベル・セクション見出しは消えるが、リンク自体（アイコン + sr-only ラベル）は残る
+		await sidebar.getByRole("button", { name: "サイドバーを折りたたむ" }).click();
+		await expect(sidebar).toHaveAttribute("data-collapsed", "true");
+		await expect(sidebar.getByText("ADMIN CONSOLE")).toBeHidden();
+		await expect(sidebar.getByText("データ取り込み")).toBeHidden();
+		await expect(transactionsLink).toBeVisible();
+		await expect(transactionsLink).toHaveAttribute("href", "/transactions");
+
+		// 再度展開する
+		await sidebar.getByRole("button", { name: "サイドバーを開く" }).click();
+		await expect(sidebar).toHaveAttribute("data-collapsed", "false");
+		await expect(sidebar.getByText("ADMIN CONSOLE")).toBeVisible();
+	});
+});

--- a/admin/e2e/tests/user-info.spec.ts
+++ b/admin/e2e/tests/user-info.spec.ts
@@ -11,7 +11,8 @@ test.describe("ユーザー情報", () => {
 		test("ログイン中のユーザーのメールアドレスが表示される", async ({ page }) => {
 			await page.goto("/user-info");
 
-			await expect(page.getByText("foo@example.com")).toBeVisible();
+			// サイドバーのフッターにもメールアドレスが表示されるため、本文領域にスコープする
+			await expect(page.getByRole("main").getByText("foo@example.com")).toBeVisible();
 		});
 
 		test("ロール情報が表示される", async ({ page }) => {

--- a/admin/src/app/(auth)/layout.tsx
+++ b/admin/src/app/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 import "server-only";
 import { redirect } from "next/navigation";
-import Sidebar from "@/client/components/layout/Sidebar";
+import AuthShell from "@/client/components/layout/AuthShell";
 import { logout } from "@/server/contexts/auth/presentation/actions/logout";
 import { getCurrentUser } from "@/server/contexts/auth/presentation/loaders/load-current-user";
 
@@ -15,9 +15,8 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
   }
 
   return (
-    <div className="grid grid-cols-[220px_1fr] h-screen bg-background">
-      <Sidebar logoutAction={logout} userRole={user.role} />
-      <main className="p-5 overflow-auto text-foreground">{children}</main>
-    </div>
+    <AuthShell logoutAction={logout} userRole={user.role} userEmail={user.email}>
+      {children}
+    </AuthShell>
   );
 }

--- a/admin/src/app/globals.css
+++ b/admin/src/app/globals.css
@@ -21,6 +21,8 @@
 
   --color-muted: #f0f0f0;
   --color-muted-foreground: #666666;
+  /* セクション見出し・補足日付など、muted よりさらに控えめな文字色（--tm-gray-400） */
+  --color-subtle-foreground: #939393;
 
   --color-accent: #e2f6f3;
   --color-accent-foreground: #0f8472;

--- a/admin/src/client/components/layout/AuthShell.tsx
+++ b/admin/src/client/components/layout/AuthShell.tsx
@@ -1,0 +1,41 @@
+"use client";
+import "client-only";
+
+import { useState } from "react";
+import type { UserRole } from "@prisma/client";
+import Sidebar from "@/client/components/layout/Sidebar";
+import { cn } from "@/client/lib/index";
+
+type AuthShellProps = {
+  logoutAction: (formData: FormData) => Promise<void>;
+  userRole: UserRole | null;
+  userEmail: string;
+  children: React.ReactNode;
+};
+
+/**
+ * 認証済み画面の共通シェル（サイドバー + 本文領域）。
+ * サイドバーの折りたたみ状態をローカル state で持ち、grid の列幅を追従させる。
+ * 本文領域は背景 #F8F8F8 でサイドバーとは独立してスクロールする。
+ */
+export default function AuthShell({ logoutAction, userRole, userEmail, children }: AuthShellProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "grid h-screen bg-background",
+        collapsed ? "grid-cols-[72px_minmax(0,1fr)]" : "grid-cols-[236px_minmax(0,1fr)]",
+      )}
+    >
+      <Sidebar
+        logoutAction={logoutAction}
+        userRole={userRole}
+        userEmail={userEmail}
+        collapsed={collapsed}
+        onToggleCollapsed={() => setCollapsed((prev) => !prev)}
+      />
+      <main className="min-w-0 overflow-y-auto p-5 text-foreground">{children}</main>
+    </div>
+  );
+}

--- a/admin/src/client/components/layout/Sidebar.tsx
+++ b/admin/src/client/components/layout/Sidebar.tsx
@@ -4,101 +4,186 @@ import "client-only";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { UserRole } from "@prisma/client";
-import { Button } from "@/client/components/ui";
+import type { Icon } from "@phosphor-icons/react";
+import {
+  AddressBook,
+  Bank,
+  CaretDoubleLeft,
+  CaretDoubleRight,
+  Coins,
+  Export,
+  HandHeart,
+  Link as LinkIcon,
+  LinkSimple,
+  ListBullets,
+  SignOut,
+  Trash,
+  UploadSimple,
+  User,
+  UserCircle,
+  Users,
+} from "@phosphor-icons/react/dist/ssr";
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@/client/components/ui";
+import { cn } from "@/client/lib/index";
+import {
+  getVisibleNavSections,
+  isNavItemActive,
+  type NavIconName,
+} from "@/client/components/layout/sidebar-nav";
 
-type NavItem = {
-  href: string;
+const NAV_ICONS: Record<NavIconName, Icon> = {
+  user: User,
+  bank: Bank,
+  users: Users,
+  "list-bullets": ListBullets,
+  trash: Trash,
+  "upload-simple": UploadSimple,
+  coins: Coins,
+  "address-book": AddressBook,
+  link: LinkIcon,
+  "hand-heart": HandHeart,
+  "link-simple": LinkSimple,
+  export: Export,
+};
+
+type SidebarProps = {
+  logoutAction: (formData: FormData) => Promise<void>;
+  userRole: UserRole | null;
+  userEmail: string;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+};
+
+/**
+ * 折りたたみ時のみツールチップでラベルを補う（展開時はラベルが見えているので不要）
+ */
+function CollapsibleTooltip({
+  label,
+  collapsed,
+  children,
+}: {
   label: string;
-  adminOnly?: boolean;
-};
-
-type NavSection = {
-  title: string;
-  items: NavItem[];
-};
+  collapsed: boolean;
+  children: React.ReactElement;
+}) {
+  if (!collapsed) return children;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="right" sideOffset={8}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 export default function Sidebar({
   logoutAction,
   userRole,
-}: {
-  logoutAction: (formData: FormData) => Promise<void>;
-  userRole: UserRole | null;
-}) {
+  userEmail,
+  collapsed,
+  onToggleCollapsed,
+}: SidebarProps) {
   const pathname = usePathname();
-
-  const isActive = (path: string) => {
-    if (path === "/") {
-      return pathname === "/";
-    }
-    return pathname.startsWith(path);
-  };
-
-  const navSections: NavSection[] = [
-    {
-      title: "基本情報",
-      items: [
-        { href: "/user-info", label: "ユーザー情報" },
-        { href: "/political-organizations", label: "政治団体" },
-        { href: "/users", label: "ユーザー管理", adminOnly: true },
-      ],
-    },
-    {
-      title: "データ取り込み",
-      items: [
-        { href: "/transactions", label: "取引一覧" },
-        { href: "/bulk-delete-transactions", label: "取引一括削除" },
-        { href: "/upload-csv", label: "CSVアップロード" },
-        { href: "/balance-snapshots", label: "残高登録" },
-      ],
-    },
-    {
-      title: "報告書",
-      items: [
-        { href: "/counterparts", label: "取引先マスタ" },
-        { href: "/assign/counterparts", label: "取引先紐付け" },
-        { href: "/donors", label: "寄付者マスタ" },
-        { href: "/assign/donors", label: "寄付者紐付け" },
-        { href: "/export-report", label: "報告書エクスポート" },
-      ],
-    },
-  ];
+  const navSections = getVisibleNavSections(userRole);
+  const ToggleIcon = collapsed ? CaretDoubleRight : CaretDoubleLeft;
+  const toggleLabel = collapsed ? "サイドバーを開く" : "サイドバーを折りたたむ";
 
   return (
-    <aside className="bg-card p-4 flex flex-col h-full">
-      <nav className="flex flex-col gap-6">
-        {navSections.map((section) => {
-          const visibleItems = section.items.filter(
-            (item) => !item.adminOnly || userRole === "admin",
-          );
-          if (visibleItems.length === 0) return null;
-
-          return (
-            <div key={section.title}>
-              <h3 className="text-muted-foreground text-xs font-medium uppercase tracking-wider mb-1 px-2.5">
-                {section.title}
-              </h3>
-              <div className="flex flex-col gap-0.5">
-                {visibleItems.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={`text-foreground no-underline px-2.5 py-2 rounded-lg transition-colors duration-200 ${
-                      isActive(item.href) ? "bg-secondary" : "hover:bg-secondary"
-                    }`}
-                  >
-                    {item.label}
-                  </Link>
-                ))}
-              </div>
+    <aside
+      data-collapsed={collapsed}
+      className="sticky top-0 flex h-screen flex-col overflow-y-auto border-r border-sidebar-border bg-sidebar px-3.5 pt-6 pb-5"
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2 px-1.5 pb-5",
+          collapsed ? "justify-center" : "justify-between",
+        )}
+      >
+        {!collapsed && (
+          <div className="min-w-0">
+            <div className="whitespace-nowrap text-[13px] font-bold tracking-[0.06em] text-foreground">
+              みらいまる見え政治資金
             </div>
-          );
-        })}
+            <div className="mt-0.5 font-latin text-[10px] font-semibold tracking-[0.14em] text-primary-hover">
+              ADMIN CONSOLE
+            </div>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          aria-label={toggleLabel}
+          aria-expanded={!collapsed}
+          title={toggleLabel}
+          className="inline-flex size-[26px] shrink-0 cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-0 text-disabled-foreground transition-colors duration-150 ease-out outline-none hover:bg-secondary hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <ToggleIcon size={13} aria-hidden="true" />
+        </button>
+      </div>
+
+      <nav aria-label="メインナビゲーション" className="flex flex-1 flex-col gap-5">
+        {navSections.map((section) => (
+          <div key={section.title}>
+            {!collapsed && (
+              <div className="mx-3 mb-1.5 text-[11px] font-semibold tracking-[0.12em] text-subtle-foreground">
+                {section.title}
+              </div>
+            )}
+            <div className="flex flex-col gap-0.5">
+              {section.items.map((item) => {
+                const ItemIcon = NAV_ICONS[item.icon];
+                const active = isNavItemActive(pathname, item.href);
+                return (
+                  <CollapsibleTooltip key={item.href} label={item.label} collapsed={collapsed}>
+                    <Link
+                      href={item.href}
+                      aria-current={active ? "page" : undefined}
+                      className={cn(
+                        "flex items-center gap-2.5 whitespace-nowrap rounded-full text-[13px] no-underline outline-none transition-colors duration-150 ease-out hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                        collapsed ? "justify-center px-0 py-[9px]" : "px-3.5 py-2",
+                        active
+                          ? "bg-sidebar-accent font-bold text-sidebar-accent-foreground"
+                          : "font-medium text-sidebar-foreground",
+                      )}
+                    >
+                      <ItemIcon size={16} className="shrink-0" aria-hidden="true" />
+                      <span className={cn(collapsed && "sr-only")}>{item.label}</span>
+                    </Link>
+                  </CollapsibleTooltip>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </nav>
-      <div className="mt-auto pt-4">
+
+      <div className="mt-4 flex flex-col gap-2.5 border-t border-sidebar-border pt-4">
+        <div
+          className={cn("flex items-center gap-2 px-2.5", collapsed && "justify-center px-0")}
+          title={userEmail}
+        >
+          <UserCircle size={20} className="shrink-0 text-primary-active" aria-hidden="true" />
+          <span
+            className={cn(
+              "truncate font-latin text-xs text-muted-foreground",
+              collapsed && "sr-only",
+            )}
+          >
+            {userEmail}
+          </span>
+        </div>
         <form action={logoutAction}>
-          <Button type="submit" variant="destructive" className="w-full">
-            ログアウト
-          </Button>
+          <CollapsibleTooltip label="ログアウト" collapsed={collapsed}>
+            <Button
+              type="submit"
+              variant="secondary"
+              className={cn("w-full text-[13px] tracking-[0.06em]", collapsed && "px-0")}
+            >
+              <SignOut size={16} aria-hidden="true" />
+              <span className={cn(collapsed && "sr-only")}>ログアウト</span>
+            </Button>
+          </CollapsibleTooltip>
         </form>
       </div>
     </aside>

--- a/admin/src/client/components/layout/sidebar-nav.ts
+++ b/admin/src/client/components/layout/sidebar-nav.ts
@@ -1,0 +1,85 @@
+import type { UserRole } from "@prisma/client";
+
+/**
+ * サイドバーの nav 項目に使う Phosphor アイコンの識別子。
+ * 実際のアイコンコンポーネントへの対応は Sidebar.tsx 側で行う
+ * （このモジュールは純粋なデータ / 判定ロジックのみを持ち、ユニットテスト可能に保つ）。
+ */
+export type NavIconName =
+  | "user"
+  | "bank"
+  | "users"
+  | "list-bullets"
+  | "trash"
+  | "upload-simple"
+  | "coins"
+  | "address-book"
+  | "link"
+  | "hand-heart"
+  | "link-simple"
+  | "export";
+
+type NavItem = {
+  href: string;
+  label: string;
+  icon: NavIconName;
+  adminOnly?: boolean;
+};
+
+type NavSection = {
+  title: string;
+  items: NavItem[];
+};
+
+// アイコン対応表はデザインハンドオフ README「1. サイドバー」節が正
+const NAV_SECTIONS: NavSection[] = [
+  {
+    title: "基本情報",
+    items: [
+      { href: "/user-info", label: "ユーザー情報", icon: "user" },
+      { href: "/political-organizations", label: "政治団体", icon: "bank" },
+      { href: "/users", label: "ユーザー管理", icon: "users", adminOnly: true },
+    ],
+  },
+  {
+    title: "データ取り込み",
+    items: [
+      { href: "/transactions", label: "取引一覧", icon: "list-bullets" },
+      { href: "/bulk-delete-transactions", label: "取引一括削除", icon: "trash" },
+      { href: "/upload-csv", label: "CSVアップロード", icon: "upload-simple" },
+      { href: "/balance-snapshots", label: "残高登録", icon: "coins" },
+    ],
+  },
+  {
+    title: "報告書",
+    items: [
+      { href: "/counterparts", label: "取引先マスタ", icon: "address-book" },
+      { href: "/assign/counterparts", label: "取引先紐付け", icon: "link" },
+      { href: "/donors", label: "寄付者マスタ", icon: "hand-heart" },
+      { href: "/assign/donors", label: "寄付者紐付け", icon: "link-simple" },
+      { href: "/export-report", label: "報告書エクスポート", icon: "export" },
+    ],
+  },
+];
+
+/**
+ * ユーザーのロールに応じて表示可能な nav セクションを返す。
+ * adminOnly の項目は admin ロールにのみ表示し、項目が空になったセクションは除外する。
+ */
+export function getVisibleNavSections(userRole: UserRole | null): NavSection[] {
+  return NAV_SECTIONS.map((section) => ({
+    ...section,
+    items: section.items.filter((item) => !item.adminOnly || userRole === "admin"),
+  })).filter((section) => section.items.length > 0);
+}
+
+/**
+ * 現在のパスが nav 項目に対応する画面かを判定する。
+ * ルート以外は前方一致（配下の詳細画面でも親項目をアクティブにする）。
+ */
+export function isNavItemActive(pathname: string, href: string): boolean {
+  if (href === "/") {
+    return pathname === "/";
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+}

--- a/admin/tests/client/components/layout/sidebar-nav.test.ts
+++ b/admin/tests/client/components/layout/sidebar-nav.test.ts
@@ -1,0 +1,77 @@
+import {
+  getVisibleNavSections,
+  isNavItemActive,
+} from "@/client/components/layout/sidebar-nav";
+
+describe("getVisibleNavSections", () => {
+  it("admin ロールにはすべての項目（ユーザー管理を含む）を表示する", () => {
+    const sections = getVisibleNavSections("admin");
+    const hrefs = sections.flatMap((s) => s.items.map((i) => i.href));
+
+    expect(sections.map((s) => s.title)).toEqual(["基本情報", "データ取り込み", "報告書"]);
+    expect(hrefs).toContain("/users");
+    expect(hrefs).toHaveLength(12);
+  });
+
+  it("admin 以外のロールには adminOnly の項目を表示しない", () => {
+    const sections = getVisibleNavSections("user");
+    const hrefs = sections.flatMap((s) => s.items.map((i) => i.href));
+
+    expect(hrefs).not.toContain("/users");
+    expect(hrefs).toHaveLength(11);
+  });
+
+  it("ロール不明（null）の場合も adminOnly の項目を表示しない", () => {
+    const hrefs = getVisibleNavSections(null).flatMap((s) => s.items.map((i) => i.href));
+
+    expect(hrefs).not.toContain("/users");
+  });
+
+  it("各項目にハンドオフ対応表どおりのアイコン識別子が設定されている", () => {
+    const iconByHref = Object.fromEntries(
+      getVisibleNavSections("admin").flatMap((s) => s.items.map((i) => [i.href, i.icon])),
+    );
+
+    expect(iconByHref).toEqual({
+      "/user-info": "user",
+      "/political-organizations": "bank",
+      "/users": "users",
+      "/transactions": "list-bullets",
+      "/bulk-delete-transactions": "trash",
+      "/upload-csv": "upload-simple",
+      "/balance-snapshots": "coins",
+      "/counterparts": "address-book",
+      "/assign/counterparts": "link",
+      "/donors": "hand-heart",
+      "/assign/donors": "link-simple",
+      "/export-report": "export",
+    });
+  });
+});
+
+describe("isNavItemActive", () => {
+  it("完全一致でアクティブになる", () => {
+    expect(isNavItemActive("/transactions", "/transactions")).toBe(true);
+  });
+
+  it("配下の詳細画面でも親項目がアクティブになる", () => {
+    expect(isNavItemActive("/political-organizations/123/edit", "/political-organizations")).toBe(
+      true,
+    );
+  });
+
+  it("前方が同じだけの別パスはアクティブにならない", () => {
+    expect(isNavItemActive("/user-info", "/users")).toBe(false);
+    expect(isNavItemActive("/users-archive", "/users")).toBe(false);
+  });
+
+  it("/assign 配下の項目は親のマスタ項目をアクティブにしない", () => {
+    expect(isNavItemActive("/assign/counterparts", "/counterparts")).toBe(false);
+    expect(isNavItemActive("/assign/counterparts", "/assign/counterparts")).toBe(true);
+  });
+
+  it("ルート（/）は完全一致のみでアクティブになる", () => {
+    expect(isNavItemActive("/", "/")).toBe(true);
+    expect(isNavItemActive("/transactions", "/")).toBe(false);
+  });
+});


### PR DESCRIPTION
## 目的（Why）

admin リデザイン（土台 #1289 / #1312）の一環として、全画面共通で最も目に入るサイドバーを
デザインハンドオフ「1. サイドバー」節に合わせ、白ベース・ピル nav・Phosphor アイコン・折りたたみ対応にする。
管理者が旧デザイン（灰背景・テキストのみ・destructive なログアウト）と新ブランドの混在した画面を使っている状態を解消する。

## 変更内容

- **Sidebar.tsx**: 白背景・右罫線 `1px #E5E5E5`・sticky・幅 236px。ヘッダーは「みらいまる見え政治資金」(13px/700) + 「ADMIN CONSOLE」(Poppins 10px/600, ls 0.14em, `#089781`) の文字のみ（ロゴ画像なし）
  - セクション見出し 11px/600・`#939393`・ls 0.12em（新トークン `--color-subtle-foreground`）
  - nav 項目はピル形。Phosphor 16px アイコン + 13px ラベル。通常 `#1F2937`/500、hover `#E2F6F3`、アクティブ `#E2F6F3` + `#0F8472`/700。`aria-current="page"` を付与
  - アイコン対応は README の表どおり（user / bank / users / list-bullets / trash / upload-simple / coins / address-book / link / hand-heart / link-simple / export）
  - ヘッダー右の枠なしアイコンボタン（`#B1B1B1` → hover `#666`）で折りたたみ。折りたたみ時は 72px のアイコンレール（中央寄せ、各項目に Tooltip、ラベルは sr-only で残す）
  - フッター: 上罫線 + user-circle（teal-deep）+ メールアドレス（Poppins 12px `#666`）。ログアウトは `variant="secondary"`（黒 1.5px 枠の白ピル、sign-out アイコン + 13px/700）に変更
- **AuthShell.tsx（新規, client）**: 折りたたみ状態をローカル state で持ち、grid を `236px ↔ 72px` で切り替えて本文領域の幅を追従させる。本文は `bg-background`（`#F8F8F8`）で独立スクロール
- **(auth)/layout.tsx**: AuthShell 経由でサイドバーを描画し、ログインユーザーのメールアドレスを渡す
- **sidebar-nav.ts（新規）**: nav データ・admin 専用項目の出し分け・アクティブ判定を純粋関数に切り出し（ユニットテスト追加）
- **globals.css**: `--color-subtle-foreground: #939393` を追加
- **E2E**: サイドバーにもメールアドレスが表示されるため `user-info.spec.ts` の `getByText` を `main` にスコープ。折りたたみ↔展開の挙動を検証する `sidebar.spec.ts` を追加

管理者専用項目の出し分け・アクティブ判定・ログアウトの挙動は従来どおり。nav 項目の追加/削除/並び替え、折りたたみ状態の永続化、各画面コンテンツ側のリデザインは対象外。

Closes #1290

## ローカルCI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ すべて通過
- admin E2E（`playwright test --workers=1`、CI と同条件）: ✅ 42 passed
  - 並列（workers 既定）では `import-donors.spec.ts` がテスト間のデータ競合で落ちるが本変更とは無関係（下記 #1313 として起票）。`report-profile` の年度切り替えは既知の flaky（#1307）

## スコープアウトして起票したIssue

- #1313 test(e2e): import-donors の E2E がローカル並列実行時に一意制約違反で落ちる（テスト間のデータ競合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 管理画面のサイドバーを折りたたみ・展開できるようになりました。
  - サイドバーにログイン中のユーザーのメールアドレスを表示します。
  - ユーザーの権限に応じて表示するナビゲーション項目を切り替えます。
  - ナビゲーションの現在位置を適切に強調表示します。
  - サイドバー項目にアイコンとツールチップを追加しました。

- **デザイン**
  - 本文領域のレイアウトと背景色を調整しました。
  - 補足情報などに使用する控えめな文字色を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->