### PR TITLE
feat(admin): 全画面のページヘッダーを英字ラベル + 下線付き見出しの共通コンポーネントに統一する

### DIFF
--- a/admin/e2e/tests/dashboard.spec.ts
+++ b/admin/e2e/tests/dashboard.spec.ts
@@ -7,7 +7,7 @@ test.describe("ダッシュボード", () => {
 
 	test.describe("読み込み", () => {
 		test("ログイン後にダッシュボードが正常に表示される", async ({ page }) => {
-			await expect(page.getByRole("heading", { name: "Welcome" })).toBeVisible();
+			await expect(page.getByRole("heading", { name: "ダッシュボード" })).toBeVisible();
 		});
 
 		test("Welcomeメッセージが表示される", async ({ page }) => {

--- a/admin/e2e/tests/login.spec.ts
+++ b/admin/e2e/tests/login.spec.ts
@@ -20,7 +20,7 @@ test.describe("ログインページ", () => {
 
 		// ダッシュボードにリダイレクトされることを確認
 		await expect(page).toHaveURL("/");
-		await expect(page.getByRole("heading", { name: "Welcome" })).toBeVisible();
+		await expect(page.getByRole("heading", { name: "ダッシュボード" })).toBeVisible();
 	});
 
 	test("間違ったパスワードでログインに失敗する", async ({ page }) => {

--- a/admin/src/app/(auth)/balance-snapshots/page.tsx
+++ b/admin/src/app/(auth)/balance-snapshots/page.tsx
@@ -2,14 +2,17 @@ import "server-only";
 
 import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/presentation/loaders/load-political-organizations-data";
 import BalanceSnapshotsClient from "@/client/components/balance-snapshots/BalanceSnapshotsClient";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 export default async function BalanceSnapshotsPage() {
   const organizations = await loadPoliticalOrganizationsData();
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-foreground mb-6">残高登録</h1>
-      <BalanceSnapshotsClient organizations={organizations} />
+    <div>
+      <PageHeader label="Balance Snapshots" title="残高登録" />
+      <div className="bg-card rounded-xl p-4">
+        <BalanceSnapshotsClient organizations={organizations} />
+      </div>
     </div>
   );
 }

--- a/admin/src/app/(auth)/export-report/[orgId]/[year]/page.tsx
+++ b/admin/src/app/(auth)/export-report/[orgId]/[year]/page.tsx
@@ -8,6 +8,7 @@ import type { ReportPreviewData } from "@/server/contexts/report/presentation/lo
 import { ExportReportSelectors } from "@/client/components/export-report/ExportReportSelectors";
 import { ExportReportPreview } from "@/client/components/export-report/ExportReportPreview";
 import { DownloadButton } from "@/client/components/export-report/DownloadButton";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 interface ExportReportDetailPageProps {
   params: Promise<{
@@ -47,11 +48,14 @@ export default async function ExportReportDetailPage({ params }: ExportReportDet
   const currentYear = new Date().getFullYear();
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-foreground mb-1">報告書エクスポート</h1>
-      <p className="text-muted-foreground mb-6">政治資金報告書をエクスポートします</p>
+    <div>
+      <PageHeader
+        label="Report Export"
+        title="報告書エクスポート"
+        description="政治資金報告書をエクスポートします"
+      />
 
-      <div className="space-y-6">
+      <div className="bg-card rounded-xl p-4 space-y-6">
         <ExportReportSelectors
           organizations={organizations}
           selectedOrgId={orgId}

--- a/admin/src/app/(auth)/export-report/page.tsx
+++ b/admin/src/app/(auth)/export-report/page.tsx
@@ -2,17 +2,20 @@ import "server-only";
 
 import { redirect } from "next/navigation";
 import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/presentation/loaders/load-political-organizations-data";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 export default async function ExportReportPage() {
   const organizations = await loadPoliticalOrganizationsData();
 
   if (organizations.length === 0) {
     return (
-      <div className="bg-card rounded-xl p-4">
-        <h1 className="text-2xl font-bold text-foreground mb-1">報告書エクスポート</h1>
-        <p className="text-muted-foreground">
-          政治団体が登録されていません。先に政治団体を作成してください。
-        </p>
+      <div>
+        <PageHeader label="Report Export" title="報告書エクスポート" />
+        <div className="bg-card rounded-xl p-4">
+          <p className="text-muted-foreground">
+            政治団体が登録されていません。先に政治団体を作成してください。
+          </p>
+        </div>
       </div>
     );
   }

--- a/admin/src/app/(auth)/import-donors/page.tsx
+++ b/admin/src/app/(auth)/import-donors/page.tsx
@@ -4,18 +4,21 @@ import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/present
 import { previewDonorCsv } from "@/server/contexts/report/presentation/actions/preview-donor-csv";
 import { importDonorCsv } from "@/server/contexts/report/presentation/actions/import-donor-csv";
 import DonorCsvImportClient from "@/client/components/donor-csv-import/DonorCsvImportClient";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 export default async function ImportDonorsPage() {
   const organizations = await loadPoliticalOrganizationsData();
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-foreground mb-6">寄付者一括インポート</h1>
-      <DonorCsvImportClient
-        organizations={organizations}
-        previewAction={previewDonorCsv}
-        importAction={importDonorCsv}
-      />
+    <div>
+      <PageHeader label="Donor Import" title="寄付者一括インポート" />
+      <div className="bg-card rounded-xl p-4">
+        <DonorCsvImportClient
+          organizations={organizations}
+          previewAction={previewDonorCsv}
+          importAction={importDonorCsv}
+        />
+      </div>
     </div>
   );
 }

--- a/admin/src/app/(auth)/page.tsx
+++ b/admin/src/app/(auth)/page.tsx
@@ -1,8 +1,12 @@
+import { PageHeader } from "@/client/components/layout/PageHeader";
+
 export default function Home() {
   return (
-    <div className="bg-card rounded-xl p-4">
-      <h1>Welcome</h1>
-      <p className="text-muted-foreground">Use the left navigation to manage data.</p>
+    <div>
+      <PageHeader label="Dashboard" title="ダッシュボード" />
+      <div className="bg-card rounded-xl p-4">
+        <p className="text-muted-foreground">Use the left navigation to manage data.</p>
+      </div>
     </div>
   );
 }

--- a/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
@@ -2,6 +2,7 @@ import "server-only";
 
 import Link from "next/link";
 import { PoliticalOrganizationForm } from "@/client/components/political-organizations/PoliticalOrganizationForm";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 import { loadPoliticalOrganizationData } from "@/server/contexts/shared/presentation/loaders/load-political-organization-data";
 import { updatePoliticalOrganization } from "@/server/contexts/shared/presentation/actions/update-political-organization";
 import type { UpdatePoliticalOrganizationData } from "@/server/contexts/shared/presentation/actions/update-political-organization";
@@ -34,28 +35,40 @@ export default async function EditPoliticalOrganizationPage({
   };
 
   return (
-    <div className="space-y-4">
-      <PoliticalOrganizationForm
-        initialData={{
-          displayName: organization.displayName,
-          orgName: organization.orgName || "",
-          slug: organization.slug,
-          description: organization.description || "",
-        }}
-        onSubmit={handleSubmit}
-        submitButtonText="更新"
-        title={`「${organization.displayName}」を編集`}
-      />
+    <div>
+      <div className="mb-4">
+        <Link
+          href="/political-organizations"
+          className="text-muted-foreground no-underline hover:text-foreground transition-colors"
+        >
+          ← 政治団体一覧に戻る
+        </Link>
+      </div>
 
-      <div className="bg-card rounded-xl p-4">
-        <h2 className="text-lg font-semibold text-foreground mb-3">関連機能</h2>
-        <div className="flex gap-3">
-          <Link
-            href={`/political-organizations/${orgId}/report-profile`}
-            className="bg-secondary text-secondary-foreground border border-border rounded-lg px-4 py-2.5 hover:bg-accent transition-colors no-underline"
-          >
-            報告書プロフィール
-          </Link>
+      <PageHeader label="Organizations" title={`「${organization.displayName}」を編集`} />
+
+      <div className="space-y-4">
+        <PoliticalOrganizationForm
+          initialData={{
+            displayName: organization.displayName,
+            orgName: organization.orgName || "",
+            slug: organization.slug,
+            description: organization.description || "",
+          }}
+          onSubmit={handleSubmit}
+          submitButtonText="更新"
+        />
+
+        <div className="bg-card rounded-xl p-4">
+          <h2 className="text-lg font-semibold text-foreground mb-3">関連機能</h2>
+          <div className="flex gap-3">
+            <Link
+              href={`/political-organizations/${orgId}/report-profile`}
+              className="bg-secondary text-secondary-foreground border border-border rounded-lg px-4 py-2.5 hover:bg-accent transition-colors no-underline"
+            >
+              報告書プロフィール
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/admin/src/app/(auth)/political-organizations/[orgId]/report-profile/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/report-profile/page.tsx
@@ -5,6 +5,7 @@ import { loadPoliticalOrganizationData } from "@/server/contexts/shared/presenta
 import { loadOrganizationProfileData } from "@/server/contexts/report/presentation/loaders/organization-profile-loader";
 import { ReportProfileForm } from "@/client/components/report-profile/ReportProfileForm";
 import { YearSelector } from "@/client/components/report-profile/YearSelector";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 interface ReportProfilePageProps {
   params: Promise<{ orgId: string }>;
@@ -41,8 +42,8 @@ export default async function ReportProfilePage({ params, searchParams }: Report
   }
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <div className="mb-5">
+    <div>
+      <div className="mb-4">
         <Link
           href="/political-organizations"
           className="text-muted-foreground no-underline hover:text-foreground transition-colors"
@@ -51,20 +52,23 @@ export default async function ReportProfilePage({ params, searchParams }: Report
         </Link>
       </div>
 
-      <h1 className="text-2xl font-bold text-foreground mb-4">
-        「{organization.displayName}」の報告書プロフィール
-      </h1>
-
-      <div className="block mb-4">
-        <YearSelector orgId={orgId} financialYear={financialYear} currentYear={currentYear} />
-      </div>
-
-      <ReportProfileForm
-        key={financialYear}
-        politicalOrganizationId={orgId}
-        financialYear={financialYear}
-        initialData={profile}
+      <PageHeader
+        label="Report Profile"
+        title={`「${organization.displayName}」の報告書プロフィール`}
       />
+
+      <div className="bg-card rounded-xl p-4">
+        <div className="block mb-4">
+          <YearSelector orgId={orgId} financialYear={financialYear} currentYear={currentYear} />
+        </div>
+
+        <ReportProfileForm
+          key={financialYear}
+          politicalOrganizationId={orgId}
+          financialYear={financialYear}
+          initialData={profile}
+        />
+      </div>
     </div>
   );
 }

--- a/admin/src/app/(auth)/political-organizations/new/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/new/page.tsx
@@ -1,6 +1,8 @@
 import "server-only";
 
+import Link from "next/link";
 import { PoliticalOrganizationForm } from "@/client/components/political-organizations/PoliticalOrganizationForm";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 import { createPoliticalOrganization } from "@/server/contexts/shared/presentation/actions/create-political-organization";
 import type { CreatePoliticalOrganizationData } from "@/server/contexts/shared/presentation/actions/create-political-organization";
 
@@ -11,10 +13,19 @@ export default function NewPoliticalOrganizationPage() {
   };
 
   return (
-    <PoliticalOrganizationForm
-      onSubmit={handleSubmit}
-      submitButtonText="作成"
-      title="新しい政治団体を作成"
-    />
+    <div>
+      <div className="mb-4">
+        <Link
+          href="/political-organizations"
+          className="text-muted-foreground no-underline hover:text-foreground transition-colors"
+        >
+          ← 政治団体一覧に戻る
+        </Link>
+      </div>
+
+      <PageHeader label="Organizations" title="新しい政治団体を作成" />
+
+      <PoliticalOrganizationForm onSubmit={handleSubmit} submitButtonText="作成" />
+    </div>
   );
 }

--- a/admin/src/app/(auth)/political-organizations/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/page.tsx
@@ -3,65 +3,73 @@ import "server-only";
 import Link from "next/link";
 import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/presentation/loaders/load-political-organizations-data";
 import { DeletePoliticalOrganizationButton } from "@/client/components/political-organizations/DeletePoliticalOrganizationButton";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 export default async function PoliticalOrganizationsPage() {
   const organizations = await loadPoliticalOrganizationsData();
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-foreground">政治団体一覧</h1>
-        <Link
-          href="/political-organizations/new"
-          className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-primary-hover transition-colors duration-200"
-        >
-          新規作成
-        </Link>
-      </div>
-
-      {organizations.length === 0 && (
-        <div className="text-center py-10">
-          <p className="text-muted-foreground">政治団体が登録されていません</p>
+    <div>
+      <PageHeader
+        label="Organizations"
+        title="政治団体一覧"
+        actions={
           <Link
             href="/political-organizations/new"
-            className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-primary-hover transition-colors duration-200 mt-4 inline-block"
+            className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-primary-hover transition-colors duration-200"
           >
-            最初の政治団体を作成
+            新規作成
           </Link>
-        </div>
-      )}
+        }
+      />
 
-      {organizations.length > 0 && (
-        <div className="mt-5">
-          <div className="grid gap-4">
-            {organizations.map((org) => (
-              <div key={org.id} className="bg-card rounded-lg p-6 border border-border">
-                <div className="flex justify-between items-start gap-4">
-                  <div className="flex-1 space-y-3">
-                    <h3 className="text-lg font-medium text-foreground">{org.displayName}</h3>
-                    {org.description && <p className="text-muted-foreground">{org.description}</p>}
-                    <div className="text-muted-foreground text-sm">
-                      作成日: {new Date(org.createdAt).toLocaleDateString("ja-JP")}
+      <div className="bg-card rounded-xl p-4">
+        {organizations.length === 0 && (
+          <div className="text-center py-10">
+            <p className="text-muted-foreground">政治団体が登録されていません</p>
+            <Link
+              href="/political-organizations/new"
+              className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-primary-hover transition-colors duration-200 mt-4 inline-block"
+            >
+              最初の政治団体を作成
+            </Link>
+          </div>
+        )}
+
+        {organizations.length > 0 && (
+          <div className="mt-5">
+            <div className="grid gap-4">
+              {organizations.map((org) => (
+                <div key={org.id} className="bg-card rounded-lg p-6 border border-border">
+                  <div className="flex justify-between items-start gap-4">
+                    <div className="flex-1 space-y-3">
+                      <h3 className="text-lg font-medium text-foreground">{org.displayName}</h3>
+                      {org.description && (
+                        <p className="text-muted-foreground">{org.description}</p>
+                      )}
+                      <div className="text-muted-foreground text-sm">
+                        作成日: {new Date(org.createdAt).toLocaleDateString("ja-JP")}
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <Link
+                        href={`/political-organizations/${org.id}`}
+                        className="bg-secondary text-secondary-foreground no-underline text-sm px-4 py-2 rounded-lg hover:bg-secondary/80 transition-colors duration-200"
+                      >
+                        編集
+                      </Link>
+                      <DeletePoliticalOrganizationButton
+                        orgId={BigInt(org.id)}
+                        orgName={org.displayName}
+                      />
                     </div>
                   </div>
-                  <div className="flex gap-2">
-                    <Link
-                      href={`/political-organizations/${org.id}`}
-                      className="bg-secondary text-secondary-foreground no-underline text-sm px-4 py-2 rounded-lg hover:bg-secondary/80 transition-colors duration-200"
-                    >
-                      編集
-                    </Link>
-                    <DeletePoliticalOrganizationButton
-                      orgId={BigInt(org.id)}
-                      orgName={org.displayName}
-                    />
-                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/admin/src/app/(auth)/upload-csv/page.tsx
+++ b/admin/src/app/(auth)/upload-csv/page.tsx
@@ -4,18 +4,21 @@ import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/present
 import { uploadCsv } from "@/server/contexts/data-import/presentation/actions/upload-csv";
 import { previewCsv } from "@/server/contexts/data-import/presentation/actions/preview-csv";
 import CsvUploadClient from "@/client/components/csv-upload/CsvUploadClient";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 export default async function UploadCsvPage() {
   const organizations = await loadPoliticalOrganizationsData();
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-foreground mb-6">CSVアップロード</h1>
-      <CsvUploadClient
-        organizations={organizations}
-        uploadAction={uploadCsv}
-        previewAction={previewCsv}
-      />
+    <div>
+      <PageHeader label="Data Import" title="CSVアップロード" />
+      <div className="bg-card rounded-xl p-4">
+        <CsvUploadClient
+          organizations={organizations}
+          uploadAction={uploadCsv}
+          previewAction={previewCsv}
+        />
+      </div>
     </div>
   );
 }

--- a/admin/src/app/(auth)/user-info/page.tsx
+++ b/admin/src/app/(auth)/user-info/page.tsx
@@ -1,4 +1,5 @@
 import { getCurrentUser } from "@/server/contexts/auth/presentation/loaders/load-current-user";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 export const runtime = "nodejs";
 
@@ -6,26 +7,33 @@ export default async function UserInfoPage() {
   const user = await getCurrentUser();
 
   if (!user) {
-    return <div className="bg-card rounded-xl p-4">ユーザー情報が見つかりません</div>;
+    return (
+      <div>
+        <PageHeader label="User Info" title="ユーザー情報" />
+        <div className="bg-card rounded-xl p-4">ユーザー情報が見つかりません</div>
+      </div>
+    );
   }
 
   const createdAt = user.createdAt instanceof Date ? user.createdAt : new Date(user.createdAt ?? 0);
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <h1>ユーザー情報</h1>
-      <p>
-        <b>ID:</b> {user.id}
-      </p>
-      <p>
-        <b>メールアドレス:</b> {user.email}
-      </p>
-      <p>
-        <b>ロール:</b> {user.role}
-      </p>
-      <p>
-        <b>作成日:</b> {createdAt.toLocaleString("ja-JP")}
-      </p>
+    <div>
+      <PageHeader label="User Info" title="ユーザー情報" />
+      <div className="bg-card rounded-xl p-4">
+        <p>
+          <b>ID:</b> {user.id}
+        </p>
+        <p>
+          <b>メールアドレス:</b> {user.email}
+        </p>
+        <p>
+          <b>ロール:</b> {user.role}
+        </p>
+        <p>
+          <b>作成日:</b> {createdAt.toLocaleString("ja-JP")}
+        </p>
+      </div>
     </div>
   );
 }

--- a/admin/src/app/(auth)/users/page.tsx
+++ b/admin/src/app/(auth)/users/page.tsx
@@ -3,6 +3,7 @@ import { loadAllUsers } from "@/server/contexts/auth/presentation/loaders/load-a
 import { updateUserRole } from "@/server/contexts/auth/presentation/actions/update-user-role";
 import { inviteUser } from "@/server/contexts/auth/presentation/actions/invite-user";
 import UserManagement from "@/client/components/user-management/UserManagement";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 export default async function UsersPage() {
   const rawUsers = await loadAllUsers();
@@ -15,14 +16,16 @@ export default async function UsersPage() {
   }));
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <h1 className="text-2xl font-bold text-foreground mb-4">ユーザー管理</h1>
-      <UserManagement
-        users={users}
-        availableRoles={["user", "admin"]}
-        updateUserRoleAction={updateUserRole}
-        inviteUserAction={inviteUser}
-      />
+    <div>
+      <PageHeader label="Users" title="ユーザー管理" />
+      <div className="bg-card rounded-xl p-4">
+        <UserManagement
+          users={users}
+          availableRoles={["user", "admin"]}
+          updateUserRoleAction={updateUserRole}
+          inviteUserAction={inviteUser}
+        />
+      </div>
     </div>
   );
 }

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
@@ -17,6 +17,7 @@ import {
 } from "./CounterpartAssignmentFilters";
 import { ClientPagination } from "@/client/components/ui/ClientPagination";
 import { Card, Input, Button, Label } from "@/client/components/ui";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
 
 const ALL_CATEGORIES_VALUE = "__all__";
@@ -209,130 +210,138 @@ export function CounterpartAssignmentClient({
     });
   };
 
-  if (organizations.length === 0) {
-    return (
-      <Card className="p-4">
-        <p className="text-foreground">
-          政治団体が登録されていません。先に政治団体を作成してください。
-        </p>
-      </Card>
-    );
-  }
-
-  return (
-    <div className="bg-card rounded-xl p-4 space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground mb-1">取引先紐付け管理</h1>
-          <p className="text-muted-foreground">
-            Transactionに対してCounterpart（取引先）を紐付けます
-          </p>
-        </div>
+  const header = (
+    <PageHeader
+      label="Counterpart Assignment"
+      title="取引先紐付け管理"
+      description="Transactionに対してCounterpart（取引先）を紐付けます"
+      actions={
         <Link
           href="/counterparts"
           className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary rounded-lg px-4 py-2.5 font-medium transition-colors duration-200"
         >
           マスタ管理へ
         </Link>
+      }
+    />
+  );
+
+  if (organizations.length === 0) {
+    return (
+      <div>
+        {header}
+        <Card className="p-4">
+          <p className="text-foreground">
+            政治団体が登録されていません。先に政治団体を作成してください。
+          </p>
+        </Card>
       </div>
+    );
+  }
 
-      <Card className="p-4">
-        <div className="flex flex-col md:flex-row md:items-end gap-4">
-          <div className="w-fit">
-            <PoliticalOrganizationSelect
-              organizations={organizations}
-              value={selectedOrganizationId}
-              onValueChange={handleOrganizationChange}
-              required
-            />
+  return (
+    <div>
+      {header}
+
+      <div className="bg-card rounded-xl p-4 space-y-6">
+        <Card className="p-4">
+          <div className="flex flex-col md:flex-row md:items-end gap-4">
+            <div className="w-fit">
+              <PoliticalOrganizationSelect
+                organizations={organizations}
+                value={selectedOrganizationId}
+                onValueChange={handleOrganizationChange}
+                required
+              />
+            </div>
+            <div className="w-fit space-y-2">
+              <Label>報告年 (西暦)</Label>
+              <Input
+                type="number"
+                value={String(financialYear)}
+                onChange={handleYearChange}
+                min={1900}
+                max={2100}
+                required
+                className="w-24"
+              />
+            </div>
           </div>
-          <div className="w-fit space-y-2">
-            <Label>報告年 (西暦)</Label>
-            <Input
-              type="number"
-              value={String(financialYear)}
-              onChange={handleYearChange}
-              min={1900}
-              max={2100}
-              required
-              className="w-24"
-            />
-          </div>
-        </div>
-      </Card>
+        </Card>
 
-      <hr className="border-border" />
+        <hr className="border-border" />
 
-      <CounterpartAssignmentFilters
-        values={{
-          categoryKey,
-          searchQuery,
-          unassignedOnly,
-          counterpartRequiredOnly,
-        }}
-        categoryOptions={categoryOptions}
-        onChange={handleFilterChange}
-      />
-
-      <Card className="p-4">
-        <div className="flex justify-between items-center mb-4">
-          <div className="text-muted-foreground text-sm">
-            {total}件のTransaction
-            {unassignedOnly && " (未紐付けのみ)"}
-          </div>
-          {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
-        </div>
-
-        <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-          <span className="text-foreground text-sm">
-            選択中: <span className="font-medium">{selectedTransactions.length}件</span>
-          </span>
-          <Button
-            type="button"
-            size="sm"
-            onClick={handleBulkAssignClick}
-            disabled={selectedTransactions.length === 0}
-          >
-            一括紐付け
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => setRowSelection({})}
-            disabled={selectedTransactions.length === 0}
-          >
-            選択解除
-          </Button>
-        </div>
-
-        <TransactionWithCounterpartTable
-          transactions={initialTransactions}
-          sortField={sortField}
-          sortOrder={sortOrder}
-          onSortChange={handleSortChange}
-          rowSelection={rowSelection}
-          onRowSelectionChange={setRowSelection}
-          onAssignClick={handleAssignClick}
+        <CounterpartAssignmentFilters
+          values={{
+            categoryKey,
+            searchQuery,
+            unassignedOnly,
+            counterpartRequiredOnly,
+          }}
+          categoryOptions={categoryOptions}
+          onChange={handleFilterChange}
         />
 
-        {totalPages > 1 && (
-          <ClientPagination
-            currentPage={page}
-            totalPages={totalPages}
-            onPageChange={handlePageChange}
-          />
-        )}
-      </Card>
+        <Card className="p-4">
+          <div className="flex justify-between items-center mb-4">
+            <div className="text-muted-foreground text-sm">
+              {total}件のTransaction
+              {unassignedOnly && " (未紐付けのみ)"}
+            </div>
+            {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
+          </div>
 
-      <AssignCounterpartDialog
-        isOpen={isAssignDialogOpen}
-        transactions={assignDialogTransactions}
-        allCounterparts={allCounterparts}
-        politicalOrganizationId={selectedOrganizationId}
-        onClose={handleAssignDialogClose}
-        onSuccess={handleAssignSuccess}
-      />
+          <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
+            <span className="text-foreground text-sm">
+              選択中: <span className="font-medium">{selectedTransactions.length}件</span>
+            </span>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleBulkAssignClick}
+              disabled={selectedTransactions.length === 0}
+            >
+              一括紐付け
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setRowSelection({})}
+              disabled={selectedTransactions.length === 0}
+            >
+              選択解除
+            </Button>
+          </div>
+
+          <TransactionWithCounterpartTable
+            transactions={initialTransactions}
+            sortField={sortField}
+            sortOrder={sortOrder}
+            onSortChange={handleSortChange}
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+            onAssignClick={handleAssignClick}
+          />
+
+          {totalPages > 1 && (
+            <ClientPagination
+              currentPage={page}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </Card>
+
+        <AssignCounterpartDialog
+          isOpen={isAssignDialogOpen}
+          transactions={assignDialogTransactions}
+          allCounterparts={allCounterparts}
+          politicalOrganizationId={selectedOrganizationId}
+          onClose={handleAssignDialogClose}
+          onSuccess={handleAssignSuccess}
+        />
+      </div>
     </div>
   );
 }

--- a/admin/src/client/components/counterparts/CounterpartDetailClient.tsx
+++ b/admin/src/client/components/counterparts/CounterpartDetailClient.tsx
@@ -14,6 +14,7 @@ import type {
 import { TransactionWithCounterpartTable } from "@/client/components/counterpart-assignment/TransactionWithCounterpartTable";
 import { AssignCounterpartDialog } from "@/client/components/counterpart-assignment/AssignCounterpartDialog";
 import { CounterpartFormDialog } from "@/client/components/counterparts/CounterpartFormDialog";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 import { ClientPagination } from "@/client/components/ui/ClientPagination";
 import { Card, Input, Button, Label } from "@/client/components/ui";
 import { formatDate } from "@/client/lib";
@@ -182,8 +183,8 @@ export function CounterpartDetailClient({
   };
 
   return (
-    <div className="bg-card rounded-xl p-4 space-y-6">
-      <div className="flex items-center gap-4">
+    <div>
+      <div className="mb-4">
         <Link
           href="/counterparts"
           className="text-muted-foreground hover:text-foreground transition-colors"
@@ -192,132 +193,136 @@ export function CounterpartDetailClient({
         </Link>
       </div>
 
-      <Card className="p-6">
-        <div className="flex justify-between items-start mb-4">
-          <h2 className="text-lg font-semibold text-foreground">カウンターパート情報</h2>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => setIsEditDialogOpen(true)}
-          >
-            編集
-          </Button>
-        </div>
+      <PageHeader label="Counterparts" title="取引先詳細" />
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <div className="text-muted-foreground text-sm mb-1">名前</div>
-            <div className="text-foreground font-medium">{counterpart.name}</div>
-          </div>
-          <div>
-            <div className="text-muted-foreground text-sm mb-1">住所</div>
-            <div className="text-foreground">{counterpart.address || "-"}</div>
-          </div>
-          <div>
-            <div className="text-muted-foreground text-sm mb-1">作成日</div>
-            <div className="text-foreground">{formatDate(counterpart.createdAt)}</div>
-          </div>
-          <div>
-            <div className="text-muted-foreground text-sm mb-1">更新日</div>
-            <div className="text-foreground">{formatDate(counterpart.updatedAt)}</div>
-          </div>
-          <div>
-            <div className="text-muted-foreground text-sm mb-1">使用回数</div>
-            <div className="text-foreground">{counterpart.usageCount}件</div>
-          </div>
-        </div>
-      </Card>
-
-      <Card className="p-6">
-        <h2 className="text-lg font-semibold text-foreground mb-4">紐づいている取引</h2>
-
-        <div className="flex flex-col md:flex-row md:items-end gap-4 mb-6">
-          <div className="w-fit">
-            <PoliticalOrganizationSelect
-              organizations={organizations}
-              value={selectedOrganizationId}
-              onValueChange={handleOrganizationChange}
-            />
-          </div>
-          <div className="w-fit space-y-2">
-            <Label>報告年 (西暦)</Label>
-            <Input
-              type="number"
-              value={String(financialYear)}
-              onChange={handleYearChange}
-              min={1900}
-              max={2100}
-              required
-              className="w-24"
-            />
-          </div>
-        </div>
-
-        <div className="flex justify-between items-center mb-4">
-          <div className="text-muted-foreground text-sm">{total}件の取引</div>
-          {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
-        </div>
-
-        {selectedTransactions.length > 0 && (
-          <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-            <span className="text-foreground text-sm">
-              選択中: <span className="font-medium">{selectedTransactions.length}件</span>
-            </span>
-            <Button type="button" size="sm" onClick={handleBulkAssignClick}>
-              一括紐付け変更
-            </Button>
+      <div className="bg-card rounded-xl p-4 space-y-6">
+        <Card className="p-6">
+          <div className="flex justify-between items-start mb-4">
+            <h2 className="text-lg font-semibold text-foreground">カウンターパート情報</h2>
             <Button
               type="button"
-              variant="destructive"
+              variant="secondary"
               size="sm"
-              onClick={handleBulkUnassign}
-              disabled={isUnassigning}
+              onClick={() => setIsEditDialogOpen(true)}
             >
-              {isUnassigning ? "処理中..." : "一括紐付け解除"}
-            </Button>
-            <Button type="button" variant="ghost" size="sm" onClick={() => setRowSelection({})}>
-              選択解除
+              編集
             </Button>
           </div>
-        )}
 
-        <TransactionWithCounterpartTable
-          transactions={transactions}
-          sortField={sortField}
-          sortOrder={sortOrder}
-          onSortChange={handleSortChange}
-          rowSelection={rowSelection}
-          onRowSelectionChange={setRowSelection}
-          onAssignClick={handleAssignClick}
-        />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <div className="text-muted-foreground text-sm mb-1">名前</div>
+              <div className="text-foreground font-medium">{counterpart.name}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-sm mb-1">住所</div>
+              <div className="text-foreground">{counterpart.address || "-"}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-sm mb-1">作成日</div>
+              <div className="text-foreground">{formatDate(counterpart.createdAt)}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-sm mb-1">更新日</div>
+              <div className="text-foreground">{formatDate(counterpart.updatedAt)}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground text-sm mb-1">使用回数</div>
+              <div className="text-foreground">{counterpart.usageCount}件</div>
+            </div>
+          </div>
+        </Card>
 
-        {totalPages > 1 && (
-          <ClientPagination
-            currentPage={page}
-            totalPages={totalPages}
-            onPageChange={handlePageChange}
+        <Card className="p-6">
+          <h2 className="text-lg font-semibold text-foreground mb-4">紐づいている取引</h2>
+
+          <div className="flex flex-col md:flex-row md:items-end gap-4 mb-6">
+            <div className="w-fit">
+              <PoliticalOrganizationSelect
+                organizations={organizations}
+                value={selectedOrganizationId}
+                onValueChange={handleOrganizationChange}
+              />
+            </div>
+            <div className="w-fit space-y-2">
+              <Label>報告年 (西暦)</Label>
+              <Input
+                type="number"
+                value={String(financialYear)}
+                onChange={handleYearChange}
+                min={1900}
+                max={2100}
+                required
+                className="w-24"
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-between items-center mb-4">
+            <div className="text-muted-foreground text-sm">{total}件の取引</div>
+            {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
+          </div>
+
+          {selectedTransactions.length > 0 && (
+            <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
+              <span className="text-foreground text-sm">
+                選択中: <span className="font-medium">{selectedTransactions.length}件</span>
+              </span>
+              <Button type="button" size="sm" onClick={handleBulkAssignClick}>
+                一括紐付け変更
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={handleBulkUnassign}
+                disabled={isUnassigning}
+              >
+                {isUnassigning ? "処理中..." : "一括紐付け解除"}
+              </Button>
+              <Button type="button" variant="ghost" size="sm" onClick={() => setRowSelection({})}>
+                選択解除
+              </Button>
+            </div>
+          )}
+
+          <TransactionWithCounterpartTable
+            transactions={transactions}
+            sortField={sortField}
+            sortOrder={sortOrder}
+            onSortChange={handleSortChange}
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+            onAssignClick={handleAssignClick}
+          />
+
+          {totalPages > 1 && (
+            <ClientPagination
+              currentPage={page}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </Card>
+
+        {isEditDialogOpen && (
+          <CounterpartFormDialog
+            mode="edit"
+            counterpart={counterpart}
+            onClose={() => setIsEditDialogOpen(false)}
+            onSuccess={handleEditSuccess}
           />
         )}
-      </Card>
 
-      {isEditDialogOpen && (
-        <CounterpartFormDialog
-          mode="edit"
-          counterpart={counterpart}
-          onClose={() => setIsEditDialogOpen(false)}
-          onSuccess={handleEditSuccess}
+        <AssignCounterpartDialog
+          isOpen={isAssignDialogOpen}
+          transactions={assignDialogTransactions}
+          allCounterparts={allCounterparts}
+          politicalOrganizationId={selectedOrganizationId || organizations[0]?.id || ""}
+          onClose={handleAssignDialogClose}
+          onSuccess={handleAssignSuccess}
         />
-      )}
-
-      <AssignCounterpartDialog
-        isOpen={isAssignDialogOpen}
-        transactions={assignDialogTransactions}
-        allCounterparts={allCounterparts}
-        politicalOrganizationId={selectedOrganizationId || organizations[0]?.id || ""}
-        onClose={handleAssignDialogClose}
-        onSuccess={handleAssignSuccess}
-      />
+      </div>
     </div>
   );
 }

--- a/admin/src/client/components/counterparts/CounterpartMasterClient.tsx
+++ b/admin/src/client/components/counterparts/CounterpartMasterClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import type { CounterpartWithUsage } from "@/server/contexts/report/domain/models/counterpart";
 import { CounterpartTable } from "@/client/components/counterparts/CounterpartTable";
 import { CounterpartFormDialog } from "@/client/components/counterparts/CounterpartFormDialog";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 
 interface CounterpartMasterClientProps {
   initialCounterparts: CounterpartWithUsage[];
@@ -52,98 +53,103 @@ export function CounterpartMasterClient({
   };
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-foreground">取引先マスタ管理</h1>
-        <button
-          type="button"
-          onClick={() => setIsCreateDialogOpen(true)}
-          className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium hover:bg-primary-hover transition-colors duration-200 cursor-pointer"
-        >
-          新規作成
-        </button>
-      </div>
-
-      <form onSubmit={handleSearch} className="mb-6">
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            placeholder="名前または住所で検索..."
-            aria-label="取引先を名前または住所で検索"
-            className="bg-input text-foreground border border-border rounded-lg px-3 py-2.5 flex-1 max-w-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary"
-          />
+    <div>
+      <PageHeader
+        label="Counterparts"
+        title="取引先マスタ管理"
+        actions={
           <button
-            type="submit"
-            className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
+            type="button"
+            onClick={() => setIsCreateDialogOpen(true)}
+            className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium hover:bg-primary-hover transition-colors duration-200 cursor-pointer"
           >
-            検索
+            新規作成
           </button>
-          {searchQuery && (
+        }
+      />
+
+      <div className="bg-card rounded-xl p-4">
+        <form onSubmit={handleSearch} className="mb-6">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              placeholder="名前または住所で検索..."
+              aria-label="取引先を名前または住所で検索"
+              className="bg-input text-foreground border border-border rounded-lg px-3 py-2.5 flex-1 max-w-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary"
+            />
             <button
-              type="button"
-              onClick={() => {
-                setSearchInput("");
-                router.push("/counterparts");
-              }}
+              type="submit"
               className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
             >
-              クリア
+              検索
             </button>
-          )}
-        </div>
-      </form>
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchInput("");
+                  router.push("/counterparts");
+                }}
+                className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
+              >
+                クリア
+              </button>
+            )}
+          </div>
+        </form>
 
-      <div className="text-muted-foreground text-sm mb-4">
-        {total}件の取引先
-        {searchQuery && <span> (検索: &quot;{searchQuery}&quot;)</span>}
+        <div className="text-muted-foreground text-sm mb-4">
+          {total}件の取引先
+          {searchQuery && <span> (検索: &quot;{searchQuery}&quot;)</span>}
+        </div>
+
+        <CounterpartTable counterparts={initialCounterparts} onUpdate={handleUpdate} />
+
+        {totalPages > 1 && (
+          <div className="flex justify-center items-center gap-2 mt-6">
+            <button
+              type="button"
+              onClick={() => handlePageChange(page - 1)}
+              disabled={page <= 1}
+              aria-label="前のページへ"
+              className={`bg-secondary text-secondary-foreground border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
+                page <= 1 ? "opacity-50 cursor-not-allowed" : "hover:bg-secondary/80 cursor-pointer"
+              }`}
+            >
+              前へ
+            </button>
+            <span className="text-foreground px-4">
+              {page} / {totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={() => handlePageChange(page + 1)}
+              disabled={page >= totalPages}
+              aria-label="次のページへ"
+              className={`bg-secondary text-secondary-foreground border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
+                page >= totalPages
+                  ? "opacity-50 cursor-not-allowed"
+                  : "hover:bg-secondary/80 cursor-pointer"
+              }`}
+            >
+              次へ
+            </button>
+          </div>
+        )}
+
+        {isCreateDialogOpen && (
+          <CounterpartFormDialog
+            mode="create"
+            onClose={() => setIsCreateDialogOpen(false)}
+            onSuccess={() => {
+              setIsCreateDialogOpen(false);
+              handleUpdate();
+            }}
+          />
+        )}
       </div>
-
-      <CounterpartTable counterparts={initialCounterparts} onUpdate={handleUpdate} />
-
-      {totalPages > 1 && (
-        <div className="flex justify-center items-center gap-2 mt-6">
-          <button
-            type="button"
-            onClick={() => handlePageChange(page - 1)}
-            disabled={page <= 1}
-            aria-label="前のページへ"
-            className={`bg-secondary text-secondary-foreground border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
-              page <= 1 ? "opacity-50 cursor-not-allowed" : "hover:bg-secondary/80 cursor-pointer"
-            }`}
-          >
-            前へ
-          </button>
-          <span className="text-foreground px-4">
-            {page} / {totalPages}
-          </span>
-          <button
-            type="button"
-            onClick={() => handlePageChange(page + 1)}
-            disabled={page >= totalPages}
-            aria-label="次のページへ"
-            className={`bg-secondary text-secondary-foreground border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
-              page >= totalPages
-                ? "opacity-50 cursor-not-allowed"
-                : "hover:bg-secondary/80 cursor-pointer"
-            }`}
-          >
-            次へ
-          </button>
-        </div>
-      )}
-
-      {isCreateDialogOpen && (
-        <CounterpartFormDialog
-          mode="create"
-          onClose={() => setIsCreateDialogOpen(false)}
-          onSuccess={() => {
-            setIsCreateDialogOpen(false);
-            handleUpdate();
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
@@ -13,6 +13,7 @@ import { AssignDonorDialog } from "./AssignDonorDialog";
 import { DonorAssignmentFilters, type DonorAssignmentFilterValues } from "./DonorAssignmentFilters";
 import { ClientPagination } from "@/client/components/ui/ClientPagination";
 import { Card, Input, Button, Label } from "@/client/components/ui";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
 
 const ALL_CATEGORIES_VALUE = "__all__";
@@ -194,123 +195,133 @@ export function DonorAssignmentClient({
     });
   };
 
+  const header = (
+    <PageHeader
+      label="Donor Assignment"
+      title="寄付者紐付け管理"
+      description="Transactionに対してDonor（寄付者）を紐付けます"
+      actions={
+        <Button asChild variant="outline">
+          <Link href="/import-donors">CSV一括登録</Link>
+        </Button>
+      }
+    />
+  );
+
   if (organizations.length === 0) {
     return (
-      <Card className="p-4">
-        <p className="text-foreground">
-          政治団体が登録されていません。先に政治団体を作成してください。
-        </p>
-      </Card>
+      <div>
+        {header}
+        <Card className="p-4">
+          <p className="text-foreground">
+            政治団体が登録されていません。先に政治団体を作成してください。
+          </p>
+        </Card>
+      </div>
     );
   }
 
   return (
-    <div className="bg-card rounded-xl p-4 space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground mb-1">寄付者紐付け管理</h1>
-          <p className="text-muted-foreground">Transactionに対してDonor（寄付者）を紐付けます</p>
-        </div>
-        <Button asChild variant="outline">
-          <Link href="/import-donors">CSV一括登録</Link>
-        </Button>
-      </div>
+    <div>
+      {header}
 
-      <Card className="p-4">
-        <div className="flex flex-col md:flex-row md:items-end gap-4">
-          <div className="w-fit">
-            <PoliticalOrganizationSelect
-              organizations={organizations}
-              value={selectedOrganizationId}
-              onValueChange={handleOrganizationChange}
-              required
-            />
+      <div className="bg-card rounded-xl p-4 space-y-6">
+        <Card className="p-4">
+          <div className="flex flex-col md:flex-row md:items-end gap-4">
+            <div className="w-fit">
+              <PoliticalOrganizationSelect
+                organizations={organizations}
+                value={selectedOrganizationId}
+                onValueChange={handleOrganizationChange}
+                required
+              />
+            </div>
+            <div className="w-fit space-y-2">
+              <Label>報告年 (西暦)</Label>
+              <Input
+                type="number"
+                value={String(financialYear)}
+                onChange={handleYearChange}
+                min={1900}
+                max={2100}
+                required
+                className="w-24"
+              />
+            </div>
           </div>
-          <div className="w-fit space-y-2">
-            <Label>報告年 (西暦)</Label>
-            <Input
-              type="number"
-              value={String(financialYear)}
-              onChange={handleYearChange}
-              min={1900}
-              max={2100}
-              required
-              className="w-24"
-            />
-          </div>
-        </div>
-      </Card>
+        </Card>
 
-      <hr className="border-border" />
+        <hr className="border-border" />
 
-      <DonorAssignmentFilters
-        values={{
-          categoryKey,
-          searchQuery,
-          unassignedOnly,
-        }}
-        categoryOptions={categoryOptions}
-        onChange={handleFilterChange}
-      />
-
-      <Card className="p-4">
-        <div className="flex justify-between items-center mb-4">
-          <div className="text-muted-foreground text-sm">
-            {total}件のTransaction
-            {unassignedOnly && " (未紐付けのみ)"}
-          </div>
-          {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
-        </div>
-
-        <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-          <span className="text-foreground text-sm">
-            選択中: <span className="font-medium">{selectedTransactions.length}件</span>
-          </span>
-          <Button
-            type="button"
-            size="sm"
-            onClick={handleBulkAssignClick}
-            disabled={selectedTransactions.length === 0}
-          >
-            一括紐付け
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => setRowSelection({})}
-            disabled={selectedTransactions.length === 0}
-          >
-            選択解除
-          </Button>
-        </div>
-
-        <TransactionWithDonorTable
-          transactions={initialTransactions}
-          sortField={sortField}
-          sortOrder={sortOrder}
-          onSortChange={handleSortChange}
-          rowSelection={rowSelection}
-          onRowSelectionChange={setRowSelection}
-          onAssignClick={handleAssignClick}
+        <DonorAssignmentFilters
+          values={{
+            categoryKey,
+            searchQuery,
+            unassignedOnly,
+          }}
+          categoryOptions={categoryOptions}
+          onChange={handleFilterChange}
         />
 
-        {totalPages > 1 && (
-          <ClientPagination
-            currentPage={page}
-            totalPages={totalPages}
-            onPageChange={handlePageChange}
-          />
-        )}
-      </Card>
+        <Card className="p-4">
+          <div className="flex justify-between items-center mb-4">
+            <div className="text-muted-foreground text-sm">
+              {total}件のTransaction
+              {unassignedOnly && " (未紐付けのみ)"}
+            </div>
+            {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
+          </div>
 
-      <AssignDonorDialog
-        isOpen={isAssignDialogOpen}
-        transactions={assignDialogTransactions}
-        allDonors={allDonors}
-        onClose={handleAssignDialogClose}
-        onSuccess={handleAssignSuccess}
-      />
+          <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
+            <span className="text-foreground text-sm">
+              選択中: <span className="font-medium">{selectedTransactions.length}件</span>
+            </span>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleBulkAssignClick}
+              disabled={selectedTransactions.length === 0}
+            >
+              一括紐付け
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setRowSelection({})}
+              disabled={selectedTransactions.length === 0}
+            >
+              選択解除
+            </Button>
+          </div>
+
+          <TransactionWithDonorTable
+            transactions={initialTransactions}
+            sortField={sortField}
+            sortOrder={sortOrder}
+            onSortChange={handleSortChange}
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+            onAssignClick={handleAssignClick}
+          />
+
+          {totalPages > 1 && (
+            <ClientPagination
+              currentPage={page}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          )}
+        </Card>
+
+        <AssignDonorDialog
+          isOpen={isAssignDialogOpen}
+          transactions={assignDialogTransactions}
+          allDonors={allDonors}
+          onClose={handleAssignDialogClose}
+          onSuccess={handleAssignSuccess}
+        />
+      </div>
     </div>
   );
 }

--- a/admin/src/client/components/donors/DonorMasterClient.tsx
+++ b/admin/src/client/components/donors/DonorMasterClient.tsx
@@ -7,6 +7,7 @@ import type { DonorWithUsage, DonorType } from "@/server/contexts/report/domain/
 import { DONOR_TYPE_LABELS, VALID_DONOR_TYPES } from "@/server/contexts/report/domain/models/donor";
 import { DonorTable } from "@/client/components/donors/DonorTable";
 import { DonorFormDialog } from "@/client/components/donors/DonorFormDialog";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 import {
   Button,
   Input,
@@ -105,97 +106,104 @@ export function DonorMasterClient({
   };
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-foreground">寄付者マスタ管理</h1>
-        <Button type="button" onClick={() => setIsCreateDialogOpen(true)}>
-          新規作成
-        </Button>
-      </div>
-
-      <form onSubmit={handleSearch} className="mb-6">
-        <div className="flex gap-2 flex-wrap">
-          <Input
-            type="text"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            placeholder="名前・住所・職業で検索..."
-            aria-label="寄付者を名前・住所・職業で検索"
-            className="flex-1 min-w-[200px] max-w-md"
-          />
-          <Select
-            value={selectedType}
-            onValueChange={(value) => handleTypeChange(value as DonorType | typeof ALL_TYPES_VALUE)}
-          >
-            <SelectTrigger className="w-[160px]" aria-label="寄付者種別でフィルタ">
-              <SelectValue placeholder="すべての種別" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL_TYPES_VALUE}>すべての種別</SelectItem>
-              {VALID_DONOR_TYPES.map((type) => (
-                <SelectItem key={type} value={type}>
-                  {DONOR_TYPE_LABELS[type]}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button type="submit" variant="secondary">
-            検索
+    <div>
+      <PageHeader
+        label="Donors"
+        title="寄付者マスタ管理"
+        actions={
+          <Button type="button" onClick={() => setIsCreateDialogOpen(true)}>
+            新規作成
           </Button>
-          {(searchQuery || donorType) && (
-            <Button type="button" variant="secondary" onClick={handleClear}>
-              クリア
+        }
+      />
+
+      <div className="bg-card rounded-xl p-4">
+        <form onSubmit={handleSearch} className="mb-6">
+          <div className="flex gap-2 flex-wrap">
+            <Input
+              type="text"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              placeholder="名前・住所・職業で検索..."
+              aria-label="寄付者を名前・住所・職業で検索"
+              className="flex-1 min-w-[200px] max-w-md"
+            />
+            <Select
+              value={selectedType}
+              onValueChange={(value) =>
+                handleTypeChange(value as DonorType | typeof ALL_TYPES_VALUE)
+              }
+            >
+              <SelectTrigger className="w-[160px]" aria-label="寄付者種別でフィルタ">
+                <SelectValue placeholder="すべての種別" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_TYPES_VALUE}>すべての種別</SelectItem>
+                {VALID_DONOR_TYPES.map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {DONOR_TYPE_LABELS[type]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button type="submit" variant="secondary">
+              検索
             </Button>
-          )}
-        </div>
-      </form>
+            {(searchQuery || donorType) && (
+              <Button type="button" variant="secondary" onClick={handleClear}>
+                クリア
+              </Button>
+            )}
+          </div>
+        </form>
 
-      <div className="text-muted-foreground text-sm mb-4">
-        {total}件の寄付者
-        {searchQuery && <span> (検索: &quot;{searchQuery}&quot;)</span>}
-        {donorType && <span> (種別: {DONOR_TYPE_LABELS[donorType]})</span>}
+        <div className="text-muted-foreground text-sm mb-4">
+          {total}件の寄付者
+          {searchQuery && <span> (検索: &quot;{searchQuery}&quot;)</span>}
+          {donorType && <span> (種別: {DONOR_TYPE_LABELS[donorType]})</span>}
+        </div>
+
+        <DonorTable donors={initialDonors} onUpdate={handleUpdate} />
+
+        {totalPages > 1 && (
+          <div className="flex justify-center items-center gap-2 mt-6">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => handlePageChange(page - 1)}
+              disabled={page <= 1}
+              aria-label="前のページへ"
+            >
+              前へ
+            </Button>
+            <span className="text-foreground px-4">
+              {page} / {totalPages}
+            </span>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => handlePageChange(page + 1)}
+              disabled={page >= totalPages}
+              aria-label="次のページへ"
+            >
+              次へ
+            </Button>
+          </div>
+        )}
+
+        {isCreateDialogOpen && (
+          <DonorFormDialog
+            mode="create"
+            onClose={() => setIsCreateDialogOpen(false)}
+            onSuccess={() => {
+              setIsCreateDialogOpen(false);
+              handleUpdate();
+            }}
+          />
+        )}
       </div>
-
-      <DonorTable donors={initialDonors} onUpdate={handleUpdate} />
-
-      {totalPages > 1 && (
-        <div className="flex justify-center items-center gap-2 mt-6">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => handlePageChange(page - 1)}
-            disabled={page <= 1}
-            aria-label="前のページへ"
-          >
-            前へ
-          </Button>
-          <span className="text-foreground px-4">
-            {page} / {totalPages}
-          </span>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => handlePageChange(page + 1)}
-            disabled={page >= totalPages}
-            aria-label="次のページへ"
-          >
-            次へ
-          </Button>
-        </div>
-      )}
-
-      {isCreateDialogOpen && (
-        <DonorFormDialog
-          mode="create"
-          onClose={() => setIsCreateDialogOpen(false)}
-          onSuccess={() => {
-            setIsCreateDialogOpen(false);
-            handleUpdate();
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/admin/src/client/components/layout/PageHeader.tsx
+++ b/admin/src/client/components/layout/PageHeader.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { cn } from "@/client/lib";
+
+interface PageHeaderProps {
+  /** 英字ラベル（Poppins）。例: "Transactions" */
+  label: string;
+  /** h1 見出し。例: "取引一覧" */
+  title: ReactNode;
+  /** 見出し下の補足文 */
+  description?: ReactNode;
+  /** 見出し右側に置くアクション（新規作成ボタンなど） */
+  actions?: ReactNode;
+  className?: string;
+}
+
+/**
+ * 認証後の全画面で使うページヘッダー。
+ * 英字ラベル + teal-soft 下線付き h1 の構成はデザインハンドオフ
+ * （docs/reference/design_handoff_admin_redesign/README.md）が正。
+ * コンテンツカードの外（ページ背景の上）に置く。
+ */
+export function PageHeader({ label, title, description, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn("mb-6 flex flex-wrap items-end justify-between gap-4", className)}>
+      <div>
+        <p className="font-latin text-[13px] font-semibold tracking-[0.1em] text-primary-hover">
+          {label}
+        </p>
+        <h1 className="mt-0.5 text-[26px] font-bold leading-[1.4] tracking-[0.06em] text-foreground">
+          <span className="underline decoration-teal-soft decoration-[3px] underline-offset-[6px]">
+            {title}
+          </span>
+        </h1>
+        {description && <p className="mt-2 text-sm text-muted-foreground">{description}</p>}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/admin/src/client/components/political-organizations/PoliticalOrganizationForm.tsx
+++ b/admin/src/client/components/political-organizations/PoliticalOrganizationForm.tsx
@@ -4,16 +4,7 @@ import "client-only";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import {
-  Button,
-  Input,
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  Label,
-  Textarea,
-} from "@/client/components/ui";
+import { Button, Input, Card, CardContent, Label, Textarea } from "@/client/components/ui";
 
 interface PoliticalOrganizationFormData {
   displayName: string;
@@ -26,14 +17,12 @@ interface PoliticalOrganizationFormProps {
   initialData?: Partial<PoliticalOrganizationFormData>;
   onSubmit: (data: PoliticalOrganizationFormData) => Promise<{ success: boolean }>;
   submitButtonText: string;
-  title: string;
 }
 
 export function PoliticalOrganizationForm({
   initialData = { displayName: "", orgName: "", slug: "", description: "" },
   onSubmit,
   submitButtonText,
-  title,
 }: PoliticalOrganizationFormProps) {
   const router = useRouter();
   const [formData, setFormData] = useState<PoliticalOrganizationFormData>({
@@ -73,17 +62,6 @@ export function PoliticalOrganizationForm({
 
   return (
     <Card>
-      <CardHeader>
-        <div className="mb-2">
-          <Link
-            href="/political-organizations"
-            className="text-muted-foreground no-underline hover:text-foreground transition-colors"
-          >
-            ← 政治団体一覧に戻る
-          </Link>
-        </div>
-        <CardTitle className="text-2xl">{title}</CardTitle>
-      </CardHeader>
       <CardContent>
         {error && (
           <div className="text-destructive mb-4 p-3 bg-destructive/10 rounded-lg border border-destructive/30">

--- a/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
+++ b/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 import {
   Button,
   Card,
@@ -82,137 +83,139 @@ export function BulkDeleteTransactionsClient({
   };
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold">取引一括削除</h1>
+    <div>
+      <PageHeader label="Bulk Delete" title="取引一括削除" />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>検索条件</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <PoliticalOrganizationSelect
-            organizations={organizations}
-            value={selectedOrgId}
-            onValueChange={(value) => {
-              setSelectedOrgId(value);
-              setSearchResult(null);
-            }}
-            required
-          />
-
-          <div className="space-y-2">
-            <Label>取引番号（カンマ区切り）</Label>
-            <Input
-              placeholder="例: 1,5,8,20"
-              value={transactionNosInput}
-              onChange={(e) => setTransactionNosInput(e.target.value)}
-            />
-          </div>
-
-          <Button
-            onClick={handleSearch}
-            disabled={!selectedOrgId || !transactionNosInput.trim() || isSearching}
-          >
-            {isSearching ? "検索中..." : "検索"}
-          </Button>
-        </CardContent>
-      </Card>
-
-      {searchResult && !searchResult.success && (
+      <div className="space-y-6">
         <Card>
-          <CardContent className="pt-6">
-            <p className="text-red-600 font-medium">エラー: {searchResult.error}</p>
+          <CardHeader>
+            <CardTitle>検索条件</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <PoliticalOrganizationSelect
+              organizations={organizations}
+              value={selectedOrgId}
+              onValueChange={(value) => {
+                setSelectedOrgId(value);
+                setSearchResult(null);
+              }}
+              required
+            />
+
+            <div className="space-y-2">
+              <Label>取引番号（カンマ区切り）</Label>
+              <Input
+                placeholder="例: 1,5,8,20"
+                value={transactionNosInput}
+                onChange={(e) => setTransactionNosInput(e.target.value)}
+              />
+            </div>
+
+            <Button
+              onClick={handleSearch}
+              disabled={!selectedOrgId || !transactionNosInput.trim() || isSearching}
+            >
+              {isSearching ? "検索中..." : "検索"}
+            </Button>
           </CardContent>
         </Card>
-      )}
 
-      {searchResult?.success && (
-        <>
-          {searchResult.notFoundNos && searchResult.notFoundNos.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-amber-600">
-                  該当なし ({searchResult.notFoundNos.length}件)
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground">
-                  以下の取引番号は見つかりませんでした:{" "}
-                  <span className="font-mono">{searchResult.notFoundNos.join(", ")}</span>
-                </p>
-              </CardContent>
-            </Card>
-          )}
+        {searchResult && !searchResult.success && (
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-red-600 font-medium">エラー: {searchResult.error}</p>
+            </CardContent>
+          </Card>
+        )}
 
-          {searchResult.foundTransactions && searchResult.foundTransactions.length > 0 && (
-            <Card>
-              <CardHeader className="flex flex-row items-center justify-between">
-                <CardTitle>削除対象 ({searchResult.foundTransactions.length}件)</CardTitle>
-                <Button variant="destructive" onClick={() => setShowConfirmDialog(true)}>
-                  削除
-                </Button>
-              </CardHeader>
-              <CardContent>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>取引番号</TableHead>
-                      <TableHead>取引日</TableHead>
-                      <TableHead>摘要</TableHead>
-                      <TableHead className="text-right">借方金額</TableHead>
-                      <TableHead className="text-right">貸方金額</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {searchResult.foundTransactions.map((t) => (
-                      <TableRow key={t.id}>
-                        <TableCell className="font-mono">{t.transactionNo}</TableCell>
-                        <TableCell>{t.transactionDate}</TableCell>
-                        <TableCell>{t.description}</TableCell>
-                        <TableCell className="text-right">
-                          {t.debitAmount.toLocaleString()}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          {t.creditAmount.toLocaleString()}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </CardContent>
-            </Card>
-          )}
-
-          {searchResult.foundTransactions?.length === 0 &&
-            searchResult.notFoundNos?.length === 0 && (
+        {searchResult?.success && (
+          <>
+            {searchResult.notFoundNos && searchResult.notFoundNos.length > 0 && (
               <Card>
-                <CardContent className="pt-6">
-                  <p className="text-muted-foreground">該当する取引はありません。</p>
+                <CardHeader>
+                  <CardTitle className="text-amber-600">
+                    該当なし ({searchResult.notFoundNos.length}件)
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-muted-foreground">
+                    以下の取引番号は見つかりませんでした:{" "}
+                    <span className="font-mono">{searchResult.notFoundNos.join(", ")}</span>
+                  </p>
                 </CardContent>
               </Card>
             )}
-        </>
-      )}
 
-      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>取引の一括削除</DialogTitle>
-            <DialogDescription>
-              {searchResult?.foundTransactions?.length}
-              件の取引を削除します。この操作は取り消せません。
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setShowConfirmDialog(false)}>
-              キャンセル
-            </Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
-              {isDeleting ? "削除中..." : "削除する"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            {searchResult.foundTransactions && searchResult.foundTransactions.length > 0 && (
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between">
+                  <CardTitle>削除対象 ({searchResult.foundTransactions.length}件)</CardTitle>
+                  <Button variant="destructive" onClick={() => setShowConfirmDialog(true)}>
+                    削除
+                  </Button>
+                </CardHeader>
+                <CardContent>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>取引番号</TableHead>
+                        <TableHead>取引日</TableHead>
+                        <TableHead>摘要</TableHead>
+                        <TableHead className="text-right">借方金額</TableHead>
+                        <TableHead className="text-right">貸方金額</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {searchResult.foundTransactions.map((t) => (
+                        <TableRow key={t.id}>
+                          <TableCell className="font-mono">{t.transactionNo}</TableCell>
+                          <TableCell>{t.transactionDate}</TableCell>
+                          <TableCell>{t.description}</TableCell>
+                          <TableCell className="text-right">
+                            {t.debitAmount.toLocaleString()}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {t.creditAmount.toLocaleString()}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+            )}
+
+            {searchResult.foundTransactions?.length === 0 &&
+              searchResult.notFoundNos?.length === 0 && (
+                <Card>
+                  <CardContent className="pt-6">
+                    <p className="text-muted-foreground">該当する取引はありません。</p>
+                  </CardContent>
+                </Card>
+              )}
+          </>
+        )}
+
+        <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>取引の一括削除</DialogTitle>
+              <DialogDescription>
+                {searchResult?.foundTransactions?.length}
+                件の取引を削除します。この操作は取り消せません。
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setShowConfirmDialog(false)}>
+                キャンセル
+              </Button>
+              <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
+                {isDeleting ? "削除中..." : "削除する"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
     </div>
   );
 }

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -7,6 +7,7 @@ import { StaticPagination } from "@/client/components/ui/StaticPagination";
 import { DeleteAllButton } from "./DeleteAllButton";
 import { ClearWebappCacheButton } from "./ClearWebappCacheButton";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
+import { PageHeader } from "@/client/components/layout/PageHeader";
 import type { GetTransactionsResult } from "@/server/contexts/data-import/presentation/types";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 
@@ -86,10 +87,10 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
   };
 
   return (
-    <div className="bg-card rounded-xl p-4">
-      <div className="mb-4">
-        <h1 className="text-2xl font-bold text-foreground mb-4">取引一覧</h1>
+    <div>
+      <PageHeader label="Transactions" title="取引一覧" />
 
+      <div className="bg-card rounded-xl p-4">
         {/* Organization Filter */}
         <div className="mb-4">
           <PoliticalOrganizationSelect
@@ -98,113 +99,113 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
             onValueChange={handleOrgFilterChange}
           />
         </div>
-      </div>
 
-      {!loading && data && (
-        <div className="flex justify-between items-center mt-5 mb-4">
-          <p className="text-muted-foreground">
-            全 {data.total} 件中 {(data.page - 1) * data.perPage + 1} -{" "}
-            {Math.min(data.page * data.perPage, data.total)} 件を表示
-          </p>
-          <div className="flex gap-2">
-            <ClearWebappCacheButton />
-            <DeleteAllButton
-              disabled={data.total === 0}
-              organizationId={selectedOrgId || undefined}
-              onDeleted={() => {
-                // データを再取得
-                window.location.reload();
-              }}
+        {!loading && data && (
+          <div className="flex justify-between items-center mt-5 mb-4">
+            <p className="text-muted-foreground">
+              全 {data.total} 件中 {(data.page - 1) * data.perPage + 1} -{" "}
+              {Math.min(data.page * data.perPage, data.total)} 件を表示
+            </p>
+            <div className="flex gap-2">
+              <ClearWebappCacheButton />
+              <DeleteAllButton
+                disabled={data.total === 0}
+                organizationId={selectedOrgId || undefined}
+                onDeleted={() => {
+                  // データを再取得
+                  window.location.reload();
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {fetching && (
+          <div className="text-center py-2 mb-4">
+            <div className="flex items-center justify-center gap-2">
+              <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
+              <p className="text-muted-foreground text-sm">取得中...</p>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-center py-10">
+            <p className="text-muted-foreground">読み込み中...</p>
+          </div>
+        ) : error ? (
+          <div className="text-center py-10">
+            <p className="text-red-500">エラー: {error}</p>
+          </div>
+        ) : !data ? (
+          <div className="text-center py-10">
+            <p className="text-muted-foreground">データがありません</p>
+          </div>
+        ) : data.transactions.length === 0 ? (
+          <div className="text-center py-10">
+            <p className="text-muted-foreground">トランザクションが登録されていません</p>
+          </div>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                      取引No
+                    </th>
+                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                      取引日
+                    </th>
+                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                      政治団体
+                    </th>
+                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                      借方勘定科目
+                    </th>
+                    <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
+                      借方金額
+                    </th>
+                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                      貸方勘定科目
+                    </th>
+                    <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
+                      貸方金額
+                    </th>
+                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                      種別
+                    </th>
+                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                      カテゴリ
+                    </th>
+                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
+                      摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
+                    </th>
+                    <th className="px-2 py-3 text-center text-sm font-semibold text-foreground w-16">
+                      操作
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.transactions.map((transaction) => (
+                    <TransactionRow
+                      key={transaction.id}
+                      transaction={transaction}
+                      onDeleted={() => fetchTransactions(selectedOrgId)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <StaticPagination
+              currentPage={data.page}
+              totalPages={data.totalPages}
+              basePath="/transactions"
             />
-          </div>
-        </div>
-      )}
-
-      {fetching && (
-        <div className="text-center py-2 mb-4">
-          <div className="flex items-center justify-center gap-2">
-            <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
-            <p className="text-muted-foreground text-sm">取得中...</p>
-          </div>
-        </div>
-      )}
-
-      {loading ? (
-        <div className="text-center py-10">
-          <p className="text-muted-foreground">読み込み中...</p>
-        </div>
-      ) : error ? (
-        <div className="text-center py-10">
-          <p className="text-red-500">エラー: {error}</p>
-        </div>
-      ) : !data ? (
-        <div className="text-center py-10">
-          <p className="text-muted-foreground">データがありません</p>
-        </div>
-      ) : data.transactions.length === 0 ? (
-        <div className="text-center py-10">
-          <p className="text-muted-foreground">トランザクションが登録されていません</p>
-        </div>
-      ) : (
-        <>
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse">
-              <thead>
-                <tr className="border-b border-border">
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                    取引No
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                    取引日
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                    政治団体
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                    借方勘定科目
-                  </th>
-                  <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
-                    借方金額
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                    貸方勘定科目
-                  </th>
-                  <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
-                    貸方金額
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                    種別
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                    カテゴリ
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                    摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
-                  </th>
-                  <th className="px-2 py-3 text-center text-sm font-semibold text-foreground w-16">
-                    操作
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.transactions.map((transaction) => (
-                  <TransactionRow
-                    key={transaction.id}
-                    transaction={transaction}
-                    onDeleted={() => fetchTransactions(selectedOrgId)}
-                  />
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <StaticPagination
-            currentPage={data.page}
-            totalPages={data.totalPages}
-            basePath="/transactions"
-          />
-        </>
-      )}
+          </>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 目的（Why）

admin リデザイン（土台 #1289 / #1312）を利用する運用者が、画面ごとにばらついた見出し（`text-2xl font-bold` の直書き h1 や素の `<h1>`）を見ている状態を解消するため。デザインハンドオフの「英字ラベル + teal-soft 下線付き h1」のページヘッダーを共通コンポーネント化し、認証後の全画面に適用する。後続の画面別リデザイン Issue（#1292〜#1299）はこのヘッダーを前提にできる。

## 変更内容

- `admin/src/client/components/layout/PageHeader.tsx` を追加
  - 英字ラベル: Poppins（`font-latin`）13px / 600 / letter-spacing 0.1em / `#089781`（`text-primary-hover`）
  - h1: 26px / 700 / letter-spacing 0.06em、`#64D8C6`（`decoration-teal-soft`）の 3px 下線 offset 6px
  - `description`（補足文）と `actions`（右側のボタン等）を受け取れる
  - モックどおりコンテンツカードの**外**（ページ背景の上）に置く構成
- 認証後の全画面に適用（ダッシュボード / ユーザー情報 / 政治団体一覧・新規作成・編集・報告書プロフィール / ユーザー管理 / 取引一覧 / 取引一括削除 / CSV アップロード / 寄付者一括インポート / 残高登録 / 取引先マスタ・取引先詳細 / 取引先紐付け / 寄付者マスタ / 寄付者紐付け / 報告書エクスポート）
  - モックにある画面はそのラベル（Transactions / Organizations / Counterparts / Data Import）、それ以外は画面名に対応する英語ラベル
- `PoliticalOrganizationForm` から `title` と戻るリンクを外し、ページ側の PageHeader + 戻るリンクに移す
- ダッシュボードの見出しを「Welcome」→ 英字ラベル「Dashboard」+「ダッシュボード」に変更し、E2E（dashboard / login）を更新
- admin 内に直書きの h1 は残っていない（`grep "<h1"` は PageHeader のみ）

見出し以外（カード・テーブル・ボタン）のスタイルは画面別 Issue の範囲なので触っていない。

Closes #1291

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ pass
- admin E2E（`playwright test --workers=1`）: ✅ 40 passed

## スコープアウトして起票した Issue

- #1315 test(admin): jest の roots が tests/ のみで src/ 配下の *.test.ts が実行されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 各管理画面に共通のページヘッダーを導入し、タイトル、説明、操作ボタンを統一表示。
  * 政治団体、寄付者、取引先、ユーザー、データ入出力などの画面レイアウトを整理し、カード形式で見やすく改善。
  * 一部の編集・作成画面に一覧へ戻る導線を追加。

* **テスト**
  * ログイン後のダッシュボード見出し検証を、実際の表示に合わせて「ダッシュボード」に更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->