### PR TITLE
feat(admin): 取引一覧画面をリデザインし、カテゴリピルを webapp と同じ表示ルールにする

### DIFF
--- a/admin/src/client/components/csv-import/TransactionRow.tsx
+++ b/admin/src/client/components/csv-import/TransactionRow.tsx
@@ -2,86 +2,13 @@
 import "client-only";
 
 import type { PreviewTransaction } from "@/server/contexts/data-import/domain/models/preview-transaction";
-import { PL_CATEGORIES } from "@/shared/accounting/account-category";
-import type { TransactionType } from "@/shared/models/transaction";
+import { CategoryPill } from "@/client/components/transactions/CategoryPill";
 
 interface TransactionRowProps {
   record: PreviewTransaction;
   index: number;
   currentPage: number;
   perPage: number;
-}
-
-const DEFAULT_CATEGORY_COLOR = "#64748B"; // slate-500 as default fallback color
-
-function getCategoryInfoByAccount(accountName: string) {
-  return PL_CATEGORIES[accountName];
-}
-
-function getCategoryColor(accountName: string): string {
-  const categoryInfo = getCategoryInfoByAccount(accountName);
-  return categoryInfo?.color || DEFAULT_CATEGORY_COLOR;
-}
-
-function getCategoryLabel(accountName: string): string {
-  const categoryInfo = getCategoryInfoByAccount(accountName);
-  return categoryInfo?.shortLabel || accountName;
-}
-
-function getTransactionCategory(record: PreviewTransaction): {
-  account: string;
-  color: string;
-  label: string;
-  type: TransactionType | "unknown";
-} {
-  // non_cash_journal取引の場合はカテゴリを表示しない
-  if (record.transaction_type === "non_cash_journal") {
-    return {
-      account: "non_cash_journal",
-      color: "#6B7280", // グレー
-      label: "-",
-      type: "non_cash_journal" as const,
-    };
-  }
-
-  // offset系の取引の場合
-  if (record.transaction_type === "offset_income") {
-    return {
-      account: record.credit_account,
-      color: getCategoryColor(record.credit_account),
-      label: getCategoryLabel(record.credit_account),
-      type: "offset_income" as const,
-    };
-  }
-
-  if (record.transaction_type === "offset_expense") {
-    return {
-      account: record.debit_account,
-      color: getCategoryColor(record.debit_account),
-      label: getCategoryLabel(record.debit_account),
-      type: "offset_expense" as const,
-    };
-  }
-
-  // 借方（debit）が費用系の場合は借方のカテゴリを、そうでなければ貸方のカテゴリを表示
-  const debitInfo = getCategoryInfoByAccount(record.debit_account);
-  const creditInfo = getCategoryInfoByAccount(record.credit_account);
-
-  if (debitInfo?.type === "expense") {
-    return {
-      account: record.debit_account,
-      color: getCategoryColor(record.debit_account),
-      label: getCategoryLabel(record.debit_account),
-      type: debitInfo.type,
-    };
-  } else {
-    return {
-      account: record.credit_account,
-      color: getCategoryColor(record.credit_account),
-      label: getCategoryLabel(record.credit_account),
-      type: creditInfo?.type || "unknown",
-    };
-  }
 }
 
 function getTypeLabel(type: string): string {
@@ -208,19 +135,7 @@ export default function TransactionRow({
         </span>
       </td>
       <td className="px-2 py-3 text-sm text-foreground">
-        {(() => {
-          const category = getTransactionCategory(record);
-          return (
-            <div
-              className={`inline-block px-2 py-1 rounded text-xs font-medium max-w-fit ${
-                category.type === "income" ? "text-black" : "text-white"
-              }`}
-              style={{ backgroundColor: category.color }}
-            >
-              {category.label}
-            </div>
-          );
-        })()}
+        <CategoryPill transaction={record} />
       </td>
       <td className="px-2 py-3 text-sm text-foreground">
         {record.description || "-"}

--- a/admin/src/client/components/political-organizations/PoliticalOrganizationSelect.tsx
+++ b/admin/src/client/components/political-organizations/PoliticalOrganizationSelect.tsx
@@ -13,6 +13,8 @@ interface PoliticalOrganizationSelectProps {
   value: string;
   onValueChange: (value: string) => void;
   required?: boolean;
+  /** ラベルを描画せず aria-label で代替する（ツールバー等でインライン配置する場合） */
+  hideLabel?: boolean;
 }
 
 export function PoliticalOrganizationSelect({
@@ -20,6 +22,7 @@ export function PoliticalOrganizationSelect({
   value,
   onValueChange,
   required,
+  hideLabel = false,
 }: PoliticalOrganizationSelectProps) {
   const options = organizations.map((org) => ({
     value: org.id,
@@ -27,10 +30,13 @@ export function PoliticalOrganizationSelect({
   }));
 
   return (
-    <div className="space-y-2">
-      <Label>政治団体</Label>
+    <div className={hideLabel ? undefined : "space-y-2"}>
+      {!hideLabel && <Label>政治団体</Label>}
       <Select value={value} onValueChange={onValueChange} required={required}>
-        <SelectTrigger>
+        <SelectTrigger
+          aria-label={hideLabel ? "政治団体" : undefined}
+          className={hideLabel ? "border-[1.5px] text-[13px]" : undefined}
+        >
           <SelectValue placeholder="政治団体を選択してください" />
         </SelectTrigger>
         <SelectContent>

--- a/admin/src/client/components/transactions/CategoryPill.tsx
+++ b/admin/src/client/components/transactions/CategoryPill.tsx
@@ -1,0 +1,27 @@
+import { type CategoryPillSource, resolveCategoryPill } from "@/client/lib";
+
+interface CategoryPillProps {
+  transaction: CategoryPillSource;
+}
+
+/**
+ * 勘定科目のカテゴリピル。表示ルールは webapp の取引テーブルと同一で、
+ * 判定ロジックは `resolveCategoryPill` に集約している（admin 内で独自の色分岐を持たない）。
+ * 色はデータ（PL_CATEGORIES）由来なので style で渡す。
+ */
+export function CategoryPill({ transaction }: CategoryPillProps) {
+  const pill = resolveCategoryPill(transaction);
+
+  return (
+    <span
+      className="inline-block rounded-full border px-3 py-0.5 text-xs font-medium leading-[1.67] whitespace-nowrap"
+      style={{
+        backgroundColor: pill.bgColor,
+        borderColor: pill.borderColor,
+        color: pill.fontColor,
+      }}
+    >
+      {pill.label}
+    </span>
+  );
+}

--- a/admin/src/client/components/transactions/ClearWebappCacheButton.tsx
+++ b/admin/src/client/components/transactions/ClearWebappCacheButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ArrowsClockwise } from "@phosphor-icons/react/dist/ssr";
 import { clearWebappCacheAction } from "@/server/contexts/shared/presentation/actions/clear-webapp-cache";
 import { Button } from "@/client/components/ui";
 
@@ -26,8 +27,17 @@ export function ClearWebappCacheButton() {
   };
 
   return (
-    <Button type="button" onClick={handleClearCache} disabled={clearing}>
-      {clearing ? "クリア中..." : "ウェブアプリのキャッシュをクリア"}
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="text-xs"
+      onClick={handleClearCache}
+      disabled={clearing}
+      title="ウェブアプリのキャッシュをクリア"
+    >
+      <ArrowsClockwise />
+      {clearing ? "クリア中..." : "キャッシュクリア"}
     </Button>
   );
 }

--- a/admin/src/client/components/transactions/DeleteAllButton.tsx
+++ b/admin/src/client/components/transactions/DeleteAllButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Trash } from "@phosphor-icons/react/dist/ssr";
 import { deleteAllTransactionsAction } from "@/server/contexts/data-import/presentation/actions/delete-all-transactions";
 import { Button } from "@/client/components/ui";
 
@@ -47,10 +48,14 @@ export function DeleteAllButton({
     <Button
       type="button"
       variant="destructive"
+      size="sm"
+      className="text-xs"
       onClick={handleDeleteAll}
       disabled={deleting || disabled}
+      title={organizationId ? "この政治団体の全取引を削除" : "全ての取引を削除"}
     >
-      {deleting ? "削除中..." : organizationId ? "この政治団体の全取引を削除" : "全ての取引を削除"}
+      <Trash />
+      {deleting ? "削除中..." : "全件削除"}
     </Button>
   );
 }

--- a/admin/src/client/components/transactions/DeleteTransactionButton.tsx
+++ b/admin/src/client/components/transactions/DeleteTransactionButton.tsx
@@ -15,18 +15,11 @@ import {
   DialogDescription,
 } from "@/client/components/ui";
 import type { TransactionWithOrganization } from "@/server/contexts/shared/domain/transaction";
+import { formatAmount, formatDate } from "@/client/lib";
 
 interface DeleteTransactionButtonProps {
   transaction: TransactionWithOrganization;
   onDeleted?: () => void;
-}
-
-function formatDate(date: Date | string) {
-  return new Date(date).toLocaleDateString("ja-JP");
-}
-
-function formatAmount(amount: number) {
-  return `¥${amount.toLocaleString()}`;
 }
 
 export function DeleteTransactionButton({ transaction, onDeleted }: DeleteTransactionButtonProps) {
@@ -55,12 +48,14 @@ export function DeleteTransactionButton({ transaction, onDeleted }: DeleteTransa
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <Button
+        type="button"
         variant="ghost"
-        size="icon"
-        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+        size="icon-sm"
+        className="text-subtle-foreground hover:bg-transparent hover:text-destructive"
         onClick={() => setOpen(true)}
+        aria-label="取引を削除"
       >
-        <Trash className="h-4 w-4" />
+        <Trash className="size-4" />
       </Button>
       <DialogContent className="max-w-md">
         <DialogHeader>

--- a/admin/src/client/components/transactions/TransactionRow.tsx
+++ b/admin/src/client/components/transactions/TransactionRow.tsx
@@ -2,8 +2,10 @@
 import "client-only";
 
 import type { TransactionWithOrganization } from "@/server/contexts/shared/domain/transaction";
-import { PL_CATEGORIES } from "@/shared/accounting/account-category";
-import type { TransactionType } from "@/shared/models/transaction";
+import { TableCell, TableRow } from "@/client/components/ui";
+import { formatAmount, formatDate } from "@/client/lib";
+import { CategoryPill } from "@/client/components/transactions/CategoryPill";
+import { TransactionTypeBadge } from "@/client/components/transactions/TransactionTypeBadge";
 import { DeleteTransactionButton } from "@/client/components/transactions/DeleteTransactionButton";
 
 interface TransactionRowProps {
@@ -11,179 +13,55 @@ interface TransactionRowProps {
   onDeleted?: () => void;
 }
 
-const DEFAULT_CATEGORY_COLOR = "#64748B"; // slate-500 as default fallback color
-
-function getCategoryInfoByAccount(accountName: string) {
-  return PL_CATEGORIES[accountName];
-}
-
-function getCategoryColor(accountName: string): string {
-  const categoryInfo = getCategoryInfoByAccount(accountName);
-  return categoryInfo?.color || DEFAULT_CATEGORY_COLOR;
-}
-
-function getCategoryLabel(accountName: string): string {
-  const categoryInfo = getCategoryInfoByAccount(accountName);
-  return categoryInfo?.shortLabel || accountName;
-}
-
-function getTransactionCategory(transaction: TransactionWithOrganization): {
-  account: string;
-  color: string;
-  label: string;
-  type: TransactionType;
-} {
-  // non_cash_journal取引の場合はカテゴリを表示しない
-  if (transaction.transaction_type === "non_cash_journal") {
-    return {
-      account: "non_cash_journal",
-      color: "#6B7280", // グレー
-      label: "-",
-      type: "non_cash_journal" as const,
-    };
-  }
-
-  // offset系の取引の場合
-  if (transaction.transaction_type === "offset_income") {
-    return {
-      account: transaction.credit_account,
-      color: getCategoryColor(transaction.credit_account),
-      label: getCategoryLabel(transaction.credit_account),
-      type: "offset_income" as const,
-    };
-  }
-
-  if (transaction.transaction_type === "offset_expense") {
-    return {
-      account: transaction.debit_account,
-      color: getCategoryColor(transaction.debit_account),
-      label: getCategoryLabel(transaction.debit_account),
-      type: "offset_expense" as const,
-    };
-  }
-
-  // 借方（debit）が費用系の場合は借方のカテゴリを、そうでなければ貸方のカテゴリを表示
-  const debitInfo = getCategoryInfoByAccount(transaction.debit_account);
-  const creditInfo = getCategoryInfoByAccount(transaction.credit_account);
-
-  if (debitInfo?.type === "expense") {
-    return {
-      account: transaction.debit_account,
-      color: getCategoryColor(transaction.debit_account),
-      label: getCategoryLabel(transaction.debit_account),
-      type: debitInfo.type,
-    };
-  } else {
-    return {
-      account: transaction.credit_account,
-      color: getCategoryColor(transaction.credit_account),
-      label: getCategoryLabel(transaction.credit_account),
-      type: creditInfo?.type || transaction.transaction_type,
-    };
-  }
-}
-
-function getTypeLabel(type: string): string {
-  switch (type) {
-    case "income":
-      return "現金収入";
-    case "expense":
-      return "現金支出";
-    case "non_cash_journal":
-      return "非現金仕訳";
-    case "offset_income":
-      return "相殺収入";
-    case "offset_expense":
-      return "相殺支出";
-    case "invalid":
-      return "無効";
-    default:
-      return "不明";
-  }
-}
-
-function getTypeBadgeClass(type: string): string {
-  switch (type) {
-    case "income":
-    case "offset_income":
-      return "bg-green-600";
-    case "expense":
-    case "offset_expense":
-      return "bg-red-600";
-    case "non_cash_journal":
-      return "bg-gray-500";
-    case "invalid":
-      return "bg-orange-600";
-    default:
-      return "bg-gray-600";
-  }
-}
-
 export function TransactionRow({ transaction, onDeleted }: TransactionRowProps) {
-  const formatDate = (date: Date | string) => {
-    return new Date(date).toLocaleDateString("ja-JP");
-  };
-
   return (
-    <tr className="border-b border-border">
-      <td className="px-2 py-3 text-sm text-foreground font-mono">{transaction.transaction_no}</td>
-      <td className="px-2 py-3 text-sm text-foreground">
+    <TableRow>
+      <TableCell className="font-latin text-xs text-muted-foreground">
+        {transaction.transaction_no}
+      </TableCell>
+      <TableCell className="font-latin text-[13px]">
         {formatDate(transaction.transaction_date)}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
+      </TableCell>
+      <TableCell className="text-[13px]">
         {transaction.political_organization_name || "-"}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
+      </TableCell>
+      <TableCell className="text-[13px]">
         {transaction.debit_account}
         {transaction.debit_sub_account && (
-          <div className="text-muted-foreground text-xs">{transaction.debit_sub_account}</div>
+          <div className="text-xs text-muted-foreground">{transaction.debit_sub_account}</div>
         )}
-      </td>
-      <td className="px-2 py-3 text-sm text-right text-foreground">
-        ¥{transaction.debit_amount.toLocaleString()}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
+      </TableCell>
+      <TableCell className="font-latin text-right text-[13px] font-semibold">
+        {formatAmount(transaction.debit_amount)}
+      </TableCell>
+      <TableCell className="text-[13px]">
         {transaction.credit_account}
         {transaction.credit_sub_account && (
-          <div className="text-muted-foreground text-xs">{transaction.credit_sub_account}</div>
+          <div className="text-xs text-muted-foreground">{transaction.credit_sub_account}</div>
         )}
-      </td>
-      <td className="px-2 py-3 text-sm text-right text-foreground">
-        ¥{transaction.credit_amount.toLocaleString()}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
-        <div
-          className={`inline-block px-2 py-1 rounded text-white text-xs font-medium ${getTypeBadgeClass(transaction.transaction_type)}`}
-        >
-          {getTypeLabel(transaction.transaction_type)}
+      </TableCell>
+      <TableCell className="font-latin text-right text-[13px] font-semibold">
+        {formatAmount(transaction.credit_amount)}
+      </TableCell>
+      <TableCell>
+        <TransactionTypeBadge type={transaction.transaction_type} />
+      </TableCell>
+      <TableCell>
+        <CategoryPill transaction={transaction} />
+      </TableCell>
+      <TableCell className="max-w-[200px] text-xs text-muted-foreground">
+        <div className="truncate" title={transaction.description || undefined}>
+          {transaction.description || "-"}
         </div>
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
-        {(() => {
-          const category = getTransactionCategory(transaction);
-          return (
-            <div
-              className={`inline-block px-2 py-1 rounded text-xs font-medium max-w-fit ${
-                category.type === "income" || category.type === "offset_income"
-                  ? "text-black"
-                  : "text-foreground"
-              }`}
-              style={{ backgroundColor: category.color }}
-            >
-              {category.label}
-            </div>
-          );
-        })()}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
-        {transaction.description || "-"}
         {transaction.label && (
-          <div className="text-muted-foreground text-xs mt-1">ラベル: {transaction.label}</div>
+          <div className="mt-1 truncate" title={transaction.label}>
+            ラベル: {transaction.label}
+          </div>
         )}
-      </td>
-      <td className="px-2 py-3 text-sm text-center">
+      </TableCell>
+      <TableCell className="text-center">
         <DeleteTransactionButton transaction={transaction} onDeleted={onDeleted} />
-      </td>
-    </tr>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/admin/src/client/components/transactions/TransactionTypeBadge.tsx
+++ b/admin/src/client/components/transactions/TransactionTypeBadge.tsx
@@ -1,0 +1,41 @@
+import type { TransactionType } from "@/shared/models/transaction";
+import { cn } from "@/client/lib";
+
+interface TransactionTypeBadgeProps {
+  type: TransactionType;
+}
+
+const TYPE_LABELS: Record<TransactionType, string> = {
+  income: "現金収入",
+  expense: "現金支出",
+  non_cash_journal: "非現金仕訳",
+  offset_income: "相殺収入",
+  offset_expense: "相殺支出",
+};
+
+function getTypeBadgeClass(type: TransactionType): string {
+  switch (type) {
+    case "income":
+    case "offset_income":
+      return "border-primary-active text-primary-active bg-accent";
+    case "expense":
+    case "offset_expense":
+      return "border-destructive text-destructive bg-card";
+    case "non_cash_journal":
+      return "border-subtle-foreground text-muted-foreground bg-secondary";
+  }
+}
+
+/** 取引種別のピルバッジ（11px/700・1.5px 枠）。 */
+export function TransactionTypeBadge({ type }: TransactionTypeBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-block rounded-full border-[1.5px] px-3 py-[3px] text-[11px] font-bold leading-none tracking-[0.04em] whitespace-nowrap",
+        getTypeBadgeClass(type),
+      )}
+    >
+      {TYPE_LABELS[type] ?? "不明"}
+    </span>
+  );
+}

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -2,17 +2,24 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { TransactionRow } from "./TransactionRow";
+import { TransactionRow } from "@/client/components/transactions/TransactionRow";
 import { StaticPagination } from "@/client/components/ui/StaticPagination";
-import { DeleteAllButton } from "./DeleteAllButton";
-import { ClearWebappCacheButton } from "./ClearWebappCacheButton";
+import { DeleteAllButton } from "@/client/components/transactions/DeleteAllButton";
+import { ClearWebappCacheButton } from "@/client/components/transactions/ClearWebappCacheButton";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/client/components/ui";
 import type { GetTransactionsResult } from "@/server/contexts/data-import/presentation/types";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 
 interface TransactionsClientProps {
   organizations: PoliticalOrganization[];
+}
+
+function formatRangeText(data: GetTransactionsResult): string {
+  const start = data.total === 0 ? 0 : (data.page - 1) * data.perPage + 1;
+  const end = Math.min(data.page * data.perPage, data.total);
+  return `全 ${data.total.toLocaleString()} 件中 ${start.toLocaleString()} - ${end.toLocaleString()} 件を表示`;
 }
 
 export function TransactionsClient({ organizations }: TransactionsClientProps) {
@@ -86,117 +93,97 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
     }
   };
 
+  const headerNote = (
+    <span className="ml-1 text-[10px] font-normal text-muted-foreground">
+      ※サービスには表示されません
+    </span>
+  );
+
   return (
     <div>
       <PageHeader label="Transactions" title="取引一覧" />
 
-      <div className="bg-card rounded-xl p-4">
-        {/* Organization Filter */}
-        <div className="mb-4">
-          <PoliticalOrganizationSelect
-            organizations={organizations}
-            value={selectedOrgId}
-            onValueChange={handleOrgFilterChange}
-          />
+      <div className="rounded-lg border border-border bg-card p-6">
+        {/* Toolbar */}
+        <div className="mb-[18px] flex flex-wrap items-center justify-between gap-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <PoliticalOrganizationSelect
+              organizations={organizations}
+              value={selectedOrgId}
+              onValueChange={handleOrgFilterChange}
+              hideLabel
+            />
+            {!loading && data && (
+              <p className="text-[13px] text-muted-foreground">{formatRangeText(data)}</p>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <ClearWebappCacheButton />
+            <DeleteAllButton
+              disabled={loading || !data || data.total === 0}
+              organizationId={selectedOrgId || undefined}
+              onDeleted={() => {
+                // データを再取得
+                window.location.reload();
+              }}
+            />
+          </div>
         </div>
 
-        {!loading && data && (
-          <div className="flex justify-between items-center mt-5 mb-4">
-            <p className="text-muted-foreground">
-              全 {data.total} 件中 {(data.page - 1) * data.perPage + 1} -{" "}
-              {Math.min(data.page * data.perPage, data.total)} 件を表示
-            </p>
-            <div className="flex gap-2">
-              <ClearWebappCacheButton />
-              <DeleteAllButton
-                disabled={data.total === 0}
-                organizationId={selectedOrgId || undefined}
-                onDeleted={() => {
-                  // データを再取得
-                  window.location.reload();
-                }}
-              />
-            </div>
-          </div>
-        )}
-
         {fetching && (
-          <div className="text-center py-2 mb-4">
-            <div className="flex items-center justify-center gap-2">
-              <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
-              <p className="text-muted-foreground text-sm">取得中...</p>
-            </div>
+          <div className="mb-4 flex items-center justify-center gap-2 py-2">
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <p className="text-sm text-muted-foreground">取得中...</p>
           </div>
         )}
 
         {loading ? (
-          <div className="text-center py-10">
+          <div className="py-10 text-center">
             <p className="text-muted-foreground">読み込み中...</p>
           </div>
         ) : error ? (
-          <div className="text-center py-10">
-            <p className="text-red-500">エラー: {error}</p>
+          <div className="py-10 text-center">
+            <p className="text-destructive">エラー: {error}</p>
           </div>
         ) : !data ? (
-          <div className="text-center py-10">
+          <div className="py-10 text-center">
             <p className="text-muted-foreground">データがありません</p>
           </div>
         ) : data.transactions.length === 0 ? (
-          <div className="text-center py-10">
+          <div className="py-10 text-center">
             <p className="text-muted-foreground">トランザクションが登録されていません</p>
           </div>
         ) : (
           <>
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse">
-                <thead>
-                  <tr className="border-b border-border">
-                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                      取引No
-                    </th>
-                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                      取引日
-                    </th>
-                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                      政治団体
-                    </th>
-                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                      借方勘定科目
-                    </th>
-                    <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
-                      借方金額
-                    </th>
-                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                      貸方勘定科目
-                    </th>
-                    <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
-                      貸方金額
-                    </th>
-                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                      種別
-                    </th>
-                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                      カテゴリ
-                    </th>
-                    <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                      摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
-                    </th>
-                    <th className="px-2 py-3 text-center text-sm font-semibold text-foreground w-16">
-                      操作
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.transactions.map((transaction) => (
-                    <TransactionRow
-                      key={transaction.id}
-                      transaction={transaction}
-                      onDeleted={() => fetchTransactions(selectedOrgId)}
-                    />
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <Table className="min-w-[980px]">
+              <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                  <TableHead>取引No</TableHead>
+                  <TableHead>取引日</TableHead>
+                  <TableHead>政治団体</TableHead>
+                  <TableHead>借方勘定科目</TableHead>
+                  <TableHead className="text-right">借方金額</TableHead>
+                  <TableHead>貸方勘定科目</TableHead>
+                  <TableHead className="text-right">貸方金額</TableHead>
+                  <TableHead>種別</TableHead>
+                  <TableHead>カテゴリ</TableHead>
+                  <TableHead>
+                    摘要
+                    {headerNote}
+                  </TableHead>
+                  <TableHead className="w-16 text-center">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.transactions.map((transaction) => (
+                  <TransactionRow
+                    key={transaction.id}
+                    transaction={transaction}
+                    onDeleted={() => fetchTransactions(selectedOrgId)}
+                  />
+                ))}
+              </TableBody>
+            </Table>
 
             <StaticPagination
               currentPage={data.page}

--- a/admin/src/client/components/ui/StaticPagination.tsx
+++ b/admin/src/client/components/ui/StaticPagination.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import type { ReactNode } from "react";
 import Link from "next/link";
+import { CaretLeft, CaretRight } from "@phosphor-icons/react/dist/ssr";
+import { cn } from "@/client/lib";
 
 interface StaticPaginationProps {
   currentPage: number;
@@ -9,96 +10,52 @@ interface StaticPaginationProps {
   basePath: string;
 }
 
+const pillClass =
+  "inline-flex items-center gap-1.5 rounded-full border-[1.5px] bg-card px-4 py-[7px] text-xs font-bold transition-colors duration-150 ease-out";
+const enabledClass =
+  "border-border text-foreground hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+const disabledClass = "border-disabled-border text-disabled-foreground cursor-not-allowed";
+
+/**
+ * URL の `?page=` で遷移する静的ページネーション。
+ * 「前へ / 次へ」の黒枠白ピルと、中央に Poppins の「現在 / 総数」表示。
+ */
 export function StaticPagination({ currentPage, totalPages, basePath }: StaticPaginationProps) {
-  const generatePageUrl = (page: number) => {
-    return `${basePath}?page=${page}`;
-  };
+  if (totalPages <= 0) return null;
 
-  const renderPageNumbers = () => {
-    if (totalPages <= 0) return null;
-
-    const pages: ReactNode[] = [];
-    const windowSize = 5;
-
-    const addPageLink = (page: number) => {
-      pages.push(
-        <Link
-          key={`page-${page}`}
-          href={generatePageUrl(page)}
-          className={`px-3 py-2 text-sm font-medium rounded-md transition-colors ${
-            page === currentPage
-              ? "bg-primary text-primary-foreground"
-              : "text-muted-foreground hover:bg-accent hover:text-foreground"
-          }`}
-        >
-          {page}
-        </Link>,
-      );
-    };
-
-    const addEllipsis = (key: string) => {
-      pages.push(
-        <span key={`ellipsis-${key}`} className="px-2 text-muted-foreground select-none">
-          …
-        </span>,
-      );
-    };
-
-    if (totalPages <= windowSize + 2) {
-      for (let page = 1; page <= totalPages; page++) {
-        addPageLink(page);
-      }
-      return pages;
-    }
-
-    addPageLink(1);
-
-    let startPage = Math.max(2, currentPage - Math.floor(windowSize / 2));
-    let endPage = Math.min(totalPages - 1, startPage + windowSize - 1);
-
-    if (endPage >= totalPages) {
-      endPage = totalPages - 1;
-      startPage = endPage - windowSize + 1;
-    }
-
-    if (startPage > 2) {
-      addEllipsis("left");
-    }
-
-    for (let page = startPage; page <= endPage; page++) {
-      addPageLink(page);
-    }
-
-    if (endPage < totalPages - 1) {
-      addEllipsis("right");
-    }
-
-    addPageLink(totalPages);
-
-    return pages;
-  };
+  const generatePageUrl = (page: number) => `${basePath}?page=${page}`;
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < totalPages;
 
   return (
-    <div className="flex justify-center items-center gap-2 mt-6">
-      {currentPage > 1 && (
-        <Link
-          href={generatePageUrl(currentPage - 1)}
-          className="px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground rounded-md transition-colors"
-        >
-          ← 前
+    <nav aria-label="pagination" className="mt-6 flex items-center justify-center gap-2.5">
+      {hasPrev ? (
+        <Link href={generatePageUrl(currentPage - 1)} className={cn(pillClass, enabledClass)}>
+          <CaretLeft className="size-3" />
+          前へ
         </Link>
+      ) : (
+        <span aria-disabled="true" className={cn(pillClass, disabledClass)}>
+          <CaretLeft className="size-3" />
+          前へ
+        </span>
       )}
 
-      {renderPageNumbers()}
+      <span className="font-latin text-[13px] font-semibold text-foreground">
+        {currentPage} / {totalPages}
+      </span>
 
-      {currentPage < totalPages && (
-        <Link
-          href={generatePageUrl(currentPage + 1)}
-          className="px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground rounded-md transition-colors"
-        >
-          次 →
+      {hasNext ? (
+        <Link href={generatePageUrl(currentPage + 1)} className={cn(pillClass, enabledClass)}>
+          次へ
+          <CaretRight className="size-3" />
         </Link>
+      ) : (
+        <span aria-disabled="true" className={cn(pillClass, disabledClass)}>
+          次へ
+          <CaretRight className="size-3" />
+        </span>
       )}
-    </div>
+    </nav>
   );
 }

--- a/admin/src/client/lib/category-pill.ts
+++ b/admin/src/client/lib/category-pill.ts
@@ -1,0 +1,90 @@
+import { PL_CATEGORIES } from "@/shared/accounting/account-category";
+import type { TransactionType } from "@/shared/models/transaction";
+
+/**
+ * カテゴリピルの表示に必要な取引情報。
+ * 取引一覧（TransactionWithOrganization）と CSV 取り込みプレビュー（PreviewTransaction）の
+ * 両方が構造的に満たす最小の形にしている。
+ */
+export interface CategoryPillSource {
+  debit_account: string;
+  credit_account: string;
+  transaction_type: TransactionType | null | undefined;
+}
+
+interface CategoryPillStyle {
+  label: string;
+  fontColor: string;
+  borderColor: string;
+  bgColor: string;
+}
+
+/** 収入ピルの文字色（webapp の TransactionTableRow と同じ値） */
+const INCOME_FONT_COLOR = "#47474C";
+/** PL_CATEGORIES に無い勘定科目のフォールバック色（webapp と同じ値） */
+const FALLBACK_CATEGORY_COLOR = "#99F6E4";
+
+/** 非現金仕訳のピル（ハンドオフ「カテゴリピル」節） */
+const NON_CASH_JOURNAL_PILL: CategoryPillStyle = {
+  label: "-",
+  fontColor: "#666666",
+  borderColor: "#CCCCCC",
+  bgColor: "#FFFFFF",
+};
+
+/**
+ * 取引からカテゴリ表示に使う勘定科目を決める。
+ * - 相殺収入は貸方、相殺支出は借方
+ * - それ以外は借方が費用系なら借方、そうでなければ貸方
+ */
+function resolveCategoryAccount(source: CategoryPillSource): string {
+  if (source.transaction_type === "offset_income") {
+    return source.credit_account;
+  }
+  if (source.transaction_type === "offset_expense") {
+    return source.debit_account;
+  }
+  const debitInfo = PL_CATEGORIES[source.debit_account];
+  return debitInfo?.type === "expense" ? source.debit_account : source.credit_account;
+}
+
+function isIncomeTransactionType(type: TransactionType | null | undefined): boolean {
+  return type === "income" || type === "offset_income";
+}
+
+/**
+ * カテゴリピルの表示ルール（webapp の取引テーブルと同一）。
+ *
+ * - 収入: 背景と枠がカテゴリ色、文字 `#47474C`
+ * - 支出: 背景白、枠と文字がカテゴリ色
+ * - 非現金仕訳: 背景白、枠 `#CCC`、文字 `#666`、ラベル「-」
+ *
+ * 色と略称は `PL_CATEGORIES` の `color` / `shortLabel` をそのまま使う。
+ * admin 内のカテゴリピルはすべてこの関数を経由すること。
+ */
+export function resolveCategoryPill(source: CategoryPillSource): CategoryPillStyle {
+  if (source.transaction_type === "non_cash_journal") {
+    return NON_CASH_JOURNAL_PILL;
+  }
+
+  const account = resolveCategoryAccount(source);
+  const mapping = PL_CATEGORIES[account];
+  const isIncome = mapping
+    ? mapping.type === "income"
+    : isIncomeTransactionType(source.transaction_type);
+  const label = mapping?.shortLabel ?? account;
+
+  if (mapping?.color) {
+    const color = mapping.color;
+    return isIncome
+      ? { label, fontColor: INCOME_FONT_COLOR, borderColor: color, bgColor: color }
+      : { label, fontColor: color, borderColor: color, bgColor: "#FFFFFF" };
+  }
+
+  return {
+    label,
+    fontColor: INCOME_FONT_COLOR,
+    borderColor: FALLBACK_CATEGORY_COLOR,
+    bgColor: isIncome ? FALLBACK_CATEGORY_COLOR : "#FFFFFF",
+  };
+}

--- a/admin/src/client/lib/format.ts
+++ b/admin/src/client/lib/format.ts
@@ -1,11 +1,11 @@
 /**
- * 日付を YYYY/MM/DD 形式でフォーマットする
+ * 日付を YYYY.MM.DD 形式でフォーマットする（Team Mirai ブランドの日付表記）
  * @param date - フォーマットする日付
- * @returns フォーマットされた日付文字列
+ * @returns フォーマットされた日付文字列（例: 2025.01.31）
  */
-export function formatDate(date: Date): string {
+export function formatDate(date: Date | string): string {
   const d = new Date(date);
-  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, "0")}.${String(d.getDate()).padStart(2, "0")}`;
 }
 
 /**

--- a/admin/src/client/lib/index.ts
+++ b/admin/src/client/lib/index.ts
@@ -1,2 +1,4 @@
 export { cn } from "./utils";
 export { formatDate, formatAmount, formatCurrency } from "./format";
+export { resolveCategoryPill } from "./category-pill";
+export type { CategoryPillSource } from "./category-pill";

--- a/admin/tests/client/lib/category-pill.test.ts
+++ b/admin/tests/client/lib/category-pill.test.ts
@@ -1,0 +1,114 @@
+import { resolveCategoryPill } from "@/client/lib/category-pill";
+import { PL_CATEGORIES } from "@/shared/accounting/account-category";
+
+const INCOME_ACCOUNT = "個人からの寄附";
+const EXPENSE_ACCOUNT = Object.keys(PL_CATEGORIES).find(
+  (key) => PL_CATEGORIES[key].type === "expense",
+) as string;
+
+describe("resolveCategoryPill", () => {
+  it("収入は背景と枠がカテゴリ色・文字 #47474C になる", () => {
+    const mapping = PL_CATEGORIES[INCOME_ACCOUNT];
+    const pill = resolveCategoryPill({
+      debit_account: "普通預金",
+      credit_account: INCOME_ACCOUNT,
+      transaction_type: "income",
+    });
+
+    expect(pill).toEqual({
+      label: mapping.shortLabel,
+      fontColor: "#47474C",
+      borderColor: mapping.color,
+      bgColor: mapping.color,
+    });
+  });
+
+  it("支出は背景白・枠と文字がカテゴリ色になる", () => {
+    const mapping = PL_CATEGORIES[EXPENSE_ACCOUNT];
+    const pill = resolveCategoryPill({
+      debit_account: EXPENSE_ACCOUNT,
+      credit_account: "普通預金",
+      transaction_type: "expense",
+    });
+
+    expect(pill).toEqual({
+      label: mapping.shortLabel,
+      fontColor: mapping.color,
+      borderColor: mapping.color,
+      bgColor: "#FFFFFF",
+    });
+  });
+
+  it("非現金仕訳は背景白・枠 #CCC・文字 #666・ラベル「-」になる", () => {
+    const pill = resolveCategoryPill({
+      debit_account: EXPENSE_ACCOUNT,
+      credit_account: INCOME_ACCOUNT,
+      transaction_type: "non_cash_journal",
+    });
+
+    expect(pill).toEqual({
+      label: "-",
+      fontColor: "#666666",
+      borderColor: "#CCCCCC",
+      bgColor: "#FFFFFF",
+    });
+  });
+
+  it("相殺収入は貸方の勘定科目でカテゴリを決める", () => {
+    const pill = resolveCategoryPill({
+      debit_account: EXPENSE_ACCOUNT,
+      credit_account: INCOME_ACCOUNT,
+      transaction_type: "offset_income",
+    });
+
+    expect(pill.label).toBe(PL_CATEGORIES[INCOME_ACCOUNT].shortLabel);
+  });
+
+  it("相殺支出は借方の勘定科目でカテゴリを決める", () => {
+    const pill = resolveCategoryPill({
+      debit_account: EXPENSE_ACCOUNT,
+      credit_account: INCOME_ACCOUNT,
+      transaction_type: "offset_expense",
+    });
+
+    expect(pill.label).toBe(PL_CATEGORIES[EXPENSE_ACCOUNT].shortLabel);
+  });
+
+  it("PL_CATEGORIES に無い勘定科目は科目名をラベルにしフォールバック色を使う", () => {
+    const income = resolveCategoryPill({
+      debit_account: "普通預金",
+      credit_account: "未知の科目",
+      transaction_type: "income",
+    });
+    expect(income).toEqual({
+      label: "未知の科目",
+      fontColor: "#47474C",
+      borderColor: "#99F6E4",
+      bgColor: "#99F6E4",
+    });
+
+    // 借方が費用系でない場合は貸方の科目を採用する（従来の判定ルールを維持）
+    const expense = resolveCategoryPill({
+      debit_account: "未知の費用",
+      credit_account: "未知の科目",
+      transaction_type: "expense",
+    });
+    expect(expense).toEqual({
+      label: "未知の科目",
+      fontColor: "#47474C",
+      borderColor: "#99F6E4",
+      bgColor: "#FFFFFF",
+    });
+  });
+
+  it("transaction_type が null（プレビューの無効行）でも落ちずに貸方で判定する", () => {
+    const pill = resolveCategoryPill({
+      debit_account: "普通預金",
+      credit_account: INCOME_ACCOUNT,
+      transaction_type: null,
+    });
+
+    expect(pill.label).toBe(PL_CATEGORIES[INCOME_ACCOUNT].shortLabel);
+    expect(pill.bgColor).toBe(PL_CATEGORIES[INCOME_ACCOUNT].color);
+  });
+});

--- a/admin/tests/client/lib/format.test.ts
+++ b/admin/tests/client/lib/format.test.ts
@@ -5,34 +5,38 @@ import {
 } from "@/client/lib/format";
 
 describe("formatDate", () => {
-  it("formats date to YYYY/MM/DD format with zero-padding", () => {
-    expect(formatDate(new Date(2025, 0, 1))).toBe("2025/01/01");
-    expect(formatDate(new Date(2025, 11, 31))).toBe("2025/12/31");
+  it("formats date to YYYY.MM.DD format with zero-padding", () => {
+    expect(formatDate(new Date(2025, 0, 1))).toBe("2025.01.01");
+    expect(formatDate(new Date(2025, 11, 31))).toBe("2025.12.31");
   });
 
   it("pads single-digit months with zero", () => {
-    expect(formatDate(new Date(2025, 0, 15))).toBe("2025/01/15");
-    expect(formatDate(new Date(2025, 8, 5))).toBe("2025/09/05");
+    expect(formatDate(new Date(2025, 0, 15))).toBe("2025.01.15");
+    expect(formatDate(new Date(2025, 8, 5))).toBe("2025.09.05");
   });
 
   it("pads single-digit days with zero", () => {
-    expect(formatDate(new Date(2025, 5, 1))).toBe("2025/06/01");
-    expect(formatDate(new Date(2025, 10, 9))).toBe("2025/11/09");
+    expect(formatDate(new Date(2025, 5, 1))).toBe("2025.06.01");
+    expect(formatDate(new Date(2025, 10, 9))).toBe("2025.11.09");
   });
 
   it("handles various years", () => {
-    expect(formatDate(new Date(2000, 0, 1))).toBe("2000/01/01");
-    expect(formatDate(new Date(1999, 11, 31))).toBe("1999/12/31");
-    expect(formatDate(new Date(2030, 6, 15))).toBe("2030/07/15");
+    expect(formatDate(new Date(2000, 0, 1))).toBe("2000.01.01");
+    expect(formatDate(new Date(1999, 11, 31))).toBe("1999.12.31");
+    expect(formatDate(new Date(2030, 6, 15))).toBe("2030.07.15");
   });
 
   it("handles date strings passed as Date objects", () => {
     const dateFromString = new Date("2025-06-15T00:00:00");
-    expect(formatDate(dateFromString)).toBe("2025/06/15");
+    expect(formatDate(dateFromString)).toBe("2025.06.15");
   });
 
   it("handles leap year dates", () => {
-    expect(formatDate(new Date(2024, 1, 29))).toBe("2024/02/29");
+    expect(formatDate(new Date(2024, 1, 29))).toBe("2024.02.29");
+  });
+
+  it("accepts date strings", () => {
+    expect(formatDate("2025-06-15T00:00:00")).toBe("2025.06.15");
   });
 });
 


### PR DESCRIPTION
## 目的（Why）

管理者が最も頻繁に見る取引一覧が旧デザイン（ダーク系 shadcn デフォルト）のままで、Team Mirai ブランドに揃った他画面と一貫性が無い状態を解消するため。あわせて、勘定科目のカテゴリピルが admin と webapp で別ルールになっており見た目が食い違う状態を解消する。

正は [デザインハンドオフ README「2. 取引一覧」「カテゴリピル」節](docs/reference/design_handoff_admin_redesign/README.md)。

## 変更内容

- **コンテンツカード**: 白・黒 1px 枠・角丸 8px・padding 24px。ツールバー左に団体 select（`hideLabel` で Label を省き aria-label 化、黒 1.5px 枠 13px）+ 件数表示「全 N 件中 x - y 件を表示」（13px `#666`）、右に「キャッシュクリア」（黒枠白ピル + ArrowsClockwise）と「全件削除」（赤枠白地赤文字ピル + Trash）
- **テーブル**: `ui/Table` に置き換え（ヘッダー下罫線黒 1.5px・行罫線 `#E5E5E5`・セル padding `10px 12px`）。取引 No は Poppins 12px `#666`、取引日は Poppins 13px `YYYY.MM.DD`、金額は Poppins 13px/600 右寄せ、摘要は 12px `#666` で max-width 200px 省略、操作列は Trash アイコン（16px `#939393`）のみ
- **種別バッジ**: `TransactionTypeBadge`（ピル 11px/700・1.5px 枠。現金収入 = teal-deep / 現金支出 = 赤 / 非現金仕訳 = グレー）
- **カテゴリピル**: `admin/src/client/lib/category-pill.ts` の `resolveCategoryPill` に表示ルールを集約し、`CategoryPill` コンポーネントを取引一覧と CSV 取り込みプレビューの取引行の両方で使用。収入 = 背景と枠がカテゴリ色・文字 `#47474C`、支出 = 背景白・枠と文字がカテゴリ色、非現金仕訳 = 背景白・枠 `#CCC`・文字 `#666`・「-」。色と略称は `PL_CATEGORIES` をそのまま使用し、admin 独自の色分岐（`getCategoryColor` 系）は削除。webapp 側は無変更
- **ページネーション**: `StaticPagination` を中央寄せの「前へ / 次へ」黒 1.5px 枠白ピル（無効時は `#CCC` 枠・`#B1B1B1` 文字・not-allowed）+ Poppins「1 / 25」に変更。`nav[aria-label="pagination"]` で囲んだ（既存 E2E が参照）
- **formatDate**: `YYYY/MM/DD` → `YYYY.MM.DD`（ガイドラインの日付表記）。取引一覧のほか取引削除ダイアログと取引先詳細の作成日・更新日表示にも反映される
- 団体切替・ページ送り・取引削除・全件削除・キャッシュクリアの挙動は従来どおり（削除確認メッセージ・window.reload 等は維持）

Closes #1292

## ローカルCI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ 全て通過（admin 895 tests, webapp 135 tests）
- admin E2E（`playwright test --workers=1`）: ✅ 42 件中 41 件通過。1 件失敗した `report-profile.spec.ts` の年度切り替えは既知の flaky（#1307）で、単体再実行では通過。取引一覧の 4 spec は全て通過

## 追加したテスト

- `admin/tests/client/lib/category-pill.test.ts`: 収入 / 支出 / 非現金仕訳 / 相殺収入・支出 / 未知の科目 / `transaction_type: null` の表示ルール
- `admin/tests/client/lib/format.test.ts`: `YYYY.MM.DD` に更新

## スコープアウトして起票した Issue

なし（CSV プレビューの種別バッジ等のカテゴリピル以外は #1298、取引先詳細・寄付者インポートの日付表記は #1294 / #1299 の範囲）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 取引一覧に、カテゴリと取引種別を統一されたピル形式で表示。
  * 政治団体選択欄でラベルを非表示にする表示オプションを追加。
  * ページネーションを前後ボタンと「現在／総数」表示の形式に刷新。

* **改善**
  * 取引一覧の表や操作ボタンのデザイン、アクセシビリティを改善。
  * 日付表示を `YYYY.MM.DD` 形式に統一し、文字列の日付にも対応。
  * 件数表示や削除操作の状態表示を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->