### PR TITLE
feat(admin): 基本情報系画面（政治団体・ユーザー情報・ユーザー管理・ダッシュボード）をリデザインする

### DIFF
--- a/admin/e2e/tests/report-profile.spec.ts
+++ b/admin/e2e/tests/report-profile.spec.ts
@@ -25,10 +25,8 @@ test.describe("報告書プロフィール", () => {
 				page.getByRole("heading", { name: new RegExp(`${orgName}.*報告書プロフィール`) }),
 			).toBeVisible();
 
-			// YearSelector の select（Label「報告年」の直後の要素）
-			const yearSelect = page.locator(
-				'xpath=//label[normalize-space()="報告年"]/following-sibling::select[1]',
-			);
+			// YearSelector の select（Label「報告年」に htmlFor で紐付いている）
+			const yearSelect = page.getByLabel("報告年");
 
 			// YearSelector の選択肢は currentYear から過去10年。
 			// 実行年に依存しないよう、currentYear-1 と currentYear-2 を使う。

--- a/admin/src/app/(auth)/page.tsx
+++ b/admin/src/app/(auth)/page.tsx
@@ -4,8 +4,8 @@ export default function Home() {
   return (
     <div>
       <PageHeader label="Dashboard" title="ダッシュボード" />
-      <div className="bg-card rounded-xl p-4">
-        <p className="text-muted-foreground">Use the left navigation to manage data.</p>
+      <div className="rounded-lg border border-border bg-card p-6">
+        <p className="text-sm text-muted-foreground">Use the left navigation to manage data.</p>
       </div>
     </div>
   );

--- a/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
@@ -3,6 +3,8 @@ import "server-only";
 import Link from "next/link";
 import { PoliticalOrganizationForm } from "@/client/components/political-organizations/PoliticalOrganizationForm";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { BackLink } from "@/client/components/layout/BackLink";
+import { Button } from "@/client/components/ui";
 import { loadPoliticalOrganizationData } from "@/server/contexts/shared/presentation/loaders/load-political-organization-data";
 import { updatePoliticalOrganization } from "@/server/contexts/shared/presentation/actions/update-political-organization";
 import type { UpdatePoliticalOrganizationData } from "@/server/contexts/shared/presentation/actions/update-political-organization";
@@ -21,10 +23,8 @@ export default async function EditPoliticalOrganizationPage({
     organization = await loadPoliticalOrganizationData(orgId);
   } catch (error) {
     return (
-      <div className="bg-card rounded-xl p-4">
-        <div className="text-red-500 text-center p-10">
-          {error instanceof Error ? error.message : "政治団体の取得に失敗しました"}
-        </div>
+      <div className="rounded-lg border border-border bg-card p-10 text-center text-sm text-destructive">
+        {error instanceof Error ? error.message : "政治団体の取得に失敗しました"}
       </div>
     );
   }
@@ -36,14 +36,7 @@ export default async function EditPoliticalOrganizationPage({
 
   return (
     <div>
-      <div className="mb-4">
-        <Link
-          href="/political-organizations"
-          className="text-muted-foreground no-underline hover:text-foreground transition-colors"
-        >
-          ← 政治団体一覧に戻る
-        </Link>
-      </div>
+      <BackLink href="/political-organizations">政治団体一覧に戻る</BackLink>
 
       <PageHeader label="Organizations" title={`「${organization.displayName}」を編集`} />
 
@@ -59,15 +52,14 @@ export default async function EditPoliticalOrganizationPage({
           submitButtonText="更新"
         />
 
-        <div className="bg-card rounded-xl p-4">
-          <h2 className="text-lg font-semibold text-foreground mb-3">関連機能</h2>
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h2 className="mb-3 text-base font-bold text-foreground">関連機能</h2>
           <div className="flex gap-3">
-            <Link
-              href={`/political-organizations/${orgId}/report-profile`}
-              className="bg-secondary text-secondary-foreground border border-border rounded-lg px-4 py-2.5 hover:bg-accent transition-colors no-underline"
-            >
-              報告書プロフィール
-            </Link>
+            <Button variant="outline" asChild>
+              <Link href={`/political-organizations/${orgId}/report-profile`}>
+                報告書プロフィール
+              </Link>
+            </Button>
           </div>
         </div>
       </div>

--- a/admin/src/app/(auth)/political-organizations/[orgId]/report-profile/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/report-profile/page.tsx
@@ -1,11 +1,11 @@
 import "server-only";
 
-import Link from "next/link";
 import { loadPoliticalOrganizationData } from "@/server/contexts/shared/presentation/loaders/load-political-organization-data";
 import { loadOrganizationProfileData } from "@/server/contexts/report/presentation/loaders/organization-profile-loader";
 import { ReportProfileForm } from "@/client/components/report-profile/ReportProfileForm";
 import { YearSelector } from "@/client/components/report-profile/YearSelector";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { BackLink } from "@/client/components/layout/BackLink";
 
 interface ReportProfilePageProps {
   params: Promise<{ orgId: string }>;
@@ -25,10 +25,8 @@ export default async function ReportProfilePage({ params, searchParams }: Report
     organization = await loadPoliticalOrganizationData(orgId);
   } catch (error) {
     return (
-      <div className="bg-card rounded-xl p-4">
-        <div className="text-red-500 text-center p-10">
-          {error instanceof Error ? error.message : "政治団体の取得に失敗しました"}
-        </div>
+      <div className="rounded-lg border border-border bg-card p-10 text-center text-sm text-destructive">
+        {error instanceof Error ? error.message : "政治団体の取得に失敗しました"}
       </div>
     );
   }
@@ -43,32 +41,22 @@ export default async function ReportProfilePage({ params, searchParams }: Report
 
   return (
     <div>
-      <div className="mb-4">
-        <Link
-          href="/political-organizations"
-          className="text-muted-foreground no-underline hover:text-foreground transition-colors"
-        >
-          ← 政治団体一覧に戻る
-        </Link>
-      </div>
+      <BackLink href="/political-organizations">政治団体一覧に戻る</BackLink>
 
       <PageHeader
         label="Report Profile"
         title={`「${organization.displayName}」の報告書プロフィール`}
+        actions={
+          <YearSelector orgId={orgId} financialYear={financialYear} currentYear={currentYear} />
+        }
       />
 
-      <div className="bg-card rounded-xl p-4">
-        <div className="block mb-4">
-          <YearSelector orgId={orgId} financialYear={financialYear} currentYear={currentYear} />
-        </div>
-
-        <ReportProfileForm
-          key={financialYear}
-          politicalOrganizationId={orgId}
-          financialYear={financialYear}
-          initialData={profile}
-        />
-      </div>
+      <ReportProfileForm
+        key={financialYear}
+        politicalOrganizationId={orgId}
+        financialYear={financialYear}
+        initialData={profile}
+      />
     </div>
   );
 }

--- a/admin/src/app/(auth)/political-organizations/new/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/new/page.tsx
@@ -1,8 +1,8 @@
 import "server-only";
 
-import Link from "next/link";
 import { PoliticalOrganizationForm } from "@/client/components/political-organizations/PoliticalOrganizationForm";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { BackLink } from "@/client/components/layout/BackLink";
 import { createPoliticalOrganization } from "@/server/contexts/shared/presentation/actions/create-political-organization";
 import type { CreatePoliticalOrganizationData } from "@/server/contexts/shared/presentation/actions/create-political-organization";
 
@@ -14,14 +14,7 @@ export default function NewPoliticalOrganizationPage() {
 
   return (
     <div>
-      <div className="mb-4">
-        <Link
-          href="/political-organizations"
-          className="text-muted-foreground no-underline hover:text-foreground transition-colors"
-        >
-          ← 政治団体一覧に戻る
-        </Link>
-      </div>
+      <BackLink href="/political-organizations">政治団体一覧に戻る</BackLink>
 
       <PageHeader label="Organizations" title="新しい政治団体を作成" />
 

--- a/admin/src/app/(auth)/political-organizations/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/page.tsx
@@ -1,9 +1,11 @@
 import "server-only";
 
 import Link from "next/link";
+import { Plus } from "@phosphor-icons/react/dist/ssr";
 import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/presentation/loaders/load-political-organizations-data";
-import { DeletePoliticalOrganizationButton } from "@/client/components/political-organizations/DeletePoliticalOrganizationButton";
+import { PoliticalOrganizationCard } from "@/client/components/political-organizations/PoliticalOrganizationCard";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { Button } from "@/client/components/ui";
 
 export default async function PoliticalOrganizationsPage() {
   const organizations = await loadPoliticalOrganizationsData();
@@ -14,62 +16,32 @@ export default async function PoliticalOrganizationsPage() {
         label="Organizations"
         title="政治団体一覧"
         actions={
-          <Link
-            href="/political-organizations/new"
-            className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-primary-hover transition-colors duration-200"
-          >
-            新規作成
-          </Link>
+          <Button className="text-[13px] tracking-[0.06em]" asChild>
+            <Link href="/political-organizations/new">
+              <Plus />
+              新規作成
+            </Link>
+          </Button>
         }
       />
 
-      <div className="bg-card rounded-xl p-4">
-        {organizations.length === 0 && (
-          <div className="text-center py-10">
-            <p className="text-muted-foreground">政治団体が登録されていません</p>
-            <Link
-              href="/political-organizations/new"
-              className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium no-underline hover:bg-primary-hover transition-colors duration-200 mt-4 inline-block"
-            >
+      {organizations.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card px-6 py-10 text-center">
+          <p className="text-sm text-muted-foreground">政治団体が登録されていません</p>
+          <Button className="mt-4" asChild>
+            <Link href="/political-organizations/new">
+              <Plus />
               最初の政治団体を作成
             </Link>
-          </div>
-        )}
-
-        {organizations.length > 0 && (
-          <div className="mt-5">
-            <div className="grid gap-4">
-              {organizations.map((org) => (
-                <div key={org.id} className="bg-card rounded-lg p-6 border border-border">
-                  <div className="flex justify-between items-start gap-4">
-                    <div className="flex-1 space-y-3">
-                      <h3 className="text-lg font-medium text-foreground">{org.displayName}</h3>
-                      {org.description && (
-                        <p className="text-muted-foreground">{org.description}</p>
-                      )}
-                      <div className="text-muted-foreground text-sm">
-                        作成日: {new Date(org.createdAt).toLocaleDateString("ja-JP")}
-                      </div>
-                    </div>
-                    <div className="flex gap-2">
-                      <Link
-                        href={`/political-organizations/${org.id}`}
-                        className="bg-secondary text-secondary-foreground no-underline text-sm px-4 py-2 rounded-lg hover:bg-secondary/80 transition-colors duration-200"
-                      >
-                        編集
-                      </Link>
-                      <DeletePoliticalOrganizationButton
-                        orgId={BigInt(org.id)}
-                        orgName={org.displayName}
-                      />
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {organizations.map((org) => (
+            <PoliticalOrganizationCard key={org.id} organization={org} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/admin/src/app/(auth)/user-info/page.tsx
+++ b/admin/src/app/(auth)/user-info/page.tsx
@@ -1,5 +1,7 @@
 import { getCurrentUser } from "@/server/contexts/auth/presentation/loaders/load-current-user";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { UserRoleBadge } from "@/client/components/user-management/UserRoleBadge";
+import { formatDate } from "@/client/lib";
 
 export const runtime = "nodejs";
 
@@ -10,7 +12,9 @@ export default async function UserInfoPage() {
     return (
       <div>
         <PageHeader label="User Info" title="ユーザー情報" />
-        <div className="bg-card rounded-xl p-4">ユーザー情報が見つかりません</div>
+        <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+          ユーザー情報が見つかりません
+        </div>
       </div>
     );
   }
@@ -20,19 +24,27 @@ export default async function UserInfoPage() {
   return (
     <div>
       <PageHeader label="User Info" title="ユーザー情報" />
-      <div className="bg-card rounded-xl p-4">
-        <p>
-          <b>ID:</b> {user.id}
-        </p>
-        <p>
-          <b>メールアドレス:</b> {user.email}
-        </p>
-        <p>
-          <b>ロール:</b> {user.role}
-        </p>
-        <p>
-          <b>作成日:</b> {createdAt.toLocaleString("ja-JP")}
-        </p>
+      <div className="rounded-lg border border-border bg-card px-6 py-2">
+        <dl className="text-sm">
+          <div className="flex items-center gap-6 border-b border-border-soft py-3">
+            <dt className="w-32 shrink-0 text-xs font-bold text-foreground">ID:</dt>
+            <dd className="font-latin text-xs text-muted-foreground">{user.id}</dd>
+          </div>
+          <div className="flex items-center gap-6 border-b border-border-soft py-3">
+            <dt className="w-32 shrink-0 text-xs font-bold text-foreground">メールアドレス:</dt>
+            <dd className="font-latin text-foreground">{user.email}</dd>
+          </div>
+          <div className="flex items-center gap-6 border-b border-border-soft py-3">
+            <dt className="w-32 shrink-0 text-xs font-bold text-foreground">ロール:</dt>
+            <dd>
+              <UserRoleBadge role={user.role} />
+            </dd>
+          </div>
+          <div className="flex items-center gap-6 py-3">
+            <dt className="w-32 shrink-0 text-xs font-bold text-foreground">作成日:</dt>
+            <dd className="font-latin text-foreground">{formatDate(createdAt)}</dd>
+          </div>
+        </dl>
       </div>
     </div>
   );

--- a/admin/src/app/(auth)/users/page.tsx
+++ b/admin/src/app/(auth)/users/page.tsx
@@ -18,14 +18,12 @@ export default async function UsersPage() {
   return (
     <div>
       <PageHeader label="Users" title="ユーザー管理" />
-      <div className="bg-card rounded-xl p-4">
-        <UserManagement
-          users={users}
-          availableRoles={["user", "admin"]}
-          updateUserRoleAction={updateUserRole}
-          inviteUserAction={inviteUser}
-        />
-      </div>
+      <UserManagement
+        users={users}
+        availableRoles={["user", "admin"]}
+        updateUserRoleAction={updateUserRole}
+        inviteUserAction={inviteUser}
+      />
     </div>
   );
 }

--- a/admin/src/client/components/layout/BackLink.tsx
+++ b/admin/src/client/components/layout/BackLink.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { ArrowLeft } from "@phosphor-icons/react/dist/ssr";
+
+interface BackLinkProps {
+  href: string;
+  children: string;
+}
+
+/** 詳細・編集画面の左上に置く「← 一覧に戻る」リンク。ページヘッダーの上に配置する。 */
+export function BackLink({ href, children }: BackLinkProps) {
+  return (
+    <div className="mb-4">
+      <Link
+        href={href}
+        className="inline-flex items-center gap-1.5 text-[13px] text-muted-foreground no-underline transition-colors duration-150 ease-out hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" />
+        {children}
+      </Link>
+    </div>
+  );
+}

--- a/admin/src/client/components/political-organizations/DeletePoliticalOrganizationButton.tsx
+++ b/admin/src/client/components/political-organizations/DeletePoliticalOrganizationButton.tsx
@@ -45,6 +45,7 @@ export function DeletePoliticalOrganizationButton({
       type="button"
       variant="destructive"
       size="sm"
+      className="text-xs"
       onClick={handleDelete}
       disabled={deleting}
     >

--- a/admin/src/client/components/political-organizations/PoliticalOrganizationCard.tsx
+++ b/admin/src/client/components/political-organizations/PoliticalOrganizationCard.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { Button } from "@/client/components/ui";
+import { formatDate } from "@/client/lib";
+import { DeletePoliticalOrganizationButton } from "@/client/components/political-organizations/DeletePoliticalOrganizationButton";
+import type { PoliticalOrganization } from "@/shared/models/political-organization";
+
+interface PoliticalOrganizationCardProps {
+  organization: PoliticalOrganization;
+}
+
+/**
+ * 政治団体一覧の 1 団体カード。
+ * 白・黒 1px 枠・角丸 8px・padding 22px 26px（ハンドオフ「3. 政治団体一覧」）。
+ * E2E がカードを「h3 の祖先で class に border を含む div」として探すため、
+ * ルート要素は div のまま `border` クラスを保持すること。
+ */
+export function PoliticalOrganizationCard({ organization }: PoliticalOrganizationCardProps) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-5 rounded-lg border border-border bg-card px-[26px] py-[22px]">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2.5">
+          <h3 className="text-[17px] font-bold leading-snug tracking-[0.04em] text-foreground">
+            {organization.displayName}
+          </h3>
+          <span className="font-latin inline-block rounded-full bg-accent px-3 py-0.5 text-[11px] font-bold leading-[1.6] text-accent-foreground">
+            {organization.slug}
+          </span>
+        </div>
+        {organization.description && (
+          <p className="mt-2 text-[13px] text-muted-foreground">{organization.description}</p>
+        )}
+        <div className="font-latin mt-2.5 text-xs text-subtle-foreground">
+          作成日: {formatDate(organization.createdAt)}
+        </div>
+      </div>
+      <div className="flex shrink-0 gap-2">
+        <Button variant="outline" size="sm" className="text-xs" asChild>
+          <Link href={`/political-organizations/${organization.id}`}>編集</Link>
+        </Button>
+        <DeletePoliticalOrganizationButton
+          orgId={BigInt(organization.id)}
+          orgName={organization.displayName}
+        />
+      </div>
+    </div>
+  );
+}

--- a/admin/src/client/components/political-organizations/PoliticalOrganizationForm.tsx
+++ b/admin/src/client/components/political-organizations/PoliticalOrganizationForm.tsx
@@ -64,7 +64,7 @@ export function PoliticalOrganizationForm({
     <Card>
       <CardContent>
         {error && (
-          <div className="text-destructive mb-4 p-3 bg-destructive/10 rounded-lg border border-destructive/30">
+          <div className="mb-4 rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive">
             {error}
           </div>
         )}

--- a/admin/src/client/components/report-profile/ContactPersonsSection.tsx
+++ b/admin/src/client/components/report-profile/ContactPersonsSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import "client-only";
 
+import { Plus } from "@phosphor-icons/react/dist/ssr";
 import type {
   ContactPerson,
   OrganizationReportProfileDetails,
@@ -58,8 +59,15 @@ export function ContactPersonsSection({ details, updateDetails }: ContactPersons
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle>事務担当者（最大3名）</CardTitle>
         {contactPersons.length < 3 && (
-          <Button type="button" variant="ghost" size="sm" onClick={addContactPerson}>
-            + 追加
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="text-xs"
+            onClick={addContactPerson}
+          >
+            <Plus />
+            追加
           </Button>
         )}
       </CardHeader>
@@ -71,15 +79,15 @@ export function ContactPersonsSection({ details, updateDetails }: ContactPersons
         )}
 
         {contactPersons.map((person, index) => (
-          <div key={person.id} className="bg-card rounded-lg p-3 border border-border">
+          <div key={person.id} className="rounded-lg border border-border-soft bg-card p-3">
             <div className="flex justify-between items-center mb-2">
               <span className="text-sm text-muted-foreground">事務担当者 {index + 1}</span>
               <Button
                 type="button"
-                variant="ghost"
+                variant="destructive"
                 size="sm"
                 onClick={() => removeContactPerson(index)}
-                className="text-destructive hover:text-destructive"
+                className="text-xs"
               >
                 削除
               </Button>

--- a/admin/src/client/components/report-profile/DietMemberRelationSection.tsx
+++ b/admin/src/client/components/report-profile/DietMemberRelationSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import "client-only";
 
+import { Plus } from "@phosphor-icons/react/dist/ssr";
 import type {
   DietMember,
   DietMemberPeriod,
@@ -15,6 +16,7 @@ import {
   Label,
   Input,
   Checkbox,
+  NativeSelect,
 } from "@/client/components/ui";
 
 interface DietMemberRelationSectionProps {
@@ -135,41 +137,48 @@ export function DietMemberRelationSection({
         <CardContent className="space-y-4">
           <div className="space-y-2">
             <Label>団体区分</Label>
-            <select
+            <NativeSelect
               value={dietMemberRelation.type}
               onChange={(e) =>
                 updateDietMemberRelation({
                   type: e.target.value as "0" | "1" | "2" | "3",
                 })
               }
-              className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-md"
+              wrapperClassName="w-full max-w-md"
             >
               <option value="1">1号団体</option>
               <option value="2">2号団体</option>
               <option value="3">両方</option>
-            </select>
+            </NativeSelect>
           </div>
 
           <div>
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-md font-medium text-foreground">関係する国会議員（最大3名）</h3>
               {(dietMemberRelation.members?.length ?? 0) < 3 && (
-                <Button type="button" variant="ghost" size="sm" onClick={addMember}>
-                  + 追加
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  onClick={addMember}
+                >
+                  <Plus />
+                  追加
                 </Button>
               )}
             </div>
             <div className="space-y-3">
               {(dietMemberRelation.members ?? []).map((member, index) => (
-                <div key={member.id} className="bg-card rounded-lg p-3 border border-border">
+                <div key={member.id} className="rounded-lg border border-border-soft bg-card p-3">
                   <div className="flex justify-between items-center mb-2">
                     <span className="text-sm text-muted-foreground">議員 {index + 1}</span>
                     <Button
                       type="button"
-                      variant="ghost"
+                      variant="destructive"
                       size="sm"
                       onClick={() => removeMember(index)}
-                      className="text-destructive hover:text-destructive"
+                      className="text-xs"
                     >
                       削除
                     </Button>
@@ -197,35 +206,35 @@ export function DietMemberRelationSection({
                   <div className="grid grid-cols-2 gap-3">
                     <div className="space-y-2">
                       <Label className="text-muted-foreground">院</Label>
-                      <select
+                      <NativeSelect
                         value={member.chamber}
                         onChange={(e) =>
                           updateMember(index, {
                             chamber: e.target.value as "1" | "2",
                           })
                         }
-                        className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                        wrapperClassName="w-full"
                       >
                         <option value="1">衆議院議員</option>
                         <option value="2">参議院議員</option>
-                      </select>
+                      </NativeSelect>
                     </div>
                     <div className="space-y-2">
                       <Label className="text-muted-foreground">種別</Label>
-                      <select
+                      <NativeSelect
                         value={member.positionType}
                         onChange={(e) =>
                           updateMember(index, {
                             positionType: e.target.value as "1" | "2" | "3" | "4",
                           })
                         }
-                        className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                        wrapperClassName="w-full"
                       >
                         <option value="1">現職</option>
                         <option value="2">候補者</option>
                         <option value="3">候補者となろうとする者</option>
                         <option value="4">候補者等</option>
-                      </select>
+                      </NativeSelect>
                     </div>
                   </div>
                 </div>
@@ -237,8 +246,15 @@ export function DietMemberRelationSection({
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-md font-medium text-foreground">指定期間（最大3件）</h3>
               {(dietMemberRelation.periods?.length ?? 0) < 3 && (
-                <Button type="button" variant="ghost" size="sm" onClick={addPeriod}>
-                  + 追加
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  onClick={addPeriod}
+                >
+                  <Plus />
+                  追加
                 </Button>
               )}
             </div>
@@ -264,10 +280,10 @@ export function DietMemberRelationSection({
                   />
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="destructive"
                     size="sm"
                     onClick={() => removePeriod(index)}
-                    className="text-destructive hover:text-destructive"
+                    className="text-xs"
                   >
                     削除
                   </Button>

--- a/admin/src/client/components/report-profile/FundManagementSection.tsx
+++ b/admin/src/client/components/report-profile/FundManagementSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import "client-only";
 
+import { Plus } from "@phosphor-icons/react/dist/ssr";
 import type {
   FundManagement,
   FundManagementPeriod,
@@ -14,6 +15,7 @@ import {
   Label,
   Input,
   Checkbox,
+  NativeSelect,
 } from "@/client/components/ui";
 
 interface FundManagementSectionProps {
@@ -113,21 +115,21 @@ export function FundManagementSection({ details, updateDetails }: FundManagement
 
           <div className="space-y-2">
             <Label>公職の種別</Label>
-            <select
+            <NativeSelect
               value={fundManagement.publicPositionType ?? ""}
               onChange={(e) =>
                 updateFundManagement({
                   publicPositionType: e.target.value as "1" | "2" | "3" | "4" | undefined,
                 })
               }
-              className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-w-md"
+              wrapperClassName="w-full max-w-md"
             >
               <option value="">選択してください</option>
               <option value="1">現職</option>
               <option value="2">候補者</option>
               <option value="3">候補者となろうとする者</option>
               <option value="4">候補者等</option>
-            </select>
+            </NativeSelect>
           </div>
 
           <div>
@@ -174,8 +176,15 @@ export function FundManagementSection({ details, updateDetails }: FundManagement
             <div className="flex justify-between items-center mb-2">
               <h3 className="text-md font-medium text-foreground">指定期間（最大3件）</h3>
               {(fundManagement.periods?.length ?? 0) < 3 && (
-                <Button type="button" variant="ghost" size="sm" onClick={addPeriod}>
-                  + 追加
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  onClick={addPeriod}
+                >
+                  <Plus />
+                  追加
                 </Button>
               )}
             </div>
@@ -201,10 +210,10 @@ export function FundManagementSection({ details, updateDetails }: FundManagement
                   />
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="destructive"
                     size="sm"
                     onClick={() => removePeriod(index)}
-                    className="text-destructive hover:text-destructive"
+                    className="text-xs"
                   >
                     削除
                   </Button>

--- a/admin/src/client/components/report-profile/OrganizationTypeSection.tsx
+++ b/admin/src/client/components/report-profile/OrganizationTypeSection.tsx
@@ -2,7 +2,15 @@
 import "client-only";
 
 import type { OrganizationReportProfileDetails } from "@/server/contexts/report/domain/models/organization-report-profile";
-import { Card, CardHeader, CardTitle, CardContent, Label, Input } from "@/client/components/ui";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Label,
+  Input,
+  NativeSelect,
+} from "@/client/components/ui";
 
 interface OrganizationTypeSectionProps {
   details: OrganizationReportProfileDetails;
@@ -31,19 +39,19 @@ export function OrganizationTypeSection({ details, updateDetails }: Organization
 
         <div className="space-y-2">
           <Label>活動区域</Label>
-          <select
+          <NativeSelect
             value={details.activityArea ?? ""}
             onChange={(e) =>
               updateDetails({
                 activityArea: e.target.value as "1" | "2" | undefined,
               })
             }
-            className="flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+            wrapperClassName="w-full"
           >
             <option value="">選択してください</option>
             <option value="1">二以上の都道府県の区域</option>
             <option value="2">一つの都道府県の区域</option>
-          </select>
+          </NativeSelect>
         </div>
 
         <div className="space-y-2">

--- a/admin/src/client/components/report-profile/ReportProfileForm.tsx
+++ b/admin/src/client/components/report-profile/ReportProfileForm.tsx
@@ -88,13 +88,13 @@ export function ReportProfileForm({
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       {error && (
-        <div className="text-destructive p-3 bg-destructive/10 rounded-lg border border-destructive/30">
+        <div className="rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive">
           {error}
         </div>
       )}
 
       {success && (
-        <div className="text-green-500 p-3 bg-green-900/20 rounded-lg border border-green-900/30">
+        <div className="rounded-lg border border-primary-active bg-accent p-3 text-sm text-accent-foreground">
           保存しました
         </div>
       )}

--- a/admin/src/client/components/report-profile/YearSelector.tsx
+++ b/admin/src/client/components/report-profile/YearSelector.tsx
@@ -2,7 +2,7 @@
 import "client-only";
 
 import { useRouter } from "next/navigation";
-import { Label } from "@/client/components/ui";
+import { Label, NativeSelect } from "@/client/components/ui";
 
 interface YearSelectorProps {
   orgId: string;
@@ -14,11 +14,14 @@ export function YearSelector({ orgId, financialYear, currentYear }: YearSelector
   const router = useRouter();
 
   return (
-    <div className="space-y-2">
-      <Label>報告年</Label>
-      <select
+    <div className="flex items-center gap-3">
+      <Label htmlFor="financial-year" className="text-xs font-bold">
+        報告年
+      </Label>
+      <NativeSelect
+        id="financial-year"
         key={financialYear}
-        className="flex h-9 w-32 rounded-md border border-border bg-input px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+        className="font-latin w-32"
         defaultValue={financialYear}
         onChange={(e) => {
           router.push(`/political-organizations/${orgId}/report-profile?year=${e.target.value}`);
@@ -29,7 +32,7 @@ export function YearSelector({ orgId, financialYear, currentYear }: YearSelector
             {y}年
           </option>
         ))}
-      </select>
+      </NativeSelect>
     </div>
   );
 }

--- a/admin/src/client/components/ui/index.ts
+++ b/admin/src/client/components/ui/index.ts
@@ -32,6 +32,7 @@ export {
   TableRow,
   TableCell,
 } from "@/client/components/ui/table";
+export { NativeSelect } from "@/client/components/ui/native-select";
 export { Textarea } from "@/client/components/ui/textarea";
 export { Checkbox } from "@/client/components/ui/checkbox";
 export {

--- a/admin/src/client/components/ui/native-select.tsx
+++ b/admin/src/client/components/ui/native-select.tsx
@@ -1,0 +1,36 @@
+import type * as React from "react";
+import { CaretDown } from "@phosphor-icons/react/dist/ssr";
+
+import { cn } from "@/client/lib/index";
+
+/**
+ * ネイティブ `<select>` のピル版。
+ * Radix Select（`Select` / `SelectTrigger`）を使えない箇所（フォーム送信でそのまま値を扱いたい、
+ * E2E が `getByLabel` で直接 select を取りたい等）向けに、ピル形状・黒枠・teal フォーカスリングを揃える。
+ * `className` は select 本体に、`wrapperClassName` は外側の相対配置ラッパーに当たる。
+ */
+function NativeSelect({
+  className,
+  wrapperClassName,
+  ...props
+}: React.ComponentProps<"select"> & { wrapperClassName?: string }) {
+  return (
+    <div data-slot="native-select" className={cn("relative inline-flex w-fit", wrapperClassName)}>
+      <select
+        className={cn(
+          "bg-input border-border text-foreground h-9 w-full min-w-0 appearance-none rounded-full border py-1 pr-10 pl-4 text-sm transition-[color,border-color,box-shadow] duration-150 ease-out outline-none",
+          "focus-visible:border-ring focus-visible:ring-ring-soft focus-visible:ring-[2px]",
+          "disabled:cursor-not-allowed disabled:border-disabled-border disabled:text-disabled-foreground",
+          className,
+        )}
+        {...props}
+      />
+      <CaretDown
+        aria-hidden
+        className="text-muted-foreground pointer-events-none absolute top-1/2 right-4 size-4 -translate-y-1/2"
+      />
+    </div>
+  );
+}
+
+export { NativeSelect };

--- a/admin/src/client/components/user-management/UserManagement.tsx
+++ b/admin/src/client/components/user-management/UserManagement.tsx
@@ -3,7 +3,19 @@ import "client-only";
 import { useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { Button, Input, Card } from "../ui";
+import {
+  Button,
+  Input,
+  NativeSelect,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/client/components/ui";
+import { UserRoleBadge } from "@/client/components/user-management/UserRoleBadge";
+import { formatDate } from "@/client/lib";
 import type { UserRole } from "@/server/contexts/auth/domain/models/user-role";
 import type { User } from "@/server/contexts/shared/domain/repositories/user-repository.interface";
 
@@ -99,86 +111,72 @@ export default function UserManagement({
   return (
     <div className="space-y-4">
       {/* Invite User Form */}
-      <Card className="p-4">
-        <h2 className="text-lg font-medium text-foreground mb-4">新規ユーザー招待</h2>
-        <form onSubmit={handleInviteUser} className="flex gap-4">
-          <div className="flex-1">
-            <Input
-              type="email"
-              value={inviteEmail}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setInviteEmail(e.target.value)}
-              placeholder="メールアドレスを入力"
-              disabled={isInviting}
-              required
-            />
-          </div>
+      <div className="rounded-lg border border-border bg-card p-6">
+        <h2 className="mb-4 text-base font-bold text-foreground">新規ユーザー招待</h2>
+        <form onSubmit={handleInviteUser} className="flex flex-wrap gap-3">
+          <Input
+            type="email"
+            value={inviteEmail}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setInviteEmail(e.target.value)}
+            placeholder="メールアドレスを入力"
+            disabled={isInviting}
+            className="max-w-md flex-1"
+            required
+          />
           <Button type="submit" disabled={isInviting || !inviteEmail.trim()}>
             {isInviting ? "送信中..." : "招待を送信"}
           </Button>
         </form>
-      </Card>
+      </div>
 
-      <Card className="overflow-hidden p-0">
-        <table className="min-w-full divide-y divide-border">
-          <thead className="bg-secondary">
-            <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                メール
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                ロール
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                作成日
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                操作
-              </th>
-            </tr>
-          </thead>
-          <tbody className="bg-card divide-y divide-border">
+      <div className="rounded-lg border border-border bg-card p-6">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>メール</TableHead>
+              <TableHead>ロール</TableHead>
+              <TableHead>作成日</TableHead>
+              <TableHead>操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {users.map((user) => (
-              <tr key={user.id}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
+              <TableRow key={user.id}>
+                <TableCell className="font-latin text-[13px] text-foreground">
                   {user.email}
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
-                  <span
-                    className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                      user.role === "admin"
-                        ? "bg-red-900 text-red-200"
-                        : "bg-green-900 text-green-200"
-                    }`}
-                  >
-                    {user.role}
-                  </span>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-muted-foreground">
-                  {new Date(user.createdAt).toLocaleDateString()}
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                  <select
+                </TableCell>
+                <TableCell>
+                  <UserRoleBadge role={user.role} />
+                </TableCell>
+                <TableCell className="font-latin text-[13px] text-muted-foreground">
+                  {formatDate(user.createdAt)}
+                </TableCell>
+                <TableCell>
+                  <NativeSelect
+                    aria-label={`${user.email} のロール`}
                     value={user.role}
                     onChange={(e) => handleRoleChange(user.id, e.target.value as UserRole)}
                     disabled={isLoading}
-                    className="bg-input text-foreground border border-border rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    className="h-8 text-xs"
                   >
                     {availableRoles.map((role) => (
                       <option key={role} value={role}>
                         {role.charAt(0).toUpperCase() + role.slice(1)}
                       </option>
                     ))}
-                  </select>
-                </td>
-              </tr>
+                  </NativeSelect>
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
 
         {users.length === 0 && (
-          <div className="text-center py-8 text-muted-foreground">ユーザーが見つかりません</div>
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            ユーザーが見つかりません
+          </div>
         )}
-      </Card>
+      </div>
     </div>
   );
 }

--- a/admin/src/client/components/user-management/UserRoleBadge.tsx
+++ b/admin/src/client/components/user-management/UserRoleBadge.tsx
@@ -1,0 +1,21 @@
+import type { UserRole } from "@/server/contexts/auth/domain/models/user-role";
+import { cn, resolveUserRoleBadge } from "@/client/lib";
+
+interface UserRoleBadgeProps {
+  role: UserRole;
+}
+
+/** ユーザーロールのピルバッジ（11px/700・1.5px 枠）。admin=teal / user=グレー。 */
+export function UserRoleBadge({ role }: UserRoleBadgeProps) {
+  const badge = resolveUserRoleBadge(role);
+  return (
+    <span
+      className={cn(
+        "font-latin inline-block rounded-full border-[1.5px] px-3 py-[3px] text-[11px] font-bold leading-none tracking-[0.04em] whitespace-nowrap",
+        badge.className,
+      )}
+    >
+      {badge.label}
+    </span>
+  );
+}

--- a/admin/src/client/lib/index.ts
+++ b/admin/src/client/lib/index.ts
@@ -2,3 +2,4 @@ export { cn } from "./utils";
 export { formatDate, formatAmount, formatCurrency } from "./format";
 export { resolveCategoryPill } from "./category-pill";
 export type { CategoryPillSource } from "./category-pill";
+export { resolveUserRoleBadge } from "./user-role-badge";

--- a/admin/src/client/lib/user-role-badge.ts
+++ b/admin/src/client/lib/user-role-badge.ts
@@ -1,0 +1,26 @@
+import type { UserRole } from "@/server/contexts/auth/domain/models/user-role";
+
+interface UserRoleBadge {
+  label: string;
+  /** ピルバッジの色クラス。admin は teal、user はグレー（ハンドオフ「状態バッジは teal / 赤 / グレーのピル」） */
+  className: string;
+}
+
+/**
+ * ユーザーロールをバッジ表示用のラベルと色クラスに解決する。
+ * ユーザー情報画面とユーザー管理画面で同じ見た目を共有するための単一の変換点。
+ */
+export function resolveUserRoleBadge(role: UserRole): UserRoleBadge {
+  switch (role) {
+    case "admin":
+      return {
+        label: "admin",
+        className: "border-primary-active text-primary-active bg-accent",
+      };
+    case "user":
+      return {
+        label: "user",
+        className: "border-subtle-foreground text-muted-foreground bg-secondary",
+      };
+  }
+}

--- a/admin/tests/client/lib/user-role-badge.test.ts
+++ b/admin/tests/client/lib/user-role-badge.test.ts
@@ -1,0 +1,23 @@
+import { resolveUserRoleBadge } from "@/client/lib/user-role-badge";
+
+describe("resolveUserRoleBadge", () => {
+  it("admin は teal 系のピル（accent 背景・teal-deep 文字）になる", () => {
+    const badge = resolveUserRoleBadge("admin");
+    expect(badge.label).toBe("admin");
+    expect(badge.className).toContain("bg-accent");
+    expect(badge.className).toContain("text-primary-active");
+  });
+
+  it("user はグレー系のピル（secondary 背景・muted 文字）になる", () => {
+    const badge = resolveUserRoleBadge("user");
+    expect(badge.label).toBe("user");
+    expect(badge.className).toContain("bg-secondary");
+    expect(badge.className).toContain("text-muted-foreground");
+  });
+
+  it("旧テーマの Tailwind パレット直書き（red/green）を含まない", () => {
+    for (const role of ["admin", "user"] as const) {
+      expect(resolveUserRoleBadge(role).className).not.toMatch(/(red|green)-\d{3}/);
+    }
+  });
+});


### PR DESCRIPTION
## 目的（Why）

admin リデザイン（土台 #1289、ページヘッダー #1291）の続きとして、サイドバー「基本情報」配下の画面とダッシュボードを Team Mirai ブランド（白カード・黒1px枠・ピル・Mirai Teal）に揃え、管理者が旧ダークテーマ由来の不統一な見た目に惑わされない状態にする。
正はハンドオフ `docs/reference/design_handoff_admin_redesign/README.md` の「3. 政治団体一覧」「6. その他の画面」。

Closes #1293

## 変更内容

- **政治団体一覧**: ヘッダー右に teal 塗り「新規作成」ピル（`Plus` アイコン）。団体カードを `PoliticalOrganizationCard` に切り出し、白・黒1px枠・角丸8px・padding `22px 26px`、団体名 17px/700 + teal-100 ピル、説明 13px、作成日 `作成日: YYYY.MM.DD`（Poppins 12px）、右に「編集」黒枠白ピル /「削除」赤枠ピル
  - モデルに「種別」が無いため、ピルには暫定で **slug** を表示（→ #1319）
- **新規作成・編集・報告書プロフィール**: 「← 一覧に戻る」を `BackLink`（Phosphor `ArrowLeft`）に共通化。旧 `rounded-md shadow-sm opacity-50` のネイティブ select をピル型 **`NativeSelect`**（ui に追加）に統一。「+ 追加」を outline、「削除」を destructive の 3 系統ボタンに。保存成功・エラー表示を teal / 赤トークンに。`YearSelector` は `htmlFor` で Label と紐付け、ページヘッダー右に配置
- **ユーザー情報**: 白カード + 弱い罫線の定義リスト、ロールバッジ、日付 `YYYY.MM.DD`
- **ユーザー管理**: 招待フォームと一覧を白カード + `ui/Table` に。ロールバッジを `UserRoleBadge`（admin=teal / user=グレー、`resolveUserRoleBadge` で共通化）に、ロール select をピル型に、日付 `YYYY.MM.DD`
- **ダッシュボード**: PageHeader + 白カード（黒1px枠）
- 旧テーマの Tailwind 直書き（`bg-red-900` `text-green-500` `text-red-500` 等）をこれらの画面から除去
- **E2E**: 報告書プロフィールの年度 select を xpath から `getByLabel("報告年")` に変更（他の E2E は変更なし。政治団体カードは `border` クラスを保持）

### スクリーンショット（ローカル）

政治団体一覧 / ユーザー管理 / ユーザー情報 / 編集 / 報告書プロフィール を Playwright で確認済み（白カード・ピル・teal バッジ・`YYYY.MM.DD` 表示）。

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ 通過（admin 898 tests, webapp 135 tests）
- admin E2E（`playwright test --workers=1`、ローカル supabase）: ✅ 42 passed

## スコープアウトして起票した Issue

- #1319 政治団体に「種別」を持たせて種別ピルに表示する（Prisma マイグレーションが必要 → `loop:human`）
- #1320 フォームラベル（`ui/label`）をハンドオフの 12px/700 に揃える（`loop:ready`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 政治団体一覧をカード形式で表示し、編集・削除・新規作成への導線を整理しました。
  - 政治団体や報告書プロフィール画面に、統一された戻るリンクを追加しました。
  - ユーザーロールをバッジで表示し、ユーザー情報と管理画面のレイアウトを刷新しました。
  - 年度や各種項目の選択 UI を統一しました。

- **改善**
  - ボタン、入力欄、エラー・成功メッセージの配色やレイアウトを統一しました。
  - 報告書プロフィール画面の操作性と情報配置を改善しました。
  - 各画面の余白、境界線、文字サイズを調整し、視認性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->