### PR TITLE
feat(admin): 取引先マスタ・寄付者マスタ画面をリデザインする

### DIFF
--- a/admin/src/client/components/counterparts/AddressInput.tsx
+++ b/admin/src/client/components/counterparts/AddressInput.tsx
@@ -2,7 +2,9 @@
 import "client-only";
 
 import { useId, useState } from "react";
+import { ArrowSquareOut, MagnifyingGlass } from "@phosphor-icons/react/dist/ssr";
 import { Button, Input, Label } from "@/client/components/ui";
+import { cn } from "@/client/lib";
 import { useAddressSearch } from "@/client/components/counterparts/useAddressSearch";
 import type { AddressCandidate } from "@/server/contexts/report/presentation/types/address-search";
 
@@ -21,12 +23,13 @@ interface AddressInputProps {
   disabled?: boolean;
 }
 
+/** 確度ラベル。ブランド外の色（黄・オレンジ）は使わず、高=teal deep / 中=墨 / 低=赤で表す */
 function getConfidenceLabel(confidence: AddressCandidate["confidence"]) {
   switch (confidence) {
     case "high":
-      return { text: "高確度", className: "text-primary-hover" };
+      return { text: "高確度", className: "text-primary-active" };
     case "medium":
-      return { text: "中確度", className: "text-yellow-600" };
+      return { text: "中確度", className: "text-foreground" };
     case "low":
       return { text: "低確度", className: "text-destructive" };
   }
@@ -62,15 +65,16 @@ export function AddressInput({
   };
 
   const canSearch = searchQuery.trim() !== "";
+  const isNoResults = searchResult?.success === false && searchResult.error.type === "NO_RESULTS";
 
   return (
-    <div className="border border-border rounded-lg bg-muted/30">
+    <div className="rounded-lg border border-border bg-secondary">
       {/* 検索フォーム */}
-      <div className="p-4 space-y-3">
-        <Label className="text-sm font-medium">AI検索で入力を補助</Label>
+      <div className="space-y-3 p-4">
+        <p className="text-xs font-bold text-foreground">AI検索で入力を補助</p>
 
-        <div>
-          <Label htmlFor={searchQueryId} className="text-sm text-muted-foreground">
+        <div className="space-y-1.5">
+          <Label htmlFor={searchQueryId} className="text-xs text-muted-foreground">
             会社名
           </Label>
           <Input
@@ -80,12 +84,11 @@ export function AddressInput({
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="XXX銀行"
             disabled={disabled || phase === "searching"}
-            className="mt-1"
           />
         </div>
 
-        <div>
-          <Label htmlFor={hintId} className="text-sm text-muted-foreground">
+        <div className="space-y-1.5">
+          <Label htmlFor={hintId} className="text-xs text-muted-foreground">
             検索ヒント（任意）
           </Label>
           <Input
@@ -95,22 +98,33 @@ export function AddressInput({
             onChange={(e) => setHint(e.target.value)}
             placeholder="印刷業/米国法人/本社住所 など"
             disabled={disabled || phase === "searching"}
-            className="mt-1"
           />
         </div>
 
         {phase === "initial" && (
-          <Button type="button" onClick={startSearch} disabled={disabled || !canSearch}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={startSearch}
+            disabled={disabled || !canSearch}
+          >
+            <MagnifyingGlass />
             AI検索
           </Button>
         )}
         {phase === "searching" && (
-          <Button type="button" disabled>
+          <Button type="button" variant="outline" disabled>
             検索中...
           </Button>
         )}
         {phase === "results" && (
-          <Button type="button" onClick={reSearch} disabled={disabled || isSearching || !canSearch}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={reSearch}
+            disabled={disabled || isSearching || !canSearch}
+          >
+            <MagnifyingGlass />
             再検索
           </Button>
         )}
@@ -119,7 +133,7 @@ export function AddressInput({
       {/* 検索結果 */}
       {phase === "results" &&
         (searchResult?.success ? (
-          <div className="border-t border-border divide-y divide-border">
+          <div className="divide-y divide-border-soft border-t border-border bg-card rounded-b-lg">
             <div className="px-4 py-2 text-xs text-muted-foreground">
               候補から選択してください（下のフィールドに自動入力されます）
             </div>
@@ -129,30 +143,37 @@ export function AddressInput({
               return (
                 <div key={key} className="px-4 py-3">
                   <div className="flex items-start justify-between gap-2">
-                    <div className="flex-1 min-w-0">
-                      <div className="text-foreground font-medium">{candidate.companyName}</div>
-                      <div className="text-muted-foreground text-sm mt-1">
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[13px] font-semibold text-foreground">
+                        {candidate.companyName}
+                      </div>
+                      <div className="mt-1 text-[13px] text-muted-foreground">
                         {candidate.postalCode && (
                           <span className="mr-2">〒{candidate.postalCode.replace(/^〒/, "")}</span>
                         )}
                         {candidate.address}
                       </div>
-                      <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+                      <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
                         <span>根拠: {candidate.source}</span>
-                        <span className={confidence.className}>{confidence.text}</span>
+                        <span className={cn("font-bold", confidence.className)}>
+                          {confidence.text}
+                        </span>
                       </div>
                     </div>
-                    <div className="flex items-center gap-2 flex-shrink-0">
+                    <div className="flex flex-shrink-0 items-center gap-2">
                       <button
                         type="button"
                         onClick={() => openGoogleSearch(candidate)}
-                        className="text-xs text-primary hover:underline"
+                        className="inline-flex items-center gap-1 text-xs text-primary-active transition-colors duration-150 ease-out hover:text-primary-hover hover:underline"
                       >
-                        確認↗
+                        確認
+                        <ArrowSquareOut className="size-3.5" />
                       </button>
                       <Button
                         type="button"
+                        variant="outline"
                         size="sm"
+                        className="text-xs"
                         onClick={() => handleSelectCandidate(candidate)}
                         disabled={disabled}
                       >
@@ -166,7 +187,14 @@ export function AddressInput({
           </div>
         ) : (
           <div className="border-t border-border p-4">
-            <div className="text-yellow-500 p-3 bg-yellow-900/20 rounded-lg border border-yellow-900/30 text-sm">
+            <div
+              className={cn(
+                "rounded-lg border p-3 text-sm",
+                isNoResults
+                  ? "border-border-soft bg-card text-muted-foreground"
+                  : "border-destructive bg-destructive-hover text-destructive",
+              )}
+            >
               {searchResult?.error.type === "NO_RESULTS"
                 ? searchResult.error.message
                 : searchResult?.error.type === "RATE_LIMIT"

--- a/admin/src/client/components/counterparts/CounterpartDetailClient.tsx
+++ b/admin/src/client/components/counterparts/CounterpartDetailClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 import "client-only";
 
-import { useMemo, useState, useTransition } from "react";
+import { useId, useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
+import { PencilSimple } from "@phosphor-icons/react/dist/ssr";
 import type { RowSelectionState } from "@tanstack/react-table";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { TransactionWithCounterpart } from "@/server/contexts/report/domain/models/transaction-with-counterpart";
@@ -15,8 +15,9 @@ import { TransactionWithCounterpartTable } from "@/client/components/counterpart
 import { AssignCounterpartDialog } from "@/client/components/counterpart-assignment/AssignCounterpartDialog";
 import { CounterpartFormDialog } from "@/client/components/counterparts/CounterpartFormDialog";
 import { PageHeader } from "@/client/components/layout/PageHeader";
-import { ClientPagination } from "@/client/components/ui/ClientPagination";
-import { Card, Input, Button, Label } from "@/client/components/ui";
+import { BackLink } from "@/client/components/layout/BackLink";
+import { StaticPagination } from "@/client/components/ui/StaticPagination";
+import { Input, Button, Label } from "@/client/components/ui";
 import { formatDate } from "@/client/lib";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
 import { bulkUnassignCounterpartAction } from "@/server/contexts/report/presentation/actions/bulk-unassign-counterpart";
@@ -49,6 +50,7 @@ export function CounterpartDetailClient({
 }: CounterpartDetailClientProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const yearInputId = useId();
 
   const initialFinancialYear = useMemo(() => new Date().getFullYear(), []);
 
@@ -171,12 +173,6 @@ export function CounterpartDetailClient({
     });
   };
 
-  const handlePageChange = (newPage: number) => {
-    startTransition(() => {
-      router.push(buildUrl({ page: newPage }));
-    });
-  };
-
   const handleEditSuccess = () => {
     setIsEditDialogOpen(false);
     router.refresh();
@@ -184,59 +180,66 @@ export function CounterpartDetailClient({
 
   return (
     <div>
-      <div className="mb-4">
-        <Link
-          href="/counterparts"
-          className="text-muted-foreground hover:text-foreground transition-colors"
-        >
-          ← 一覧に戻る
-        </Link>
-      </div>
+      <BackLink href="/counterparts">一覧に戻る</BackLink>
 
-      <PageHeader label="Counterparts" title="取引先詳細" />
+      <PageHeader
+        label="Counterparts"
+        title="取引先詳細"
+        actions={
+          <Button
+            type="button"
+            variant="outline"
+            className="text-[13px]"
+            onClick={() => setIsEditDialogOpen(true)}
+          >
+            <PencilSimple />
+            編集
+          </Button>
+        }
+      />
 
-      <div className="bg-card rounded-xl p-4 space-y-6">
-        <Card className="p-6">
-          <div className="flex justify-between items-start mb-4">
-            <h2 className="text-lg font-semibold text-foreground">カウンターパート情報</h2>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => setIsEditDialogOpen(true)}
-            >
-              編集
-            </Button>
-          </div>
+      <div className="flex flex-col gap-6">
+        <section className="rounded-lg border border-border bg-card p-6">
+          <h2 className="mb-4 text-[17px] font-bold tracking-[0.04em] text-foreground">
+            取引先情報
+          </h2>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <dl className="grid grid-cols-1 gap-x-8 gap-y-4 md:grid-cols-2">
             <div>
-              <div className="text-muted-foreground text-sm mb-1">名前</div>
-              <div className="text-foreground font-medium">{counterpart.name}</div>
+              <dt className="mb-1 text-xs font-bold text-muted-foreground">名前</dt>
+              <dd className="text-sm font-semibold text-foreground">{counterpart.name}</dd>
             </div>
             <div>
-              <div className="text-muted-foreground text-sm mb-1">住所</div>
-              <div className="text-foreground">{counterpart.address || "-"}</div>
+              <dt className="mb-1 text-xs font-bold text-muted-foreground">住所</dt>
+              <dd className="text-sm text-foreground">{counterpart.address || "-"}</dd>
             </div>
             <div>
-              <div className="text-muted-foreground text-sm mb-1">作成日</div>
-              <div className="text-foreground">{formatDate(counterpart.createdAt)}</div>
+              <dt className="mb-1 text-xs font-bold text-muted-foreground">作成日</dt>
+              <dd className="font-latin text-sm text-foreground">
+                {formatDate(counterpart.createdAt)}
+              </dd>
             </div>
             <div>
-              <div className="text-muted-foreground text-sm mb-1">更新日</div>
-              <div className="text-foreground">{formatDate(counterpart.updatedAt)}</div>
+              <dt className="mb-1 text-xs font-bold text-muted-foreground">更新日</dt>
+              <dd className="font-latin text-sm text-foreground">
+                {formatDate(counterpart.updatedAt)}
+              </dd>
             </div>
             <div>
-              <div className="text-muted-foreground text-sm mb-1">使用回数</div>
-              <div className="text-foreground">{counterpart.usageCount}件</div>
+              <dt className="mb-1 text-xs font-bold text-muted-foreground">使用回数</dt>
+              <dd className="font-latin text-sm font-semibold text-foreground">
+                {counterpart.usageCount}件
+              </dd>
             </div>
-          </div>
-        </Card>
+          </dl>
+        </section>
 
-        <Card className="p-6">
-          <h2 className="text-lg font-semibold text-foreground mb-4">紐づいている取引</h2>
+        <section className="rounded-lg border border-border bg-card p-6">
+          <h2 className="mb-4 text-[17px] font-bold tracking-[0.04em] text-foreground">
+            紐づいている取引
+          </h2>
 
-          <div className="flex flex-col md:flex-row md:items-end gap-4 mb-6">
+          <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-end">
             <div className="w-fit">
               <PoliticalOrganizationSelect
                 organizations={organizations}
@@ -245,28 +248,30 @@ export function CounterpartDetailClient({
               />
             </div>
             <div className="w-fit space-y-2">
-              <Label>報告年 (西暦)</Label>
+              <Label htmlFor={yearInputId}>報告年 (西暦)</Label>
               <Input
+                id={yearInputId}
                 type="number"
                 value={String(financialYear)}
                 onChange={handleYearChange}
                 min={1900}
                 max={2100}
                 required
-                className="w-24"
+                className="font-latin w-28"
               />
             </div>
           </div>
 
-          <div className="flex justify-between items-center mb-4">
-            <div className="text-muted-foreground text-sm">{total}件の取引</div>
-            {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
+          <div className="mb-3 flex items-center justify-between">
+            <p className="text-[13px] text-muted-foreground">{total}件の取引</p>
+            {isPending && <p className="text-[13px] text-muted-foreground">読み込み中...</p>}
           </div>
 
           {selectedTransactions.length > 0 && (
-            <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-              <span className="text-foreground text-sm">
-                選択中: <span className="font-medium">{selectedTransactions.length}件</span>
+            <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-border-soft bg-secondary p-3">
+              <span className="text-[13px] text-foreground">
+                選択中:{" "}
+                <span className="font-latin font-semibold">{selectedTransactions.length}</span>件
               </span>
               <Button type="button" size="sm" onClick={handleBulkAssignClick}>
                 一括紐付け変更
@@ -280,7 +285,7 @@ export function CounterpartDetailClient({
               >
                 {isUnassigning ? "処理中..." : "一括紐付け解除"}
               </Button>
-              <Button type="button" variant="ghost" size="sm" onClick={() => setRowSelection({})}>
+              <Button type="button" variant="outline" size="sm" onClick={() => setRowSelection({})}>
                 選択解除
               </Button>
             </div>
@@ -297,13 +302,13 @@ export function CounterpartDetailClient({
           />
 
           {totalPages > 1 && (
-            <ClientPagination
+            <StaticPagination
               currentPage={page}
               totalPages={totalPages}
-              onPageChange={handlePageChange}
+              buildPageUrl={(nextPage) => buildUrl({ page: nextPage })}
             />
           )}
-        </Card>
+        </section>
 
         {isEditDialogOpen && (
           <CounterpartFormDialog

--- a/admin/src/client/components/counterparts/CounterpartFormContent.tsx
+++ b/admin/src/client/components/counterparts/CounterpartFormContent.tsx
@@ -87,9 +87,12 @@ export function CounterpartFormContent({
   const loadingLabel = submitLabel ? `${submitLabel}中...` : defaultLoadingLabel;
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-5">
       {error && (
-        <div className="text-red-500 p-3 bg-red-900/20 rounded-lg border border-red-900/30">
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive"
+        >
           {error}
         </div>
       )}
@@ -102,9 +105,9 @@ export function CounterpartFormContent({
       />
 
       {/* 目的フィールド: 社名入力 */}
-      <div>
+      <div className="space-y-2">
         <Label htmlFor={nameId}>
-          名前 <span className="text-red-500">*</span>
+          名前 <span className="text-destructive">*</span>
         </Label>
         <Input
           type="text"
@@ -119,7 +122,7 @@ export function CounterpartFormContent({
       </div>
 
       {/* 目的フィールド: 郵便番号入力 */}
-      <div>
+      <div className="space-y-2">
         <Label htmlFor={postalCodeId}>郵便番号</Label>
         <Input
           type="text"
@@ -133,7 +136,7 @@ export function CounterpartFormContent({
       </div>
 
       {/* 目的フィールド: 住所入力 */}
-      <div>
+      <div className="space-y-2">
         <Label htmlFor={addressId}>住所</Label>
         <Input
           type="text"
@@ -147,13 +150,14 @@ export function CounterpartFormContent({
       </div>
 
       {mode === "edit" && initialData?.usageCount !== undefined && (
-        <div className="text-muted-foreground text-sm">
-          使用状況: {initialData.usageCount}件のTransactionで使用中
-        </div>
+        <p className="text-[13px] text-muted-foreground">
+          使用状況: <span className="font-latin">{initialData.usageCount}</span>
+          件の取引で使用中
+        </p>
       )}
 
       {mode === "create" && (
-        <p className="text-muted-foreground text-sm">
+        <p className="text-[13px] text-muted-foreground">
           ※ 同じ名前・住所の組み合わせは登録できません
         </p>
       )}

--- a/admin/src/client/components/counterparts/CounterpartFormDialog.tsx
+++ b/admin/src/client/components/counterparts/CounterpartFormDialog.tsx
@@ -70,7 +70,7 @@ export function CounterpartFormDialog(props: CounterpartFormDialogProps) {
 
   return (
     <Dialog open={true} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-[85vw] max-h-[85vh] w-full overflow-y-auto">
+      <DialogContent className="max-h-[85vh] w-[calc(100vw-2rem)] max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/admin/src/client/components/counterparts/CounterpartMasterClient.tsx
+++ b/admin/src/client/components/counterparts/CounterpartMasterClient.tsx
@@ -3,10 +3,13 @@ import "client-only";
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { MagnifyingGlass, Plus } from "@phosphor-icons/react/dist/ssr";
 import type { CounterpartWithUsage } from "@/server/contexts/report/domain/models/counterpart";
 import { CounterpartTable } from "@/client/components/counterparts/CounterpartTable";
 import { CounterpartFormDialog } from "@/client/components/counterparts/CounterpartFormDialog";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { StaticPagination } from "@/client/components/ui/StaticPagination";
+import { Button, Input } from "@/client/components/ui";
 
 interface CounterpartMasterClientProps {
   initialCounterparts: CounterpartWithUsage[];
@@ -29,23 +32,18 @@ export function CounterpartMasterClient({
 
   const totalPages = Math.ceil(total / perPage);
 
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    const params = new URLSearchParams();
-    if (searchInput.trim()) {
-      params.set("q", searchInput.trim());
+  const buildUrl = (params: { q?: string; page: number }) => {
+    const urlParams = new URLSearchParams();
+    if (params.q?.trim()) {
+      urlParams.set("q", params.q.trim());
     }
-    params.set("page", "1");
-    router.push(`/counterparts?${params.toString()}`);
+    urlParams.set("page", params.page.toString());
+    return `/counterparts?${urlParams.toString()}`;
   };
 
-  const handlePageChange = (newPage: number) => {
-    const params = new URLSearchParams();
-    if (searchQuery) {
-      params.set("q", searchQuery);
-    }
-    params.set("page", newPage.toString());
-    router.push(`/counterparts?${params.toString()}`);
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    router.push(buildUrl({ q: searchInput, page: 1 }));
   };
 
   const handleUpdate = () => {
@@ -58,85 +56,59 @@ export function CounterpartMasterClient({
         label="Counterparts"
         title="取引先マスタ管理"
         actions={
-          <button
+          <Button
             type="button"
+            className="text-[13px] tracking-[0.06em]"
             onClick={() => setIsCreateDialogOpen(true)}
-            className="bg-primary text-primary-foreground border-0 rounded-lg px-4 py-2.5 font-medium hover:bg-primary-hover transition-colors duration-200 cursor-pointer"
           >
+            <Plus />
             新規作成
-          </button>
+          </Button>
         }
       />
 
-      <div className="bg-card rounded-xl p-4">
-        <form onSubmit={handleSearch} className="mb-6">
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              placeholder="名前または住所で検索..."
-              aria-label="取引先を名前または住所で検索"
-              className="bg-input text-foreground border border-border rounded-lg px-3 py-2.5 flex-1 max-w-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary"
-            />
-            <button
-              type="submit"
-              className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
+      <div className="rounded-lg border border-border bg-card p-6">
+        <form onSubmit={handleSearch} className="mb-2 flex flex-wrap gap-2">
+          <Input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="名前または住所で検索..."
+            aria-label="取引先を名前または住所で検索"
+            className="min-w-[200px] max-w-[380px] flex-1 border-[1.5px] text-[13px]"
+          />
+          <Button type="submit" variant="outline" className="text-[13px]">
+            <MagnifyingGlass />
+            検索
+          </Button>
+          {searchQuery && (
+            <Button
+              type="button"
+              variant="outline"
+              className="text-[13px]"
+              onClick={() => {
+                setSearchInput("");
+                router.push("/counterparts");
+              }}
             >
-              検索
-            </button>
-            {searchQuery && (
-              <button
-                type="button"
-                onClick={() => {
-                  setSearchInput("");
-                  router.push("/counterparts");
-                }}
-                className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary/80 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 cursor-pointer"
-              >
-                クリア
-              </button>
-            )}
-          </div>
+              クリア
+            </Button>
+          )}
         </form>
 
-        <div className="text-muted-foreground text-sm mb-4">
+        <p className="mb-3 text-[13px] text-muted-foreground">
           {total}件の取引先
           {searchQuery && <span> (検索: &quot;{searchQuery}&quot;)</span>}
-        </div>
+        </p>
 
         <CounterpartTable counterparts={initialCounterparts} onUpdate={handleUpdate} />
 
         {totalPages > 1 && (
-          <div className="flex justify-center items-center gap-2 mt-6">
-            <button
-              type="button"
-              onClick={() => handlePageChange(page - 1)}
-              disabled={page <= 1}
-              aria-label="前のページへ"
-              className={`bg-secondary text-secondary-foreground border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
-                page <= 1 ? "opacity-50 cursor-not-allowed" : "hover:bg-secondary/80 cursor-pointer"
-              }`}
-            >
-              前へ
-            </button>
-            <span className="text-foreground px-4">
-              {page} / {totalPages}
-            </span>
-            <button
-              type="button"
-              onClick={() => handlePageChange(page + 1)}
-              disabled={page >= totalPages}
-              aria-label="次のページへ"
-              className={`bg-secondary text-secondary-foreground border border-border rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 ${
-                page >= totalPages
-                  ? "opacity-50 cursor-not-allowed"
-                  : "hover:bg-secondary/80 cursor-pointer"
-              }`}
-            >
-              次へ
-            </button>
-          </div>
+          <StaticPagination
+            currentPage={page}
+            totalPages={totalPages}
+            buildPageUrl={(nextPage) => buildUrl({ q: searchQuery, page: nextPage })}
+          />
         )}
 
         {isCreateDialogOpen && (

--- a/admin/src/client/components/counterparts/CounterpartTable.tsx
+++ b/admin/src/client/components/counterparts/CounterpartTable.tsx
@@ -4,21 +4,34 @@ import "client-only";
 import { useState } from "react";
 import Link from "next/link";
 import type { CounterpartWithUsage } from "@/server/contexts/report/domain/models/counterpart";
-import { Button } from "@/client/components/ui";
-import { CounterpartFormDialog } from "./CounterpartFormDialog";
-import { DeleteCounterpartButton } from "./DeleteCounterpartButton";
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/client/components/ui";
+import { CounterpartFormDialog } from "@/client/components/counterparts/CounterpartFormDialog";
+import { DeleteCounterpartButton } from "@/client/components/counterparts/DeleteCounterpartButton";
 
 interface CounterpartTableProps {
   counterparts: CounterpartWithUsage[];
   onUpdate: () => void;
 }
 
+/**
+ * 取引先マスタの一覧テーブル。
+ * 罫線は取引一覧と同じ（ヘッダー下黒 1.5px・行 #E5E5E5）。名前はリンク、使用数は Poppins 右寄せ、
+ * 操作列は「編集」黒枠 / 「削除」赤枠の小ピル（ハンドオフ「4. 取引先マスタ」）。
+ */
 export function CounterpartTable({ counterparts, onUpdate }: CounterpartTableProps) {
   const [editingCounterpart, setEditingCounterpart] = useState<CounterpartWithUsage | null>(null);
 
   if (counterparts.length === 0) {
     return (
-      <div className="text-center py-10">
+      <div className="py-10 text-center">
         <p className="text-muted-foreground">取引先が登録されていません</p>
       </div>
     );
@@ -26,55 +39,54 @@ export function CounterpartTable({ counterparts, onUpdate }: CounterpartTablePro
 
   return (
     <>
-      <div className="overflow-x-auto">
-        <table className="w-full">
-          <thead>
-            <tr className="border-b border-border">
-              <th className="text-left py-3 px-4 text-muted-foreground font-medium">名前</th>
-              <th className="text-left py-3 px-4 text-muted-foreground font-medium">住所</th>
-              <th className="text-right py-3 px-4 text-muted-foreground font-medium">使用数</th>
-              <th className="text-right py-3 px-4 text-muted-foreground font-medium">操作</th>
-            </tr>
-          </thead>
-          <tbody>
-            {counterparts.map((counterpart) => (
-              <tr
-                key={counterpart.id}
-                className="border-b border-border hover:bg-secondary/30 transition-colors"
-              >
-                <td className="py-3 px-4">
-                  <Link
-                    href={`/counterparts/${counterpart.id}`}
-                    className="text-foreground hover:text-primary hover:underline transition-colors"
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead>名前</TableHead>
+            <TableHead>住所</TableHead>
+            <TableHead className="text-right">使用数</TableHead>
+            <TableHead className="text-right">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {counterparts.map((counterpart) => (
+            <TableRow key={counterpart.id}>
+              <TableCell className="whitespace-normal">
+                <Link
+                  href={`/counterparts/${counterpart.id}`}
+                  className="text-[13px] font-semibold text-primary-active transition-colors duration-150 ease-out hover:text-primary-hover hover:underline"
+                >
+                  {counterpart.name}
+                </Link>
+              </TableCell>
+              <TableCell className="whitespace-normal text-[13px] text-muted-foreground">
+                {counterpart.address}
+              </TableCell>
+              <TableCell className="font-latin text-right text-[13px] font-semibold text-foreground">
+                {counterpart.usageCount}件
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="flex justify-end gap-1.5">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    onClick={() => setEditingCounterpart(counterpart)}
                   >
-                    {counterpart.name}
-                  </Link>
-                </td>
-                <td className="py-3 px-4 text-foreground">{counterpart.address}</td>
-                <td className="py-3 px-4 text-foreground text-right">{counterpart.usageCount}件</td>
-                <td className="py-3 px-4 text-right">
-                  <div className="flex gap-2 justify-end">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setEditingCounterpart(counterpart)}
-                    >
-                      編集
-                    </Button>
-                    <DeleteCounterpartButton
-                      counterpartId={counterpart.id}
-                      counterpartName={counterpart.name}
-                      usageCount={counterpart.usageCount}
-                      onDelete={onUpdate}
-                    />
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+                    編集
+                  </Button>
+                  <DeleteCounterpartButton
+                    counterpartId={counterpart.id}
+                    counterpartName={counterpart.name}
+                    usageCount={counterpart.usageCount}
+                    onDelete={onUpdate}
+                  />
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
 
       {editingCounterpart && (
         <CounterpartFormDialog

--- a/admin/src/client/components/counterparts/DeleteCounterpartButton.tsx
+++ b/admin/src/client/components/counterparts/DeleteCounterpartButton.tsx
@@ -50,7 +50,7 @@ export function DeleteCounterpartButton({
     <Button
       type="button"
       variant="destructive"
-      size="sm"
+      size="xs"
       onClick={handleDelete}
       disabled={isDeleting}
     >

--- a/admin/src/client/components/donors/DeleteDonorButton.tsx
+++ b/admin/src/client/components/donors/DeleteDonorButton.tsx
@@ -50,7 +50,7 @@ export function DeleteDonorButton({
     <Button
       type="button"
       variant="destructive"
-      size="sm"
+      size="xs"
       onClick={handleDelete}
       disabled={isDeleting}
     >

--- a/admin/src/client/components/donors/DonorFormContent.tsx
+++ b/admin/src/client/components/donors/DonorFormContent.tsx
@@ -2,7 +2,7 @@
 import "client-only";
 
 import { useState, useId } from "react";
-import { Button, Input, Label } from "@/client/components/ui";
+import { Button, Input, Label, NativeSelect } from "@/client/components/ui";
 import type { DonorType } from "@/server/contexts/report/domain/models/donor";
 import {
   MAX_NAME_LENGTH,
@@ -88,35 +88,38 @@ export function DonorFormContent({
   const loadingLabel = submitLabel ? `${submitLabel}中...` : defaultLoadingLabel;
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-5">
       {error && (
-        <div className="text-red-500 p-3 bg-red-900/20 rounded-lg border border-red-900/30">
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive"
+        >
           {error}
         </div>
       )}
 
-      <div>
+      <div className="space-y-2">
         <Label htmlFor={donorTypeId}>
-          種別 <span className="text-red-500">*</span>
+          種別 <span className="text-destructive">*</span>
         </Label>
-        <select
+        <NativeSelect
           id={donorTypeId}
           value={donorType}
           onChange={(e) => handleDonorTypeChange(e.target.value as DonorType)}
           disabled={isDisabled}
-          className="w-full bg-input text-foreground border border-border rounded-lg px-3 py-2.5 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
+          wrapperClassName="w-full"
         >
           {VALID_DONOR_TYPES.map((type) => (
             <option key={type} value={type}>
               {DONOR_TYPE_LABELS[type]}
             </option>
           ))}
-        </select>
+        </NativeSelect>
       </div>
 
-      <div>
+      <div className="space-y-2">
         <Label htmlFor={nameId}>
-          名前 <span className="text-red-500">*</span>
+          名前 <span className="text-destructive">*</span>
         </Label>
         <Input
           type="text"
@@ -130,7 +133,7 @@ export function DonorFormContent({
         />
       </div>
 
-      <div>
+      <div className="space-y-2">
         <Label htmlFor={addressId}>住所</Label>
         <Input
           type="text"
@@ -144,9 +147,9 @@ export function DonorFormContent({
       </div>
 
       {isIndividual && (
-        <div>
+        <div className="space-y-2">
           <Label htmlFor={occupationId}>
-            職業 <span className="text-red-500">*</span>
+            職業 <span className="text-destructive">*</span>
           </Label>
           <Input
             type="text"
@@ -162,13 +165,14 @@ export function DonorFormContent({
       )}
 
       {mode === "edit" && initialData?.usageCount !== undefined && (
-        <div className="text-muted-foreground text-sm">
-          使用状況: {initialData.usageCount}件のTransactionで使用中
-        </div>
+        <p className="text-[13px] text-muted-foreground">
+          使用状況: <span className="font-latin">{initialData.usageCount}</span>
+          件の取引で使用中
+        </p>
       )}
 
       {mode === "create" && (
-        <p className="text-muted-foreground text-sm">
+        <p className="text-[13px] text-muted-foreground">
           ※ 同じ名前・住所・種別の組み合わせは登録できません
         </p>
       )}

--- a/admin/src/client/components/donors/DonorFormDialog.tsx
+++ b/admin/src/client/components/donors/DonorFormDialog.tsx
@@ -73,7 +73,7 @@ export function DonorFormDialog(props: DonorFormDialogProps) {
 
   return (
     <Dialog open={true} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-[85vw] max-h-[85vh] w-full overflow-y-auto">
+      <DialogContent className="max-h-[85vh] w-[calc(100vw-2rem)] max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/admin/src/client/components/donors/DonorMasterClient.tsx
+++ b/admin/src/client/components/donors/DonorMasterClient.tsx
@@ -3,11 +3,13 @@ import "client-only";
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { MagnifyingGlass, Plus } from "@phosphor-icons/react/dist/ssr";
 import type { DonorWithUsage, DonorType } from "@/server/contexts/report/domain/models/donor";
 import { DONOR_TYPE_LABELS, VALID_DONOR_TYPES } from "@/server/contexts/report/domain/models/donor";
 import { DonorTable } from "@/client/components/donors/DonorTable";
 import { DonorFormDialog } from "@/client/components/donors/DonorFormDialog";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { StaticPagination } from "@/client/components/ui/StaticPagination";
 import {
   Button,
   Input,
@@ -85,16 +87,6 @@ export function DonorMasterClient({
     );
   };
 
-  const handlePageChange = (newPage: number) => {
-    router.push(
-      buildUrl({
-        q: searchQuery,
-        type: donorType,
-        page: newPage.toString(),
-      }),
-    );
-  };
-
   const handleClear = () => {
     setSearchInput("");
     setSelectedType(ALL_TYPES_VALUE);
@@ -111,86 +103,73 @@ export function DonorMasterClient({
         label="Donors"
         title="寄付者マスタ管理"
         actions={
-          <Button type="button" onClick={() => setIsCreateDialogOpen(true)}>
+          <Button
+            type="button"
+            className="text-[13px] tracking-[0.06em]"
+            onClick={() => setIsCreateDialogOpen(true)}
+          >
+            <Plus />
             新規作成
           </Button>
         }
       />
 
-      <div className="bg-card rounded-xl p-4">
-        <form onSubmit={handleSearch} className="mb-6">
-          <div className="flex gap-2 flex-wrap">
-            <Input
-              type="text"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              placeholder="名前・住所・職業で検索..."
-              aria-label="寄付者を名前・住所・職業で検索"
-              className="flex-1 min-w-[200px] max-w-md"
-            />
-            <Select
-              value={selectedType}
-              onValueChange={(value) =>
-                handleTypeChange(value as DonorType | typeof ALL_TYPES_VALUE)
-              }
+      <div className="rounded-lg border border-border bg-card p-6">
+        <form onSubmit={handleSearch} className="mb-2 flex flex-wrap gap-2">
+          <Input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="名前・住所・職業で検索..."
+            aria-label="寄付者を名前・住所・職業で検索"
+            className="min-w-[200px] max-w-[380px] flex-1 border-[1.5px] text-[13px]"
+          />
+          <Select
+            value={selectedType}
+            onValueChange={(value) => handleTypeChange(value as DonorType | typeof ALL_TYPES_VALUE)}
+          >
+            <SelectTrigger
+              className="w-[160px] border-[1.5px] text-[13px]"
+              aria-label="寄付者種別でフィルタ"
             >
-              <SelectTrigger className="w-[160px]" aria-label="寄付者種別でフィルタ">
-                <SelectValue placeholder="すべての種別" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL_TYPES_VALUE}>すべての種別</SelectItem>
-                {VALID_DONOR_TYPES.map((type) => (
-                  <SelectItem key={type} value={type}>
-                    {DONOR_TYPE_LABELS[type]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Button type="submit" variant="secondary">
-              検索
+              <SelectValue placeholder="すべての種別" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_TYPES_VALUE}>すべての種別</SelectItem>
+              {VALID_DONOR_TYPES.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {DONOR_TYPE_LABELS[type]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button type="submit" variant="outline" className="text-[13px]">
+            <MagnifyingGlass />
+            検索
+          </Button>
+          {(searchQuery || donorType) && (
+            <Button type="button" variant="outline" className="text-[13px]" onClick={handleClear}>
+              クリア
             </Button>
-            {(searchQuery || donorType) && (
-              <Button type="button" variant="secondary" onClick={handleClear}>
-                クリア
-              </Button>
-            )}
-          </div>
+          )}
         </form>
 
-        <div className="text-muted-foreground text-sm mb-4">
+        <p className="mb-3 text-[13px] text-muted-foreground">
           {total}件の寄付者
           {searchQuery && <span> (検索: &quot;{searchQuery}&quot;)</span>}
           {donorType && <span> (種別: {DONOR_TYPE_LABELS[donorType]})</span>}
-        </div>
+        </p>
 
         <DonorTable donors={initialDonors} onUpdate={handleUpdate} />
 
         {totalPages > 1 && (
-          <div className="flex justify-center items-center gap-2 mt-6">
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => handlePageChange(page - 1)}
-              disabled={page <= 1}
-              aria-label="前のページへ"
-            >
-              前へ
-            </Button>
-            <span className="text-foreground px-4">
-              {page} / {totalPages}
-            </span>
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => handlePageChange(page + 1)}
-              disabled={page >= totalPages}
-              aria-label="次のページへ"
-            >
-              次へ
-            </Button>
-          </div>
+          <StaticPagination
+            currentPage={page}
+            totalPages={totalPages}
+            buildPageUrl={(nextPage) =>
+              buildUrl({ q: searchQuery, type: donorType, page: nextPage.toString() })
+            }
+          />
         )}
 
         {isCreateDialogOpen && (

--- a/admin/src/client/components/donors/DonorTable.tsx
+++ b/admin/src/client/components/donors/DonorTable.tsx
@@ -3,22 +3,34 @@ import "client-only";
 
 import { useState } from "react";
 import type { DonorWithUsage } from "@/server/contexts/report/domain/models/donor";
-import { DONOR_TYPE_LABELS } from "@/server/contexts/report/domain/models/donor";
-import { Button } from "@/client/components/ui";
-import { DonorFormDialog } from "./DonorFormDialog";
-import { DeleteDonorButton } from "./DeleteDonorButton";
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/client/components/ui";
+import { DonorFormDialog } from "@/client/components/donors/DonorFormDialog";
+import { DonorTypeBadge } from "@/client/components/donors/DonorTypeBadge";
+import { DeleteDonorButton } from "@/client/components/donors/DeleteDonorButton";
 
 interface DonorTableProps {
   donors: DonorWithUsage[];
   onUpdate: () => void;
 }
 
+/**
+ * 寄付者マスタの一覧テーブル。取引先マスタと同じ語彙
+ * （ヘッダー下黒 1.5px・行 #E5E5E5・使用数 Poppins 右寄せ・操作列は小ピル）。
+ */
 export function DonorTable({ donors, onUpdate }: DonorTableProps) {
   const [editingDonor, setEditingDonor] = useState<DonorWithUsage | null>(null);
 
   if (donors.length === 0) {
     return (
-      <div className="text-center py-10">
+      <div className="py-10 text-center">
         <p className="text-muted-foreground">寄付者が登録されていません</p>
       </div>
     );
@@ -26,58 +38,57 @@ export function DonorTable({ donors, onUpdate }: DonorTableProps) {
 
   return (
     <>
-      <div className="overflow-x-auto">
-        <table className="w-full">
-          <thead>
-            <tr className="border-b border-border">
-              <th className="text-left py-3 px-4 text-muted-foreground font-medium">種別</th>
-              <th className="text-left py-3 px-4 text-muted-foreground font-medium">名前</th>
-              <th className="text-left py-3 px-4 text-muted-foreground font-medium">住所</th>
-              <th className="text-left py-3 px-4 text-muted-foreground font-medium">職業</th>
-              <th className="text-right py-3 px-4 text-muted-foreground font-medium">使用数</th>
-              <th className="text-right py-3 px-4 text-muted-foreground font-medium">操作</th>
-            </tr>
-          </thead>
-          <tbody>
-            {donors.map((donor) => (
-              <tr
-                key={donor.id}
-                className="border-b border-border hover:bg-secondary/30 transition-colors"
-              >
-                <td className="py-3 px-4 text-foreground">
-                  <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-secondary">
-                    {DONOR_TYPE_LABELS[donor.donorType]}
-                  </span>
-                </td>
-                <td className="py-3 px-4 text-foreground">{donor.name}</td>
-                <td className="py-3 px-4 text-foreground">{donor.address ?? "-"}</td>
-                <td className="py-3 px-4 text-foreground">
-                  {donor.donorType === "individual" ? (donor.occupation ?? "-") : "-"}
-                </td>
-                <td className="py-3 px-4 text-foreground text-right">{donor.usageCount}件</td>
-                <td className="py-3 px-4 text-right">
-                  <div className="flex gap-2 justify-end">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setEditingDonor(donor)}
-                    >
-                      編集
-                    </Button>
-                    <DeleteDonorButton
-                      donorId={donor.id}
-                      donorName={donor.name}
-                      usageCount={donor.usageCount}
-                      onDelete={onUpdate}
-                    />
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead>種別</TableHead>
+            <TableHead>名前</TableHead>
+            <TableHead>住所</TableHead>
+            <TableHead>職業</TableHead>
+            <TableHead className="text-right">使用数</TableHead>
+            <TableHead className="text-right">操作</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {donors.map((donor) => (
+            <TableRow key={donor.id}>
+              <TableCell>
+                <DonorTypeBadge donorType={donor.donorType} />
+              </TableCell>
+              <TableCell className="whitespace-normal text-[13px] font-semibold text-foreground">
+                {donor.name}
+              </TableCell>
+              <TableCell className="whitespace-normal text-[13px] text-muted-foreground">
+                {donor.address ?? "-"}
+              </TableCell>
+              <TableCell className="whitespace-normal text-[13px] text-muted-foreground">
+                {donor.donorType === "individual" ? (donor.occupation ?? "-") : "-"}
+              </TableCell>
+              <TableCell className="font-latin text-right text-[13px] font-semibold text-foreground">
+                {donor.usageCount}件
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="flex justify-end gap-1.5">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    onClick={() => setEditingDonor(donor)}
+                  >
+                    編集
+                  </Button>
+                  <DeleteDonorButton
+                    donorId={donor.id}
+                    donorName={donor.name}
+                    usageCount={donor.usageCount}
+                    onDelete={onUpdate}
+                  />
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
 
       {editingDonor && (
         <DonorFormDialog

--- a/admin/src/client/components/donors/DonorTypeBadge.tsx
+++ b/admin/src/client/components/donors/DonorTypeBadge.tsx
@@ -1,0 +1,21 @@
+import type { DonorType } from "@/server/contexts/report/domain/models/donor";
+import { cn, resolveDonorTypeBadge } from "@/client/lib";
+
+interface DonorTypeBadgeProps {
+  donorType: DonorType;
+}
+
+/** 寄付者種別のピルバッジ（11px/700・1.5px 枠）。個人=teal / 法人=グレー / 政治団体=黒枠。 */
+export function DonorTypeBadge({ donorType }: DonorTypeBadgeProps) {
+  const badge = resolveDonorTypeBadge(donorType);
+  return (
+    <span
+      className={cn(
+        "inline-block rounded-full border-[1.5px] px-3 py-[3px] text-[11px] font-bold leading-none whitespace-nowrap",
+        badge.className,
+      )}
+    >
+      {badge.label}
+    </span>
+  );
+}

--- a/admin/src/client/components/ui/StaticPagination.tsx
+++ b/admin/src/client/components/ui/StaticPagination.tsx
@@ -7,7 +7,10 @@ import { cn } from "@/client/lib";
 interface StaticPaginationProps {
   currentPage: number;
   totalPages: number;
-  basePath: string;
+  /** `${basePath}?page=N` 形式で遷移する。`buildPageUrl` を渡す場合は不要 */
+  basePath?: string;
+  /** 検索クエリなど他のパラメータを保持したい場合に、ページ番号から URL を組み立てる */
+  buildPageUrl?: (page: number) => string;
 }
 
 const pillClass =
@@ -20,10 +23,15 @@ const disabledClass = "border-disabled-border text-disabled-foreground cursor-no
  * URL の `?page=` で遷移する静的ページネーション。
  * 「前へ / 次へ」の黒枠白ピルと、中央に Poppins の「現在 / 総数」表示。
  */
-export function StaticPagination({ currentPage, totalPages, basePath }: StaticPaginationProps) {
+export function StaticPagination({
+  currentPage,
+  totalPages,
+  basePath = "",
+  buildPageUrl,
+}: StaticPaginationProps) {
   if (totalPages <= 0) return null;
 
-  const generatePageUrl = (page: number) => `${basePath}?page=${page}`;
+  const generatePageUrl = buildPageUrl ?? ((page: number) => `${basePath}?page=${page}`);
   const hasPrev = currentPage > 1;
   const hasNext = currentPage < totalPages;
 

--- a/admin/src/client/components/ui/button.tsx
+++ b/admin/src/client/components/ui/button.tsx
@@ -21,6 +21,8 @@ const buttonVariants = cva(
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
+        /** テーブル操作列などの小ピル（11px/700、ハンドオフ「4. 取引先マスタ」） */
+        xs: "h-7 gap-1 px-3.5 text-[11px] has-[>svg]:px-3",
         lg: "h-10 px-6 has-[>svg]:px-4",
         icon: "size-9",
         "icon-sm": "size-8",

--- a/admin/src/client/lib/donor-type-badge.ts
+++ b/admin/src/client/lib/donor-type-badge.ts
@@ -1,0 +1,24 @@
+import type { DonorType } from "@/server/contexts/report/domain/models/donor";
+import { DONOR_TYPE_LABELS } from "@/server/contexts/report/domain/models/donor";
+
+interface DonorTypeBadge {
+  label: string;
+  /** ピルバッジの色クラス。ブランドの teal / グレー / 黒枠のみを使う（青・紫・オレンジは使わない） */
+  className: string;
+}
+
+/**
+ * 寄付者種別をバッジ表示用のラベルと色クラスに解決する。
+ * 個人 = teal、法人 = グレー、政治団体 = 黒枠白地。
+ */
+export function resolveDonorTypeBadge(donorType: DonorType): DonorTypeBadge {
+  const label = DONOR_TYPE_LABELS[donorType];
+  switch (donorType) {
+    case "individual":
+      return { label, className: "border-primary-active text-primary-active bg-accent" };
+    case "corporation":
+      return { label, className: "border-subtle-foreground text-muted-foreground bg-secondary" };
+    case "political_organization":
+      return { label, className: "border-border text-foreground bg-card" };
+  }
+}

--- a/admin/src/client/lib/index.ts
+++ b/admin/src/client/lib/index.ts
@@ -3,3 +3,4 @@ export { formatDate, formatAmount, formatCurrency } from "./format";
 export { resolveCategoryPill } from "./category-pill";
 export type { CategoryPillSource } from "./category-pill";
 export { resolveUserRoleBadge } from "./user-role-badge";
+export { resolveDonorTypeBadge } from "./donor-type-badge";

--- a/admin/tests/client/lib/donor-type-badge.test.ts
+++ b/admin/tests/client/lib/donor-type-badge.test.ts
@@ -1,0 +1,33 @@
+import { resolveDonorTypeBadge } from "@/client/lib/donor-type-badge";
+import { VALID_DONOR_TYPES } from "@/server/contexts/report/domain/models/donor";
+
+describe("resolveDonorTypeBadge", () => {
+  it("個人は teal 系のピル（accent 背景・teal-deep 文字）になる", () => {
+    const badge = resolveDonorTypeBadge("individual");
+    expect(badge.label).toBe("個人");
+    expect(badge.className).toContain("bg-accent");
+    expect(badge.className).toContain("text-primary-active");
+  });
+
+  it("法人はグレー系のピル（secondary 背景・muted 文字）になる", () => {
+    const badge = resolveDonorTypeBadge("corporation");
+    expect(badge.label).toBe("法人");
+    expect(badge.className).toContain("bg-secondary");
+    expect(badge.className).toContain("text-muted-foreground");
+  });
+
+  it("政治団体は黒枠白地のピルになる", () => {
+    const badge = resolveDonorTypeBadge("political_organization");
+    expect(badge.label).toBe("政治団体");
+    expect(badge.className).toContain("border-border");
+    expect(badge.className).toContain("bg-card");
+  });
+
+  it("すべての種別で旧テーマの Tailwind パレット直書きを含まない", () => {
+    for (const type of VALID_DONOR_TYPES) {
+      expect(resolveDonorTypeBadge(type).className).not.toMatch(
+        /(red|green|blue|yellow|purple|orange|gray|slate)-\d{3}/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## 目的（Why）

admin リデザイン（土台 #1289 / ページヘッダー #1291）の一環として、取引先マスタ・寄付者マスタの一覧 + ダイアログ画面が旧テーマ（角丸 lg・青系・Tailwind パレット直書き）のまま残っている状態を解消し、ハンドオフ [docs/reference/design_handoff_admin_redesign/README.md](docs/reference/design_handoff_admin_redesign/README.md) の「4. 取引先マスタ」節の語彙に揃える。

## 変更内容

- **取引先マスタ一覧 / 寄付者マスタ一覧**: ヘッダー右に teal 塗り「新規作成」ピル（Plus アイコン）。白カード（黒 1px 枠・角丸 8px・padding 24px）内に検索 input（ピル・黒 1.5px 枠・focus で teal 枠 + ring）と「検索」黒枠ピル（MagnifyingGlass）、件数「N件の取引先 / 寄付者」（13px `#666`）
- **テーブル**: `ui/Table` に置き換え（ヘッダー下黒 1.5px・行 `#E5E5E5`）。取引先名はリンク（`#0F8472`、hover で `#089781` + 下線）、使用数は Poppins 右寄せ「N件」、操作列は「編集」黒枠 / 「削除」赤枠の小ピル（11px/700・折り返しなし）
- **`Button` に `size="xs"` を追加**（h-7・11px/700 の小ピル）。操作列の編集・削除ボタンで使用
- **`StaticPagination` に `buildPageUrl` を追加**: 検索クエリ・種別フィルタ・詳細画面のフィルタを保持したまま「前へ / 次へ」ピル + Poppins「1 / N」でページ遷移。取引先一覧・寄付者一覧・取引先詳細の独自ページネーションを置き換え
- **作成・編集ダイアログ**: 幅を `max-w-2xl` に調整（従来は 85vw）。エラー表示・必須マークを destructive トークンに、寄付者種別 select を `NativeSelect`（ピル）に置き換え
- **AI 住所検索ボックス**（`AddressInput`）: グレー地黒枠カード、outline ボタン、確度ラベルを teal / 墨 / 赤に（`text-yellow-*` 直書きを除去）、「確認」リンクを ArrowSquareOut アイコン付きに
- **取引先詳細**: `BackLink` + `PageHeader`（右に「編集」）、白カード 2 枚（取引先情報の定義リスト・紐づく取引）。選択中バーを `bg-secondary` + 黒枠 / 赤枠 / outline の 3 系統ボタンに
- **寄付者種別バッジ**: `DonorTypeBadge` + `lib/donor-type-badge.ts` に集約（個人=teal / 法人=グレー / 政治団体=黒枠）。ユニットテストを追加

取引先紐付け・寄付者紐付け画面（#1295）と、それらが持つ `TransactionWithCounterpartTable` などのコンポーネントは触っていない。

Closes #1294

## ローカル CI

- `pnpm verify`: ✅ 通過（test / typecheck / lint / knip / depcruise）
- admin E2E（`playwright test --workers=1`）: ✅ 42 passed

補足: E2E 実行時に `report-profile.spec.ts` の年度切り替えテストが本変更と無関係に落ちる現象を観測した。原因は Next.js dev の `unstable_cache` が `db:reset` 後に再利用された団体 ID の古いプロフィールを返すことで、`admin/.next/cache` を削除すると全件通過した。詳細は #1307 / #1311 にコメント済み。

## スコープアウトして起票・コメントした Issue

- #1307 にコメント: flaky の原因候補（`unstable_cache` の古いエントリが `db:reset` 後に再利用される団体 ID と衝突）と再現手順
- #1311 にコメント: ローカル E2E 手順に `admin/.next/cache` の削除が必要である旨

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 寄付者の種別を、見やすいバッジで表示できるようになりました。
  * 一覧画面のページ移動と検索操作を改善しました。

* **改善**
  * 取引先・寄付者の一覧、フォーム、詳細画面を共通デザインに統一しました。
  * 検索・作成・編集ボタンにアイコンを追加し、操作性を向上しました。
  * ダイアログの幅を画面に合わせて調整しました。
  * エラー表示、確度ラベル、空状態の見た目を改善しました。
  * 使用件数などの表示文言をわかりやすく変更しました。

* **テスト**
  * 寄付者種別バッジの表示を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->