### PR TITLE
feat(admin): 取引先紐付け・寄付者紐付け画面をリデザインする

### DIFF
--- a/admin/src/client/components/assignment/AssignmentSelectionBar.tsx
+++ b/admin/src/client/components/assignment/AssignmentSelectionBar.tsx
@@ -1,0 +1,34 @@
+"use client";
+import "client-only";
+
+import { Button } from "@/client/components/ui";
+
+interface AssignmentSelectionBarProps {
+  selectedCount: number;
+  onBulkAssign: () => void;
+  onClear: () => void;
+}
+
+/**
+ * 紐付け一覧の選択件数と一括操作（一括紐付け = teal 塗り / 選択解除 = 黒枠白）を並べるバー。
+ */
+export function AssignmentSelectionBar({
+  selectedCount,
+  onBulkAssign,
+  onClear,
+}: AssignmentSelectionBarProps) {
+  const hasSelection = selectedCount > 0;
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-border-soft bg-secondary px-4 py-2.5">
+      <span className="text-[13px] text-muted-foreground">
+        選択中: <span className="font-latin font-semibold text-foreground">{selectedCount}</span>件
+      </span>
+      <Button type="button" size="sm" onClick={onBulkAssign} disabled={!hasSelection}>
+        一括紐付け
+      </Button>
+      <Button type="button" variant="outline" size="sm" onClick={onClear} disabled={!hasSelection}>
+        選択解除
+      </Button>
+    </div>
+  );
+}

--- a/admin/src/client/components/assignment/AssignmentStatusBadge.tsx
+++ b/admin/src/client/components/assignment/AssignmentStatusBadge.tsx
@@ -1,0 +1,20 @@
+import { cn, resolveAssignmentStatusBadge } from "@/client/lib";
+
+interface AssignmentStatusBadgeProps {
+  assigned: boolean;
+}
+
+/** 取引先・寄付者の紐付け状態を示すピルバッジ（11px/700・1.5px 枠）。紐付け済み = teal / 未紐付け = グレー。 */
+export function AssignmentStatusBadge({ assigned }: AssignmentStatusBadgeProps) {
+  const badge = resolveAssignmentStatusBadge(assigned);
+  return (
+    <span
+      className={cn(
+        "inline-block rounded-full border-[1.5px] px-3 py-[3px] text-[11px] font-bold leading-none whitespace-nowrap",
+        badge.className,
+      )}
+    >
+      {badge.label}
+    </span>
+  );
+}

--- a/admin/src/client/components/assignment/CandidateList.tsx
+++ b/admin/src/client/components/assignment/CandidateList.tsx
@@ -1,0 +1,76 @@
+"use client";
+import "client-only";
+
+import type { ReactNode } from "react";
+import { cn } from "@/client/lib";
+
+interface CandidateListProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/** 紐付け候補一覧の枠（弱い罫線 `#E5E5E5`・角丸 8px・縦スクロール）。 */
+export function CandidateList({ children, className }: CandidateListProps) {
+  return (
+    <div className={cn("max-h-64 overflow-y-auto rounded-lg border border-border-soft", className)}>
+      {children}
+    </div>
+  );
+}
+
+interface CandidateGroupLabelProps {
+  children: ReactNode;
+}
+
+/** 候補一覧内のグループ見出し（提案 / すべて / 寄付者種別など）。 */
+export function CandidateGroupLabel({ children }: CandidateGroupLabelProps) {
+  return (
+    <div className="bg-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.06em] text-subtle-foreground">
+      {children}
+    </div>
+  );
+}
+
+interface CandidateListItemProps {
+  selected: boolean;
+  onSelect: () => void;
+  children: ReactNode;
+}
+
+/**
+ * 候補一覧の 1 行。ラジオ風の丸（選択時 teal）+ 内容。選択行は accent 背景。
+ */
+export function CandidateListItem({ selected, onSelect, children }: CandidateListItemProps) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full cursor-pointer items-start gap-3 px-3 py-2 text-left transition-colors duration-150 ease-out hover:bg-secondary",
+        selected && "bg-accent hover:bg-accent",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border-[1.5px]",
+          selected ? "border-primary" : "border-disabled-border",
+        )}
+      >
+        {selected && <span className="size-2 rounded-full bg-primary" />}
+      </span>
+      <span className="min-w-0 flex-1">{children}</span>
+    </button>
+  );
+}
+
+interface CandidateEmptyProps {
+  children: ReactNode;
+}
+
+/** 候補が 0 件のときの表示。 */
+export function CandidateEmpty({ children }: CandidateEmptyProps) {
+  return <div className="px-3 py-4 text-center text-sm text-muted-foreground">{children}</div>;
+}

--- a/admin/src/client/components/assignment/FormErrorAlert.tsx
+++ b/admin/src/client/components/assignment/FormErrorAlert.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/client/lib";
+
+interface FormErrorAlertProps {
+  message: string;
+  className?: string;
+}
+
+/** 紐付けダイアログ内のエラー表示（赤枠・淡い赤背景・赤文字）。 */
+export function FormErrorAlert({ message, className }: FormErrorAlertProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive",
+        className,
+      )}
+    >
+      {message}
+    </div>
+  );
+}

--- a/admin/src/client/components/assignment/SelectedCandidateCard.tsx
+++ b/admin/src/client/components/assignment/SelectedCandidateCard.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+interface SelectedCandidateCardProps {
+  children: ReactNode;
+}
+
+/** 候補一覧の上に置く「選択中」の確認カード（teal 枠・accent 背景）。 */
+export function SelectedCandidateCard({ children }: SelectedCandidateCardProps) {
+  return (
+    <div className="rounded-lg border border-primary bg-accent p-3">
+      <p className="mb-1 text-[11px] font-semibold tracking-[0.06em] text-primary-active">選択中</p>
+      {children}
+    </div>
+  );
+}

--- a/admin/src/client/components/assignment/SelectedTransactionsPanel.tsx
+++ b/admin/src/client/components/assignment/SelectedTransactionsPanel.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+import { formatAmount, formatDate } from "@/client/lib";
+
+interface SelectedTransactionSummary {
+  id: string;
+  transactionDate: Date;
+  debitAmount: number;
+  description: string | null;
+}
+
+interface SelectedTransactionsPanelProps {
+  transactions: SelectedTransactionSummary[];
+  title: string;
+  /** 一覧の下に置く補足（寄付者種別の制約など） */
+  footer?: ReactNode;
+}
+
+const MAX_VISIBLE = 10;
+
+/**
+ * 紐付けダイアログ左側の「選択中の取引」一覧。日付は `YYYY.MM.DD`、金額は Poppins で表示し、
+ * 罫線はテーブル行と同じ `#E5E5E5`。
+ */
+export function SelectedTransactionsPanel({
+  transactions,
+  title,
+  footer,
+}: SelectedTransactionsPanelProps) {
+  const hiddenCount = transactions.length - MAX_VISIBLE;
+  return (
+    <div className="flex min-h-0 flex-col lg:w-1/3 lg:shrink-0">
+      <p className="mb-2 text-xs font-bold text-foreground">{title}</p>
+
+      <ul className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-border-soft">
+        {transactions.slice(0, MAX_VISIBLE).map((t) => (
+          <li key={t.id} className="border-b border-border-soft px-3 py-2 last:border-b-0">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-latin text-xs text-muted-foreground">
+                {formatDate(t.transactionDate)}
+              </span>
+              <span className="font-latin text-[13px] font-semibold text-foreground">
+                {formatAmount(t.debitAmount)}
+              </span>
+            </div>
+            <p className="truncate text-xs text-muted-foreground">{t.description || "-"}</p>
+          </li>
+        ))}
+        {hiddenCount > 0 && (
+          <li className="px-3 py-2 text-center text-xs text-muted-foreground">
+            ...他 <span className="font-latin">{hiddenCount}</span>件
+          </li>
+        )}
+      </ul>
+
+      {footer}
+    </div>
+  );
+}

--- a/admin/src/client/components/assignment/SortableColumnHeader.tsx
+++ b/admin/src/client/components/assignment/SortableColumnHeader.tsx
@@ -1,0 +1,44 @@
+"use client";
+import "client-only";
+
+import { CaretDown, CaretUp, CaretUpDown } from "@phosphor-icons/react/dist/ssr";
+import { cn } from "@/client/lib";
+
+interface SortableColumnHeaderProps {
+  label: string;
+  /** この列で現在ソートしているか */
+  active: boolean;
+  order: "asc" | "desc";
+  onClick: () => void;
+  /** 金額列など右寄せの見出しで使う */
+  align?: "left" | "right";
+}
+
+/**
+ * 紐付け一覧のソート可能な列見出し。文字は th と同じ 12px/700、
+ * ソート方向は Phosphor のキャレットで示す（アクティブ列は teal）。
+ */
+export function SortableColumnHeader({
+  label,
+  active,
+  order,
+  onClick,
+  align = "left",
+}: SortableColumnHeaderProps) {
+  const Icon = active ? (order === "asc" ? CaretUp : CaretDown) : CaretUpDown;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`${label}で${active ? (order === "asc" ? "降順" : "昇順") : "昇順"}に並び替え`}
+      className={cn(
+        "inline-flex w-full cursor-pointer items-center gap-1 text-xs font-bold transition-colors duration-150 ease-out hover:text-primary-hover",
+        align === "right" && "justify-end",
+        active ? "text-primary-active" : "text-foreground",
+      )}
+    >
+      {label}
+      <Icon className={cn("size-3.5", active ? "text-primary-active" : "text-subtle-foreground")} />
+    </button>
+  );
+}

--- a/admin/src/client/components/counterpart-assignment/AssignWithCounterpartContent.tsx
+++ b/admin/src/client/components/counterpart-assignment/AssignWithCounterpartContent.tsx
@@ -3,11 +3,12 @@ import "client-only";
 
 import { useState, useTransition } from "react";
 import { Button, Tabs, TabsList, TabsTrigger, TabsContent } from "@/client/components/ui";
-import { formatDate, formatAmount } from "@/client/lib";
 import type { Counterpart } from "@/server/contexts/report/domain/models/counterpart";
 import type { TransactionWithCounterpart } from "@/server/contexts/report/domain/models/transaction-with-counterpart";
 import { CounterpartFormContent } from "@/client/components/counterparts/CounterpartFormContent";
 import { CounterpartSelectorContent } from "@/client/components/counterparts/CounterpartSelectorContent";
+import { SelectedTransactionsPanel } from "@/client/components/assignment/SelectedTransactionsPanel";
+import { FormErrorAlert } from "@/client/components/assignment/FormErrorAlert";
 import { createCounterpartAction } from "@/server/contexts/report/presentation/actions/create-counterpart";
 import { bulkAssignCounterpartAction } from "@/server/contexts/report/presentation/actions/bulk-assign-counterpart";
 
@@ -19,6 +20,10 @@ interface AssignWithCounterpartContentProps {
   onCancel: () => void;
 }
 
+/**
+ * 取引先紐付けダイアログの本体。左に選択中の取引、右に「既存から選択 / 新規作成」タブ。
+ * 確定は teal 塗り、キャンセルは黒枠白のピル。
+ */
 export function AssignWithCounterpartContent({
   transactions,
   allCounterparts,
@@ -79,54 +84,28 @@ export function AssignWithCounterpartContent({
     onSuccess(transactions.length);
   };
 
-  const getSelectButtonLabel = () => {
-    return `紐付け (${transactions.length}件)`;
-  };
-
   return (
-    <div className="flex flex-col lg:flex-row gap-6 flex-1 min-h-0 overflow-hidden">
-      <div className="lg:w-1/3 flex-shrink-0 flex flex-col min-h-0">
-        <div className="text-foreground font-medium mb-3">
-          {`選択中の取引 (${transactions.length}件)`}
-        </div>
+    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden lg:flex-row">
+      <SelectedTransactionsPanel
+        transactions={transactions}
+        title={`選択中の取引 (${transactions.length}件)`}
+      />
 
-        <div className="border border-border rounded-lg flex-1 overflow-y-auto">
-          {transactions.slice(0, 10).map((t) => (
-            <div key={t.id} className="px-3 py-2 text-sm border-b border-border last:border-b-0">
-              <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">{formatDate(t.transactionDate)}</span>
-                <span className="text-foreground">{formatAmount(t.debitAmount)}</span>
-              </div>
-              <div className="text-muted-foreground text-xs truncate">{t.description || "-"}</div>
-            </div>
-          ))}
-          {transactions.length > 10 && (
-            <div className="px-3 py-2 text-sm text-muted-foreground text-center">
-              ...他 {transactions.length - 10}件
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="lg:flex-1 flex flex-col min-h-0 min-w-0">
-        {error && (
-          <div className="text-red-500 p-3 bg-red-900/20 rounded-lg border border-red-900/30 mb-4 flex-shrink-0">
-            {error}
-          </div>
-        )}
+      <div className="flex min-h-0 min-w-0 flex-col lg:flex-1">
+        {error && <FormErrorAlert message={error} className="mb-4 shrink-0" />}
 
         <Tabs
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as "select" | "create")}
-          className="flex flex-col flex-1 min-h-0"
+          className="flex min-h-0 flex-1 flex-col"
         >
-          <TabsList className="mb-4 flex-shrink-0">
+          <TabsList className="mb-4 shrink-0">
             <TabsTrigger value="select">既存から選択</TabsTrigger>
             <TabsTrigger value="create">新規作成</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="select" className="flex-1 flex flex-col min-h-0 mt-0">
-            <div className="flex-1 overflow-y-auto min-h-0">
+          <TabsContent value="select" className="mt-0 flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 overflow-y-auto">
               <CounterpartSelectorContent
                 allCounterparts={allCounterparts}
                 selectedCounterpartId={selectedCounterpartId}
@@ -136,8 +115,8 @@ export function AssignWithCounterpartContent({
               />
             </div>
 
-            <div className="flex justify-end gap-2 pt-4 border-t border-border flex-shrink-0">
-              <Button type="button" variant="secondary" onClick={onCancel} disabled={isPending}>
+            <div className="flex shrink-0 justify-end gap-2 border-t border-border-soft pt-4">
+              <Button type="button" variant="outline" onClick={onCancel} disabled={isPending}>
                 キャンセル
               </Button>
               <Button
@@ -145,13 +124,13 @@ export function AssignWithCounterpartContent({
                 onClick={handleSelectExisting}
                 disabled={isPending || !selectedCounterpartId}
               >
-                {isPending ? "紐付け中..." : getSelectButtonLabel()}
+                {isPending ? "紐付け中..." : `紐付け (${transactions.length}件)`}
               </Button>
             </div>
           </TabsContent>
 
-          <TabsContent value="create" className="flex-1 flex flex-col min-h-0 mt-0">
-            <div className="flex-1 overflow-y-auto min-h-0">
+          <TabsContent value="create" className="mt-0 flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 overflow-y-auto">
               <CounterpartFormContent
                 mode="create"
                 defaultSearchQuery={transactions[0]?.description ?? ""}

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
+import { AddressBook } from "@phosphor-icons/react/dist/ssr";
 import type { RowSelectionState } from "@tanstack/react-table";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { TransactionWithCounterpart } from "@/server/contexts/report/domain/models/transaction-with-counterpart";
@@ -16,11 +17,14 @@ import {
   type CounterpartAssignmentFilterValues,
 } from "./CounterpartAssignmentFilters";
 import { ClientPagination } from "@/client/components/ui/ClientPagination";
-import { Card, Input, Button, Label } from "@/client/components/ui";
+import { Input, Button, Label } from "@/client/components/ui";
 import { PageHeader } from "@/client/components/layout/PageHeader";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
+import { AssignmentSelectionBar } from "@/client/components/assignment/AssignmentSelectionBar";
 
 const ALL_CATEGORIES_VALUE = "__all__";
+
+type SortField = "transactionDate" | "debitAmount" | "categoryKey";
 
 interface CounterpartAssignmentClientProps {
   organizations: PoliticalOrganization[];
@@ -35,7 +39,7 @@ interface CounterpartAssignmentClientProps {
     counterpartRequiredOnly: boolean;
     categoryKey: string;
     searchQuery: string;
-    sortField: "transactionDate" | "debitAmount" | "categoryKey";
+    sortField: SortField;
     sortOrder: "asc" | "desc";
   };
   allCounterparts: Counterpart[];
@@ -192,7 +196,7 @@ export function CounterpartAssignmentClient({
     }
   };
 
-  const handleSortChange = (field: "transactionDate" | "debitAmount" | "categoryKey") => {
+  const handleSortChange = (field: SortField) => {
     let newOrder: "asc" | "desc" = "asc";
     if (sortField === field) {
       newOrder = sortOrder === "asc" ? "desc" : "asc";
@@ -214,14 +218,14 @@ export function CounterpartAssignmentClient({
     <PageHeader
       label="Counterpart Assignment"
       title="取引先紐付け管理"
-      description="Transactionに対してCounterpart（取引先）を紐付けます"
+      description="取引に対して取引先を紐付けます"
       actions={
-        <Link
-          href="/counterparts"
-          className="bg-secondary text-secondary-foreground border border-border hover:bg-secondary rounded-lg px-4 py-2.5 font-medium transition-colors duration-200"
-        >
-          マスタ管理へ
-        </Link>
+        <Button asChild variant="outline" className="text-[13px]">
+          <Link href="/counterparts">
+            <AddressBook />
+            マスタ管理へ
+          </Link>
+        </Button>
       }
     />
   );
@@ -230,11 +234,11 @@ export function CounterpartAssignmentClient({
     return (
       <div>
         {header}
-        <Card className="p-4">
-          <p className="text-foreground">
+        <div className="rounded-lg border border-border bg-card p-6">
+          <p className="text-sm text-muted-foreground">
             政治団体が登録されていません。先に政治団体を作成してください。
           </p>
-        </Card>
+        </div>
       </div>
     );
   }
@@ -243,33 +247,32 @@ export function CounterpartAssignmentClient({
     <div>
       {header}
 
-      <div className="bg-card rounded-xl p-4 space-y-6">
-        <Card className="p-4">
-          <div className="flex flex-col md:flex-row md:items-end gap-4">
-            <div className="w-fit">
-              <PoliticalOrganizationSelect
-                organizations={organizations}
-                value={selectedOrganizationId}
-                onValueChange={handleOrganizationChange}
-                required
-              />
-            </div>
-            <div className="w-fit space-y-2">
-              <Label>報告年 (西暦)</Label>
-              <Input
-                type="number"
-                value={String(financialYear)}
-                onChange={handleYearChange}
-                min={1900}
-                max={2100}
-                required
-                className="w-24"
-              />
-            </div>
+      <div className="rounded-lg border border-border bg-card p-6">
+        {/* Toolbar: 団体・報告年 */}
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <PoliticalOrganizationSelect
+            organizations={organizations}
+            value={selectedOrganizationId}
+            onValueChange={handleOrganizationChange}
+            required
+            hideLabel
+          />
+          <div className="flex items-center gap-2">
+            <Label htmlFor="financial-year" className="text-xs font-bold">
+              報告年
+            </Label>
+            <Input
+              id="financial-year"
+              type="number"
+              value={String(financialYear)}
+              onChange={handleYearChange}
+              min={1900}
+              max={2100}
+              required
+              className="font-latin w-[104px] border-[1.5px] text-[13px]"
+            />
           </div>
-        </Card>
-
-        <hr className="border-border" />
+        </div>
 
         <CounterpartAssignmentFilters
           values={{
@@ -282,56 +285,42 @@ export function CounterpartAssignmentClient({
           onChange={handleFilterChange}
         />
 
-        <Card className="p-4">
-          <div className="flex justify-between items-center mb-4">
-            <div className="text-muted-foreground text-sm">
-              {total}件のTransaction
-              {unassignedOnly && " (未紐付けのみ)"}
+        <div className="mt-5 mb-3 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-[13px] text-muted-foreground">
+            <span className="font-latin">{total}</span>件の取引
+            {unassignedOnly && " (未紐付けのみ)"}
+          </p>
+          {isPending && (
+            <div className="flex items-center gap-2">
+              <div className="size-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              <p className="text-[13px] text-muted-foreground">読み込み中...</p>
             </div>
-            {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
-          </div>
-
-          <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-            <span className="text-foreground text-sm">
-              選択中: <span className="font-medium">{selectedTransactions.length}件</span>
-            </span>
-            <Button
-              type="button"
-              size="sm"
-              onClick={handleBulkAssignClick}
-              disabled={selectedTransactions.length === 0}
-            >
-              一括紐付け
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setRowSelection({})}
-              disabled={selectedTransactions.length === 0}
-            >
-              選択解除
-            </Button>
-          </div>
-
-          <TransactionWithCounterpartTable
-            transactions={initialTransactions}
-            sortField={sortField}
-            sortOrder={sortOrder}
-            onSortChange={handleSortChange}
-            rowSelection={rowSelection}
-            onRowSelectionChange={setRowSelection}
-            onAssignClick={handleAssignClick}
-          />
-
-          {totalPages > 1 && (
-            <ClientPagination
-              currentPage={page}
-              totalPages={totalPages}
-              onPageChange={handlePageChange}
-            />
           )}
-        </Card>
+        </div>
+
+        <AssignmentSelectionBar
+          selectedCount={selectedTransactions.length}
+          onBulkAssign={handleBulkAssignClick}
+          onClear={() => setRowSelection({})}
+        />
+
+        <TransactionWithCounterpartTable
+          transactions={initialTransactions}
+          sortField={sortField}
+          sortOrder={sortOrder}
+          onSortChange={handleSortChange}
+          rowSelection={rowSelection}
+          onRowSelectionChange={setRowSelection}
+          onAssignClick={handleAssignClick}
+        />
+
+        {totalPages > 1 && (
+          <ClientPagination
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        )}
 
         <AssignCounterpartDialog
           isOpen={isAssignDialogOpen}

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
@@ -2,7 +2,7 @@
 import "client-only";
 
 import { useState } from "react";
-import { Question } from "@phosphor-icons/react/dist/ssr";
+import { MagnifyingGlass, Question } from "@phosphor-icons/react/dist/ssr";
 import {
   Input,
   Button,
@@ -11,14 +11,12 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
-} from "@/client/components/ui";
-import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/client/components/ui/select";
+} from "@/client/components/ui";
 
 export interface CounterpartAssignmentFilterValues {
   categoryKey: string;
@@ -33,6 +31,10 @@ interface CounterpartAssignmentFiltersProps {
   onChange: (values: Partial<CounterpartAssignmentFilterValues>) => void;
 }
 
+/**
+ * 取引先紐付け一覧の絞り込み。カテゴリ select・検索 input はピル（黒 1.5px 枠・13px）、
+ * チェックボックスは 2 行目にまとめる。
+ */
 export function CounterpartAssignmentFilters({
   values,
   categoryOptions,
@@ -51,62 +53,63 @@ export function CounterpartAssignmentFilters({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col md:flex-row gap-4">
-        <div className="flex-1 space-y-2">
-          <Label>カテゴリ</Label>
-          <Select
-            value={values.categoryKey}
-            onValueChange={(value) => onChange({ categoryKey: value })}
-          >
-            <SelectTrigger className="w-full md:w-64">
-              <SelectValue placeholder="カテゴリを選択" />
-            </SelectTrigger>
-            <SelectContent>
-              {categoryOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Select
+          value={values.categoryKey}
+          onValueChange={(value) => onChange({ categoryKey: value })}
+        >
+          <SelectTrigger className="w-[200px] border-[1.5px] text-[13px]" aria-label="カテゴリ">
+            <SelectValue placeholder="カテゴリを選択" />
+          </SelectTrigger>
+          <SelectContent>
+            {categoryOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
-        <form onSubmit={handleSearchSubmit} className="flex-1 space-y-2">
-          <Label>検索</Label>
-          <div className="flex gap-2">
-            <Input
-              type="text"
-              value={localSearchQuery}
-              onChange={(e) => setLocalSearchQuery(e.target.value)}
-              placeholder="摘要、メモ、相手先で検索..."
-              className="flex-1"
-            />
-            <Button type="submit" variant="secondary">
-              検索
+        <form onSubmit={handleSearchSubmit} className="flex flex-1 flex-wrap items-center gap-2">
+          <Input
+            type="text"
+            value={localSearchQuery}
+            onChange={(e) => setLocalSearchQuery(e.target.value)}
+            placeholder="摘要、メモ、相手先で検索..."
+            aria-label="摘要、メモ、相手先で検索"
+            className="min-w-[200px] max-w-[380px] flex-1 border-[1.5px] text-[13px]"
+          />
+          <Button type="submit" variant="outline" className="text-[13px]">
+            <MagnifyingGlass />
+            検索
+          </Button>
+          {values.searchQuery && (
+            <Button
+              type="button"
+              variant="outline"
+              className="text-[13px]"
+              onClick={handleSearchClear}
+            >
+              クリア
             </Button>
-            {values.searchQuery && (
-              <Button type="button" variant="ghost" onClick={handleSearchClear}>
-                クリア
-              </Button>
-            )}
-          </div>
+          )}
         </form>
       </div>
 
-      <div className="flex flex-wrap gap-4">
-        <div className="flex items-center gap-2 cursor-pointer">
+      <div className="flex flex-wrap gap-5">
+        <div className="flex items-center gap-2">
           <Checkbox
             id="unassigned-only"
             checked={values.unassignedOnly}
             onCheckedChange={(checked) => onChange({ unassignedOnly: checked === true })}
           />
-          <Label htmlFor="unassigned-only" className="text-foreground text-sm cursor-pointer">
+          <Label htmlFor="unassigned-only" className="cursor-pointer text-[13px] font-medium">
             未紐付けのみ表示
           </Label>
         </div>
 
-        <div className="flex items-center gap-2 cursor-pointer">
+        <div className="flex items-center gap-2">
           <Checkbox
             id="counterpart-required-only"
             checked={values.counterpartRequiredOnly}
@@ -114,12 +117,12 @@ export function CounterpartAssignmentFilters({
           />
           <Label
             htmlFor="counterpart-required-only"
-            className="text-foreground text-sm cursor-pointer flex items-center gap-1"
+            className="flex cursor-pointer items-center gap-1 text-[13px] font-medium"
           >
             取引先必須のみ表示
             <Tooltip>
               <TooltipTrigger asChild onClick={(e) => e.stopPropagation()}>
-                <Question className="size-4 hover:text-foreground cursor-help" />
+                <Question className="size-4 cursor-help text-subtle-foreground transition-colors duration-150 ease-out hover:text-foreground" />
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-sm">
                 <div className="space-y-2 text-left">
@@ -129,14 +132,14 @@ export function CounterpartAssignmentFilters({
                   </p>
                   <div className="space-y-1">
                     <p className="font-medium">【収入】全額記載必須</p>
-                    <ul className="list-disc list-inside text-xs">
+                    <ul className="list-inside list-disc text-xs">
                       <li>借入金</li>
                       <li>本部・支部交付金</li>
                     </ul>
                   </div>
                   <div className="space-y-1">
                     <p className="font-medium">【経常経費】5万円以上</p>
-                    <ul className="list-disc list-inside text-xs">
+                    <ul className="list-inside list-disc text-xs">
                       <li>光熱水費</li>
                       <li>備品・消耗品費</li>
                       <li>事務所費</li>
@@ -144,7 +147,7 @@ export function CounterpartAssignmentFilters({
                   </div>
                   <div className="space-y-1">
                     <p className="font-medium">【政治活動費】5万円以上</p>
-                    <ul className="list-disc list-inside text-xs">
+                    <ul className="list-inside list-disc text-xs">
                       <li>組織活動費、選挙関係費、機関紙誌の発行事業費 等</li>
                     </ul>
                   </div>

--- a/admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx
+++ b/admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx
@@ -11,17 +11,35 @@ import {
   type RowSelectionState,
 } from "@tanstack/react-table";
 import { toast } from "sonner";
+import { Question } from "@phosphor-icons/react/dist/ssr";
 import type { TransactionWithCounterpart } from "@/server/contexts/report/domain/models/transaction-with-counterpart";
-import { PL_CATEGORIES } from "@/shared/accounting/account-category";
 import { cn, formatDate, formatAmount } from "@/client/lib";
-import { Switch, Tooltip, TooltipTrigger, TooltipContent } from "@/client/components/ui";
+import {
+  Button,
+  Checkbox,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/client/components/ui";
+import { CategoryPill } from "@/client/components/transactions/CategoryPill";
+import { AssignmentStatusBadge } from "@/client/components/assignment/AssignmentStatusBadge";
+import { SortableColumnHeader } from "@/client/components/assignment/SortableColumnHeader";
 import { updateGrantExpenditureFlagAction } from "@/server/contexts/report/presentation/actions/update-grant-expenditure-flag";
+
+type SortField = "transactionDate" | "debitAmount" | "categoryKey";
 
 interface TransactionWithCounterpartTableProps {
   transactions: TransactionWithCounterpart[];
-  sortField: "transactionDate" | "debitAmount" | "categoryKey";
+  sortField: SortField;
   sortOrder: "asc" | "desc";
-  onSortChange: (field: "transactionDate" | "debitAmount" | "categoryKey") => void;
+  onSortChange: (field: SortField) => void;
   rowSelection: RowSelectionState;
   onRowSelectionChange: (selection: RowSelectionState) => void;
   onAssignClick: (transaction: TransactionWithCounterpart) => void;
@@ -29,29 +47,10 @@ interface TransactionWithCounterpartTableProps {
 
 const columnHelper = createColumnHelper<TransactionWithCounterpart>();
 
-const DEFAULT_CATEGORY_COLOR = "#64748B"; // slate-500 as default fallback color
-
-function getCategoryInfo(categoryKey: string): {
-  label: string;
-  color: string;
-  type: string | undefined;
-} {
-  for (const [, value] of Object.entries(PL_CATEGORIES)) {
-    if (value.key === categoryKey) {
-      return {
-        label: value.shortLabel || value.category,
-        color: value.color || DEFAULT_CATEGORY_COLOR,
-        type: value.type,
-      };
-    }
-  }
-  return {
-    label: categoryKey,
-    color: DEFAULT_CATEGORY_COLOR,
-    type: undefined,
-  };
-}
-
+/**
+ * 取引先紐付け対象の取引一覧。罫線は取引一覧と同じ（ヘッダー下黒 1.5px・行 #E5E5E5）、
+ * 日付は `YYYY.MM.DD`、金額は Poppins 右寄せ、紐付け状態はピルバッジで示す。
+ */
 export function TransactionWithCounterpartTable({
   transactions,
   sortField,
@@ -101,60 +100,55 @@ export function TransactionWithCounterpartTable({
       columnHelper.display({
         id: "select",
         header: ({ table }) => (
-          <input
-            type="checkbox"
+          <Checkbox
+            aria-label="すべての取引を選択"
             checked={table.getIsAllRowsSelected()}
-            onChange={table.getToggleAllRowsSelectedHandler()}
-            className="w-4 h-4 rounded border-border bg-input text-primary focus:ring-ring focus:ring-offset-0 cursor-pointer"
+            onCheckedChange={(checked) => table.toggleAllRowsSelected(checked === true)}
           />
         ),
         cell: ({ row }) => (
-          <input
-            type="checkbox"
+          <Checkbox
+            aria-label="この取引を選択"
             checked={row.getIsSelected()}
-            onChange={row.getToggleSelectedHandler()}
-            className="w-4 h-4 rounded border-border bg-input text-primary focus:ring-ring focus:ring-offset-0 cursor-pointer"
+            onCheckedChange={(checked) => row.toggleSelected(checked === true)}
           />
         ),
       }),
       columnHelper.accessor("transactionDate", {
         header: () => (
-          <button
-            type="button"
+          <SortableColumnHeader
+            label="日付"
+            active={sortField === "transactionDate"}
+            order={sortOrder}
             onClick={() => onSortChange("transactionDate")}
-            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
-          >
-            日付
-            {sortField === "transactionDate" && (
-              <span className="text-primary">{sortOrder === "asc" ? "↑" : "↓"}</span>
-            )}
-          </button>
+          />
         ),
-        cell: (info) => formatDate(info.getValue()),
+        cell: (info) => (
+          <span className="font-latin text-[13px]">{formatDate(info.getValue())}</span>
+        ),
       }),
       columnHelper.accessor("debitAmount", {
         header: () => (
-          <button
-            type="button"
+          <SortableColumnHeader
+            label="金額"
+            active={sortField === "debitAmount"}
+            order={sortOrder}
             onClick={() => onSortChange("debitAmount")}
-            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
-          >
-            金額
-            {sortField === "debitAmount" && (
-              <span className="text-primary">{sortOrder === "asc" ? "↑" : "↓"}</span>
-            )}
-          </button>
+            align="right"
+          />
         ),
         cell: (info) => {
           const transaction = info.row.original;
           return (
-            <div className="flex items-center gap-2">
-              <span>{formatAmount(info.getValue())}</span>
+            <div className="flex items-center justify-end gap-2">
               {transaction.requiresCounterpart && (
-                <span className="text-xs bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded">
+                <span className="inline-block rounded-full border-[1.5px] border-destructive bg-card px-3 py-[3px] text-[11px] font-bold leading-none whitespace-nowrap text-destructive">
                   取引先必須
                 </span>
               )}
+              <span className="font-latin text-[13px] font-semibold">
+                {formatAmount(info.getValue())}
+              </span>
             </div>
           );
         },
@@ -165,25 +159,8 @@ export function TransactionWithCounterpartTable({
             <span>交付金</span>
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="cursor-help text-muted-foreground hover:text-foreground">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    role="img"
-                    aria-label="交付金フラグの説明"
-                  >
-                    <title>交付金フラグの説明</title>
-                    <circle cx="12" cy="12" r="10" />
-                    <path d="M12 16v-4" />
-                    <path d="M12 8h.01" />
-                  </svg>
+                <span className="cursor-help text-subtle-foreground transition-colors duration-150 ease-out hover:text-foreground">
+                  <Question className="size-4" aria-label="交付金フラグの説明" />
                 </span>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-xs">
@@ -200,6 +177,7 @@ export function TransactionWithCounterpartTable({
           const currentValue = getGrantExpenditureValue(transaction);
           return (
             <Switch
+              aria-label="交付金フラグ"
               checked={currentValue}
               onCheckedChange={(checked) =>
                 handleGrantExpenditureFlagChange(transaction.id, checked)
@@ -211,38 +189,31 @@ export function TransactionWithCounterpartTable({
       }),
       columnHelper.accessor("categoryKey", {
         header: () => (
-          <button
-            type="button"
+          <SortableColumnHeader
+            label="カテゴリ"
+            active={sortField === "categoryKey"}
+            order={sortOrder}
             onClick={() => onSortChange("categoryKey")}
-            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
-          >
-            カテゴリ
-            {sortField === "categoryKey" && (
-              <span className="text-primary">{sortOrder === "asc" ? "↑" : "↓"}</span>
-            )}
-          </button>
+          />
         ),
-        cell: (info) => {
-          const categoryInfo = getCategoryInfo(info.getValue());
-          return (
-            <div
-              className={`inline-block px-2 py-1 rounded text-xs font-medium ${
-                categoryInfo.type === "income" ? "text-black" : "text-white"
-              }`}
-              style={{ backgroundColor: categoryInfo.color }}
-            >
-              {categoryInfo.label}
-            </div>
-          );
-        },
+        cell: (info) => <CategoryPill categoryKey={info.getValue()} />,
       }),
       columnHelper.accessor("friendlyCategory", {
         header: "詳細区分",
-        cell: (info) => info.getValue() || "-",
+        cell: (info) => (
+          <span className="text-[13px] text-muted-foreground">{info.getValue() || "-"}</span>
+        ),
       }),
       columnHelper.accessor("description", {
         header: "摘要",
-        cell: (info) => info.getValue() || "-",
+        cell: (info) => (
+          <div
+            className="max-w-[240px] truncate text-xs text-muted-foreground"
+            title={info.getValue() || undefined}
+          >
+            {info.getValue() || "-"}
+          </div>
+        ),
       }),
       columnHelper.accessor("counterpart", {
         header: "取引先",
@@ -250,24 +221,27 @@ export function TransactionWithCounterpartTable({
           const transaction = info.row.original;
           const counterpart = transaction.counterpart;
           return (
-            <button
-              type="button"
-              onClick={() => onAssignClick(transaction)}
-              className={`w-full text-left px-3 py-2 rounded-lg border transition-colors duration-200 hover:bg-secondary cursor-pointer ${
-                counterpart ? "bg-input border-border" : "bg-yellow-400/10 border-yellow-400/30"
-              }`}
-            >
+            <div className="flex items-center gap-3">
+              <AssignmentStatusBadge assigned={counterpart !== null} />
               {counterpart ? (
-                <div className="flex flex-col">
-                  <span className="text-foreground font-medium truncate">{counterpart.name}</span>
-                  <span className="text-muted-foreground text-xs truncate">
-                    {counterpart.address}
-                  </span>
+                <div className="min-w-0 max-w-[220px]">
+                  <p className="truncate text-[13px] font-semibold text-foreground">
+                    {counterpart.name}
+                  </p>
+                  {counterpart.address && (
+                    <p className="truncate text-xs text-muted-foreground">{counterpart.address}</p>
+                  )}
                 </div>
-              ) : (
-                <span className="text-yellow-600">未設定</span>
-              )}
-            </button>
+              ) : null}
+              <Button
+                type="button"
+                variant={counterpart ? "outline" : "default"}
+                size="xs"
+                onClick={() => onAssignClick(transaction)}
+              >
+                {counterpart ? "変更" : "紐付け"}
+              </Button>
+            </div>
           );
         },
       }),
@@ -300,52 +274,44 @@ export function TransactionWithCounterpartTable({
 
   if (transactions.length === 0) {
     return (
-      <div className="text-center py-10">
-        <p className="text-muted-foreground">該当するTransactionがありません</p>
+      <div className="py-10 text-center">
+        <p className="text-muted-foreground">該当する取引がありません</p>
       </div>
     );
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id} className="border-b border-border">
-              {headerGroup.headers.map((header) => (
-                <th
-                  key={header.id}
-                  className="text-left py-2 px-4 text-muted-foreground font-medium whitespace-nowrap"
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(header.column.columnDef.header, header.getContext())}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr
-              key={row.id}
-              className="border-b border-border hover:bg-secondary/30 transition-colors"
-            >
-              {row.getVisibleCells().map((cell) => (
-                <td
-                  key={cell.id}
-                  className={cn(
-                    "py-2 px-4 text-foreground",
-                    cell.column.id !== "description" && "whitespace-nowrap",
-                  )}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <Table className="min-w-[960px]">
+      <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow key={headerGroup.id} className="hover:bg-transparent">
+            {headerGroup.headers.map((header) => (
+              <TableHead
+                key={header.id}
+                className={cn(header.column.id === "debitAmount" && "text-right")}
+              >
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(header.column.columnDef.header, header.getContext())}
+              </TableHead>
+            ))}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {table.getRowModel().rows.map((row) => (
+          <TableRow key={row.id} data-state={row.getIsSelected() ? "selected" : undefined}>
+            {row.getVisibleCells().map((cell) => (
+              <TableCell
+                key={cell.id}
+                className={cn("text-foreground", cell.column.id === "debitAmount" && "text-right")}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 }

--- a/admin/src/client/components/counterparts/CounterpartSelectorContent.tsx
+++ b/admin/src/client/components/counterparts/CounterpartSelectorContent.tsx
@@ -7,6 +7,13 @@ import type { Counterpart } from "@/server/contexts/report/domain/models/counter
 import type { TransactionWithCounterpart } from "@/server/contexts/report/domain/models/transaction-with-counterpart";
 import { suggestCounterpartAction } from "@/server/contexts/report/presentation/actions/suggest-counterpart";
 import type { CounterpartSuggestion } from "@/server/contexts/report/presentation/types/counterpart-suggestion";
+import {
+  CandidateEmpty,
+  CandidateGroupLabel,
+  CandidateList,
+  CandidateListItem,
+} from "@/client/components/assignment/CandidateList";
+import { SelectedCandidateCard } from "@/client/components/assignment/SelectedCandidateCard";
 
 interface CounterpartSelectorContentProps {
   allCounterparts: Counterpart[];
@@ -16,6 +23,10 @@ interface CounterpartSelectorContentProps {
   politicalOrganizationId: string;
 }
 
+/**
+ * 紐付けダイアログの「既存から選択」タブ。検索 input + 候補一覧（提案 → すべて）。
+ * 候補行の見た目は寄付者側と共通（CandidateListItem）。
+ */
 export function CounterpartSelectorContent({
   allCounterparts,
   selectedCounterpartId,
@@ -64,121 +75,88 @@ export function CounterpartSelectorContent({
   }, [transactions, politicalOrganizationId]);
 
   const selectedCounterpart = allCounterparts.find((cp) => cp.id === selectedCounterpartId);
+  const showSuggestions = !isLoadingSuggestions && suggestions.length > 0 && !searchQuery.trim();
 
   return (
     <div className="space-y-4">
-      <div>
-        <Label htmlFor="counterpart-search">取引先を検索</Label>
+      <div className="space-y-2">
+        <Label htmlFor="counterpart-search" className="text-xs font-bold">
+          取引先を検索
+        </Label>
         <Input
           id="counterpart-search"
           type="text"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="名前または住所で検索..."
+          className="border-[1.5px] text-[13px]"
         />
       </div>
 
       {selectedCounterpart && (
-        <div className="bg-primary/10 border border-primary rounded-lg p-3">
-          <p className="text-xs text-muted-foreground mb-1">選択中:</p>
-          <p className="text-foreground font-medium">{selectedCounterpart.name}</p>
+        <SelectedCandidateCard>
+          <p className="text-[13px] font-semibold text-foreground">{selectedCounterpart.name}</p>
           {selectedCounterpart.address && (
-            <p className="text-muted-foreground text-xs">{selectedCounterpart.address}</p>
+            <p className="text-xs text-muted-foreground">{selectedCounterpart.address}</p>
           )}
-        </div>
+        </SelectedCandidateCard>
       )}
 
-      <div className="border border-border rounded-lg max-h-64 overflow-y-auto">
+      <CandidateList>
         {isLoadingSuggestions && (
-          <div className="px-3 py-2 text-muted-foreground text-sm">提案を読み込み中...</div>
+          <div className="px-3 py-2 text-sm text-muted-foreground">提案を読み込み中...</div>
         )}
 
-        {!isLoadingSuggestions && suggestions.length > 0 && !searchQuery.trim() && (
-          <div className="py-1 border-b border-border">
-            <div className="px-3 py-1 text-xs text-muted-foreground bg-secondary/30">
+        {showSuggestions && (
+          <div className="border-b border-border-soft">
+            <CandidateGroupLabel>
               {transactions.length === 1
-                ? "提案（このTransactionに基づく）"
-                : "提案（選択したTransactionに基づく）"}
-            </div>
-            {suggestions.map((suggestion) => {
-              const isSelected = selectedCounterpartId === suggestion.counterpart.id;
-              return (
-                <button
-                  key={suggestion.counterpart.id}
-                  type="button"
-                  onClick={() => onSelect(suggestion.counterpart.id)}
-                  className={`w-full text-left px-3 py-2 hover:bg-secondary transition-colors flex items-start gap-3 ${
-                    isSelected ? "bg-secondary" : ""
-                  }`}
-                >
-                  <div
-                    className={`w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5 flex-shrink-0 ${
-                      isSelected ? "border-primary" : "border-gray-500"
-                    }`}
-                  >
-                    {isSelected && <div className="w-2 h-2 rounded-full bg-primary" />}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <span className="text-foreground font-medium block">
-                      {suggestion.counterpart.name}
-                    </span>
-                    {suggestion.counterpart.address && (
-                      <span className="text-muted-foreground text-xs truncate block">
-                        {suggestion.counterpart.address}
-                      </span>
-                    )}
-                    <span className="text-primary text-xs mt-0.5 block">{suggestion.reason}</span>
-                  </div>
-                </button>
-              );
-            })}
+                ? "提案（この取引に基づく）"
+                : "提案（選択した取引に基づく）"}
+            </CandidateGroupLabel>
+            {suggestions.map((suggestion) => (
+              <CandidateListItem
+                key={suggestion.counterpart.id}
+                selected={selectedCounterpartId === suggestion.counterpart.id}
+                onSelect={() => onSelect(suggestion.counterpart.id)}
+              >
+                <span className="block text-[13px] font-semibold text-foreground">
+                  {suggestion.counterpart.name}
+                </span>
+                {suggestion.counterpart.address && (
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {suggestion.counterpart.address}
+                  </span>
+                )}
+                <span className="mt-0.5 block text-xs text-primary-active">
+                  {suggestion.reason}
+                </span>
+              </CandidateListItem>
+            ))}
           </div>
         )}
 
         {nonSuggestedCounterparts.length > 0 ? (
-          <div className="py-1">
-            <div className="px-3 py-1 text-xs text-muted-foreground bg-secondary/30">
-              すべての取引先
-            </div>
-            {nonSuggestedCounterparts.map((cp) => {
-              const isSelected = selectedCounterpartId === cp.id;
-              return (
-                <button
-                  key={cp.id}
-                  type="button"
-                  onClick={() => onSelect(cp.id)}
-                  className={`w-full text-left px-3 py-2 hover:bg-secondary transition-colors flex items-start gap-3 ${
-                    isSelected ? "bg-secondary" : ""
-                  }`}
-                >
-                  <div
-                    className={`w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5 flex-shrink-0 ${
-                      isSelected ? "border-primary" : "border-gray-500"
-                    }`}
-                  >
-                    {isSelected && <div className="w-2 h-2 rounded-full bg-primary" />}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <span className="text-foreground font-medium block">{cp.name}</span>
-                    {cp.address && (
-                      <span className="text-muted-foreground text-xs truncate block">
-                        {cp.address}
-                      </span>
-                    )}
-                  </div>
-                </button>
-              );
-            })}
+          <div>
+            <CandidateGroupLabel>すべての取引先</CandidateGroupLabel>
+            {nonSuggestedCounterparts.map((cp) => (
+              <CandidateListItem
+                key={cp.id}
+                selected={selectedCounterpartId === cp.id}
+                onSelect={() => onSelect(cp.id)}
+              >
+                <span className="block text-[13px] font-semibold text-foreground">{cp.name}</span>
+                {cp.address && (
+                  <span className="block truncate text-xs text-muted-foreground">{cp.address}</span>
+                )}
+              </CandidateListItem>
+            ))}
           </div>
         ) : (
           !suggestions.length &&
-          !isLoadingSuggestions && (
-            <div className="px-3 py-4 text-center text-muted-foreground text-sm">
-              該当する取引先がありません
-            </div>
-          )
+          !isLoadingSuggestions && <CandidateEmpty>該当する取引先がありません</CandidateEmpty>
         )}
-      </div>
+      </CandidateList>
     </div>
   );
 }

--- a/admin/src/client/components/donor-assignment/AssignWithDonorContent.tsx
+++ b/admin/src/client/components/donor-assignment/AssignWithDonorContent.tsx
@@ -3,11 +3,13 @@ import "client-only";
 
 import { useState, useTransition, useMemo } from "react";
 import { Button, Tabs, TabsList, TabsTrigger, TabsContent } from "@/client/components/ui";
-import { formatDate, formatAmount } from "@/client/lib";
 import type { Donor, DonorType } from "@/server/contexts/report/domain/models/donor";
+import { DONOR_TYPE_LABELS } from "@/server/contexts/report/domain/models/donor";
 import type { TransactionWithDonor } from "@/server/contexts/report/domain/models/transaction-with-donor";
 import { DonorFormContent } from "./DonorFormContent";
 import { DonorSelectorContent } from "./DonorSelectorContent";
+import { SelectedTransactionsPanel } from "@/client/components/assignment/SelectedTransactionsPanel";
+import { FormErrorAlert } from "@/client/components/assignment/FormErrorAlert";
 import { createDonorAction } from "@/server/contexts/report/presentation/actions/create-donor";
 import { bulkAssignDonorAction } from "@/server/contexts/report/presentation/actions/bulk-assign-donor";
 import { getCommonAllowedDonorTypes } from "@/server/contexts/report/domain/models/donor-assignment-rules";
@@ -19,6 +21,10 @@ interface AssignWithDonorContentProps {
   onCancel: () => void;
 }
 
+/**
+ * 寄付者紐付けダイアログの本体。左に選択中の取引（と種別制約の注記）、右に「既存から選択 / 新規作成」タブ。
+ * 確定は teal 塗り、キャンセルは黒枠白のピル。
+ */
 export function AssignWithDonorContent({
   transactions,
   allDonors,
@@ -87,70 +93,43 @@ export function AssignWithDonorContent({
     onSuccess();
   };
 
-  const getSelectButtonLabel = () => {
-    if (isBulk) {
-      return `すべてに紐付け (${transactions.length}件)`;
-    }
-    return "この寄付者を紐付け";
-  };
+  const selectButtonLabel = isBulk
+    ? `すべてに紐付け (${transactions.length}件)`
+    : "この寄付者を紐付け";
+
+  const allowedTypesNote =
+    allowedDonorTypes.length > 0 && allowedDonorTypes.length < 3 ? (
+      <div className="mt-3 rounded-lg border border-border-soft bg-secondary p-3 text-xs text-muted-foreground">
+        選択された取引のカテゴリでは、以下の寄付者種別のみ紐付け可能です:
+        <span className="ml-1 font-semibold text-foreground">
+          {allowedDonorTypes.map((t) => DONOR_TYPE_LABELS[t]).join(", ")}
+        </span>
+      </div>
+    ) : null;
 
   return (
-    <div className="flex flex-col lg:flex-row gap-6 flex-1 min-h-0 overflow-hidden">
-      <div className="lg:w-1/3 flex-shrink-0 flex flex-col min-h-0">
-        <div className="text-foreground font-medium mb-3">
-          {isBulk ? `選択中の取引 (${transactions.length}件)` : "取引情報"}
-        </div>
+    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden lg:flex-row">
+      <SelectedTransactionsPanel
+        transactions={transactions}
+        title={isBulk ? `選択中の取引 (${transactions.length}件)` : "取引情報"}
+        footer={allowedTypesNote}
+      />
 
-        <div className="border border-border rounded-lg flex-1 overflow-y-auto">
-          {transactions.slice(0, 10).map((t) => (
-            <div key={t.id} className="px-3 py-2 text-sm border-b border-border last:border-b-0">
-              <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">{formatDate(t.transactionDate)}</span>
-                <span className="text-foreground">{formatAmount(t.debitAmount)}</span>
-              </div>
-              <div className="text-muted-foreground text-xs truncate">{t.description || "-"}</div>
-            </div>
-          ))}
-          {transactions.length > 10 && (
-            <div className="px-3 py-2 text-sm text-muted-foreground text-center">
-              ...他 {transactions.length - 10}件
-            </div>
-          )}
-        </div>
-
-        {allowedDonorTypes.length > 0 && allowedDonorTypes.length < 3 && (
-          <div className="mt-3 p-2 bg-secondary/30 rounded-lg text-xs text-muted-foreground">
-            選択された取引のカテゴリでは、以下の寄付者種別のみ紐付け可能です:
-            <span className="text-foreground ml-1">
-              {allowedDonorTypes
-                .map((t) =>
-                  t === "individual" ? "個人" : t === "corporation" ? "法人" : "政治団体",
-                )
-                .join(", ")}
-            </span>
-          </div>
-        )}
-      </div>
-
-      <div className="lg:flex-1 flex flex-col min-h-0 min-w-0">
-        {error && (
-          <div className="text-red-500 p-3 bg-red-900/20 rounded-lg border border-red-900/30 mb-4 flex-shrink-0">
-            {error}
-          </div>
-        )}
+      <div className="flex min-h-0 min-w-0 flex-col lg:flex-1">
+        {error && <FormErrorAlert message={error} className="mb-4 shrink-0" />}
 
         <Tabs
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as "select" | "create")}
-          className="flex flex-col flex-1 min-h-0"
+          className="flex min-h-0 flex-1 flex-col"
         >
-          <TabsList className="mb-4 flex-shrink-0">
+          <TabsList className="mb-4 shrink-0">
             <TabsTrigger value="select">既存から選択</TabsTrigger>
             <TabsTrigger value="create">新規作成</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="select" className="flex-1 flex flex-col min-h-0 mt-0">
-            <div className="flex-1 overflow-y-auto min-h-0">
+          <TabsContent value="select" className="mt-0 flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 overflow-y-auto">
               <DonorSelectorContent
                 allDonors={allDonors}
                 selectedDonorId={selectedDonorId}
@@ -159,8 +138,8 @@ export function AssignWithDonorContent({
               />
             </div>
 
-            <div className="flex justify-end gap-2 pt-4 border-t border-border flex-shrink-0">
-              <Button type="button" variant="secondary" onClick={onCancel} disabled={isPending}>
+            <div className="flex shrink-0 justify-end gap-2 border-t border-border-soft pt-4">
+              <Button type="button" variant="outline" onClick={onCancel} disabled={isPending}>
                 キャンセル
               </Button>
               <Button
@@ -168,13 +147,13 @@ export function AssignWithDonorContent({
                 onClick={handleSelectExisting}
                 disabled={isPending || !selectedDonorId}
               >
-                {isPending ? "紐付け中..." : getSelectButtonLabel()}
+                {isPending ? "紐付け中..." : selectButtonLabel}
               </Button>
             </div>
           </TabsContent>
 
-          <TabsContent value="create" className="flex-1 flex flex-col min-h-0 mt-0">
-            <div className="flex-1 overflow-y-auto min-h-0">
+          <TabsContent value="create" className="mt-0 flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 overflow-y-auto">
               <DonorFormContent
                 mode="create"
                 defaultName={transactions[0]?.description ?? ""}

--- a/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
@@ -4,6 +4,7 @@ import "client-only";
 import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { HandHeart, UploadSimple } from "@phosphor-icons/react/dist/ssr";
 import type { RowSelectionState } from "@tanstack/react-table";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { TransactionWithDonor } from "@/server/contexts/report/domain/models/transaction-with-donor";
@@ -12,11 +13,14 @@ import { TransactionWithDonorTable } from "./TransactionWithDonorTable";
 import { AssignDonorDialog } from "./AssignDonorDialog";
 import { DonorAssignmentFilters, type DonorAssignmentFilterValues } from "./DonorAssignmentFilters";
 import { ClientPagination } from "@/client/components/ui/ClientPagination";
-import { Card, Input, Button, Label } from "@/client/components/ui";
+import { Input, Button, Label } from "@/client/components/ui";
 import { PageHeader } from "@/client/components/layout/PageHeader";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
+import { AssignmentSelectionBar } from "@/client/components/assignment/AssignmentSelectionBar";
 
 const ALL_CATEGORIES_VALUE = "__all__";
+
+type SortField = "transactionDate" | "debitAmount" | "categoryKey";
 
 interface DonorAssignmentClientProps {
   organizations: PoliticalOrganization[];
@@ -30,7 +34,7 @@ interface DonorAssignmentClientProps {
     unassignedOnly: boolean;
     categoryKey: string;
     searchQuery: string;
-    sortField: "transactionDate" | "debitAmount" | "categoryKey";
+    sortField: SortField;
     sortOrder: "asc" | "desc";
   };
   allDonors: Donor[];
@@ -177,7 +181,7 @@ export function DonorAssignmentClient({
     }
   };
 
-  const handleSortChange = (field: "transactionDate" | "debitAmount" | "categoryKey") => {
+  const handleSortChange = (field: SortField) => {
     let newOrder: "asc" | "desc" = "asc";
     if (sortField === field) {
       newOrder = sortOrder === "asc" ? "desc" : "asc";
@@ -199,11 +203,22 @@ export function DonorAssignmentClient({
     <PageHeader
       label="Donor Assignment"
       title="寄付者紐付け管理"
-      description="Transactionに対してDonor（寄付者）を紐付けます"
+      description="取引に対して寄付者を紐付けます"
       actions={
-        <Button asChild variant="outline">
-          <Link href="/import-donors">CSV一括登録</Link>
-        </Button>
+        <>
+          <Button asChild variant="outline" className="text-[13px]">
+            <Link href="/donors">
+              <HandHeart />
+              マスタ管理へ
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="text-[13px]">
+            <Link href="/import-donors">
+              <UploadSimple />
+              CSV一括登録
+            </Link>
+          </Button>
+        </>
       }
     />
   );
@@ -212,11 +227,11 @@ export function DonorAssignmentClient({
     return (
       <div>
         {header}
-        <Card className="p-4">
-          <p className="text-foreground">
+        <div className="rounded-lg border border-border bg-card p-6">
+          <p className="text-sm text-muted-foreground">
             政治団体が登録されていません。先に政治団体を作成してください。
           </p>
-        </Card>
+        </div>
       </div>
     );
   }
@@ -225,33 +240,32 @@ export function DonorAssignmentClient({
     <div>
       {header}
 
-      <div className="bg-card rounded-xl p-4 space-y-6">
-        <Card className="p-4">
-          <div className="flex flex-col md:flex-row md:items-end gap-4">
-            <div className="w-fit">
-              <PoliticalOrganizationSelect
-                organizations={organizations}
-                value={selectedOrganizationId}
-                onValueChange={handleOrganizationChange}
-                required
-              />
-            </div>
-            <div className="w-fit space-y-2">
-              <Label>報告年 (西暦)</Label>
-              <Input
-                type="number"
-                value={String(financialYear)}
-                onChange={handleYearChange}
-                min={1900}
-                max={2100}
-                required
-                className="w-24"
-              />
-            </div>
+      <div className="rounded-lg border border-border bg-card p-6">
+        {/* Toolbar: 団体・報告年 */}
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <PoliticalOrganizationSelect
+            organizations={organizations}
+            value={selectedOrganizationId}
+            onValueChange={handleOrganizationChange}
+            required
+            hideLabel
+          />
+          <div className="flex items-center gap-2">
+            <Label htmlFor="financial-year" className="text-xs font-bold">
+              報告年
+            </Label>
+            <Input
+              id="financial-year"
+              type="number"
+              value={String(financialYear)}
+              onChange={handleYearChange}
+              min={1900}
+              max={2100}
+              required
+              className="font-latin w-[104px] border-[1.5px] text-[13px]"
+            />
           </div>
-        </Card>
-
-        <hr className="border-border" />
+        </div>
 
         <DonorAssignmentFilters
           values={{
@@ -263,56 +277,42 @@ export function DonorAssignmentClient({
           onChange={handleFilterChange}
         />
 
-        <Card className="p-4">
-          <div className="flex justify-between items-center mb-4">
-            <div className="text-muted-foreground text-sm">
-              {total}件のTransaction
-              {unassignedOnly && " (未紐付けのみ)"}
+        <div className="mt-5 mb-3 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-[13px] text-muted-foreground">
+            <span className="font-latin">{total}</span>件の取引
+            {unassignedOnly && " (未紐付けのみ)"}
+          </p>
+          {isPending && (
+            <div className="flex items-center gap-2">
+              <div className="size-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              <p className="text-[13px] text-muted-foreground">読み込み中...</p>
             </div>
-            {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
-          </div>
-
-          <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-            <span className="text-foreground text-sm">
-              選択中: <span className="font-medium">{selectedTransactions.length}件</span>
-            </span>
-            <Button
-              type="button"
-              size="sm"
-              onClick={handleBulkAssignClick}
-              disabled={selectedTransactions.length === 0}
-            >
-              一括紐付け
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setRowSelection({})}
-              disabled={selectedTransactions.length === 0}
-            >
-              選択解除
-            </Button>
-          </div>
-
-          <TransactionWithDonorTable
-            transactions={initialTransactions}
-            sortField={sortField}
-            sortOrder={sortOrder}
-            onSortChange={handleSortChange}
-            rowSelection={rowSelection}
-            onRowSelectionChange={setRowSelection}
-            onAssignClick={handleAssignClick}
-          />
-
-          {totalPages > 1 && (
-            <ClientPagination
-              currentPage={page}
-              totalPages={totalPages}
-              onPageChange={handlePageChange}
-            />
           )}
-        </Card>
+        </div>
+
+        <AssignmentSelectionBar
+          selectedCount={selectedTransactions.length}
+          onBulkAssign={handleBulkAssignClick}
+          onClear={() => setRowSelection({})}
+        />
+
+        <TransactionWithDonorTable
+          transactions={initialTransactions}
+          sortField={sortField}
+          sortOrder={sortOrder}
+          onSortChange={handleSortChange}
+          rowSelection={rowSelection}
+          onRowSelectionChange={setRowSelection}
+          onAssignClick={handleAssignClick}
+        />
+
+        {totalPages > 1 && (
+          <ClientPagination
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        )}
 
         <AssignDonorDialog
           isOpen={isAssignDialogOpen}

--- a/admin/src/client/components/donor-assignment/DonorAssignmentFilters.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentFilters.tsx
@@ -2,14 +2,18 @@
 import "client-only";
 
 import { useState } from "react";
-import { Input, Label, Checkbox, Button } from "@/client/components/ui";
+import { MagnifyingGlass } from "@phosphor-icons/react/dist/ssr";
 import {
+  Input,
+  Label,
+  Checkbox,
+  Button,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/client/components/ui/select";
+} from "@/client/components/ui";
 
 export interface DonorAssignmentFilterValues {
   categoryKey: string;
@@ -23,6 +27,9 @@ interface DonorAssignmentFiltersProps {
   onChange: (changes: Partial<DonorAssignmentFilterValues>) => void;
 }
 
+/**
+ * 寄付者紐付け一覧の絞り込み。取引先紐付けと同じ語彙（ピル select / input・黒 1.5px 枠・13px）。
+ */
 export function DonorAssignmentFilters({
   values,
   categoryOptions,
@@ -41,54 +48,55 @@ export function DonorAssignmentFilters({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col md:flex-row gap-4">
-        <div className="flex-1 space-y-2">
-          <Label>カテゴリ</Label>
-          <Select value={values.categoryKey} onValueChange={(v) => onChange({ categoryKey: v })}>
-            <SelectTrigger className="w-full md:w-64">
-              <SelectValue placeholder="カテゴリを選択" />
-            </SelectTrigger>
-            <SelectContent>
-              {categoryOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Select value={values.categoryKey} onValueChange={(v) => onChange({ categoryKey: v })}>
+          <SelectTrigger className="w-[200px] border-[1.5px] text-[13px]" aria-label="カテゴリ">
+            <SelectValue placeholder="カテゴリを選択" />
+          </SelectTrigger>
+          <SelectContent>
+            {categoryOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
-        <form onSubmit={handleSearchSubmit} className="flex-1 space-y-2">
-          <Label>検索</Label>
-          <div className="flex gap-2">
-            <Input
-              type="text"
-              value={localSearchQuery}
-              onChange={(e) => setLocalSearchQuery(e.target.value)}
-              placeholder="摘要、メモ、相手先で検索..."
-              className="flex-1"
-            />
-            <Button type="submit" variant="secondary">
-              検索
+        <form onSubmit={handleSearchSubmit} className="flex flex-1 flex-wrap items-center gap-2">
+          <Input
+            type="text"
+            value={localSearchQuery}
+            onChange={(e) => setLocalSearchQuery(e.target.value)}
+            placeholder="摘要、メモ、相手先で検索..."
+            aria-label="摘要、メモ、相手先で検索"
+            className="min-w-[200px] max-w-[380px] flex-1 border-[1.5px] text-[13px]"
+          />
+          <Button type="submit" variant="outline" className="text-[13px]">
+            <MagnifyingGlass />
+            検索
+          </Button>
+          {values.searchQuery && (
+            <Button
+              type="button"
+              variant="outline"
+              className="text-[13px]"
+              onClick={handleSearchClear}
+            >
+              クリア
             </Button>
-            {values.searchQuery && (
-              <Button type="button" variant="ghost" onClick={handleSearchClear}>
-                クリア
-              </Button>
-            )}
-          </div>
+          )}
         </form>
       </div>
 
-      <div className="flex flex-wrap gap-4">
-        <div className="flex items-center gap-2 cursor-pointer">
+      <div className="flex flex-wrap gap-5">
+        <div className="flex items-center gap-2">
           <Checkbox
             id="unassigned-only"
             checked={values.unassignedOnly}
             onCheckedChange={(checked) => onChange({ unassignedOnly: checked === true })}
           />
-          <Label htmlFor="unassigned-only" className="text-foreground text-sm cursor-pointer">
+          <Label htmlFor="unassigned-only" className="cursor-pointer text-[13px] font-medium">
             未紐付けのみ表示
           </Label>
         </div>

--- a/admin/src/client/components/donor-assignment/DonorFormContent.tsx
+++ b/admin/src/client/components/donor-assignment/DonorFormContent.tsx
@@ -2,14 +2,17 @@
 import "client-only";
 
 import { useState, useId, useEffect } from "react";
-import { Button, Input, Label } from "@/client/components/ui";
 import {
+  Button,
+  Input,
+  Label,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/client/components/ui/select";
+} from "@/client/components/ui";
+import { FormErrorAlert } from "@/client/components/assignment/FormErrorAlert";
 import {
   MAX_NAME_LENGTH,
   MAX_OCCUPATION_LENGTH,
@@ -62,6 +65,7 @@ export function DonorFormContent({
   const [error, setError] = useState<string | null>(null);
 
   const nameId = useId();
+  const addressId = useId();
   const occupationId = useId();
   const donorTypeId = useId();
 
@@ -101,16 +105,12 @@ export function DonorFormContent({
   const loadingLabel = submitLabel ? `${submitLabel}中...` : defaultLoadingLabel;
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {error && (
-        <div className="text-red-500 p-3 bg-red-900/20 rounded-lg border border-red-900/30">
-          {error}
-        </div>
-      )}
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {error && <FormErrorAlert message={error} />}
 
-      <div>
+      <div className="space-y-2">
         <Label htmlFor={donorTypeId}>
-          寄付者種別 <span className="text-red-500">*</span>
+          寄付者種別 <span className="text-destructive">*</span>
         </Label>
         <Select
           value={donorType}
@@ -130,9 +130,9 @@ export function DonorFormContent({
         </Select>
       </div>
 
-      <div>
+      <div className="space-y-2">
         <Label htmlFor={nameId}>
-          名前 <span className="text-red-500">*</span>
+          名前 <span className="text-destructive">*</span>
         </Label>
         <Input
           type="text"
@@ -146,11 +146,11 @@ export function DonorFormContent({
         />
       </div>
 
-      <div>
-        <Label htmlFor="address">住所</Label>
+      <div className="space-y-2">
+        <Label htmlFor={addressId}>住所</Label>
         <Input
           type="text"
-          id="address"
+          id={addressId}
           value={address}
           onChange={(e) => setAddress(e.target.value)}
           maxLength={MAX_ADDRESS_LENGTH}
@@ -160,9 +160,9 @@ export function DonorFormContent({
       </div>
 
       {donorType === "individual" && (
-        <div>
+        <div className="space-y-2">
           <Label htmlFor={occupationId}>
-            職業 <span className="text-red-500">*</span>
+            職業 <span className="text-destructive">*</span>
           </Label>
           <Input
             type="text"
@@ -174,25 +174,26 @@ export function DonorFormContent({
             disabled={isDisabled}
             required
           />
-          <p className="text-muted-foreground text-xs mt-1">
+          <p className="text-xs text-muted-foreground">
             個人からの寄附の場合、職業の記載が必要です
           </p>
         </div>
       )}
 
       {mode === "edit" && initialData?.usageCount !== undefined && (
-        <div className="text-muted-foreground text-sm">
-          使用状況: {initialData.usageCount}件のTransactionで使用中
-        </div>
+        <p className="text-[13px] text-muted-foreground">
+          使用状況: <span className="font-latin">{initialData.usageCount}</span>
+          件の取引で使用中
+        </p>
       )}
 
       {mode === "create" && (
-        <p className="text-muted-foreground text-sm">
+        <p className="text-[13px] text-muted-foreground">
           ※ 同じ名前・住所・種別の組み合わせは登録できません
         </p>
       )}
 
-      <div className="flex justify-end gap-2 pt-2">
+      <div className="flex justify-end gap-2">
         <Button type="submit" disabled={isDisabled || !isFormValid}>
           {isSubmitting ? loadingLabel : buttonLabel}
         </Button>

--- a/admin/src/client/components/donor-assignment/DonorSelectorContent.tsx
+++ b/admin/src/client/components/donor-assignment/DonorSelectorContent.tsx
@@ -5,6 +5,14 @@ import { useState, useMemo } from "react";
 import { Input, Label } from "@/client/components/ui";
 import type { Donor, DonorType } from "@/server/contexts/report/domain/models/donor";
 import { DONOR_TYPE_LABELS } from "@/server/contexts/report/domain/models/donor";
+import { DonorTypeBadge } from "@/client/components/donors/DonorTypeBadge";
+import {
+  CandidateEmpty,
+  CandidateGroupLabel,
+  CandidateList,
+  CandidateListItem,
+} from "@/client/components/assignment/CandidateList";
+import { SelectedCandidateCard } from "@/client/components/assignment/SelectedCandidateCard";
 
 interface DonorSelectorContentProps {
   allDonors: Donor[];
@@ -13,6 +21,12 @@ interface DonorSelectorContentProps {
   allowedDonorTypes?: DonorType[];
 }
 
+const DONOR_TYPE_ORDER: DonorType[] = ["individual", "corporation", "political_organization"];
+
+/**
+ * 紐付けダイアログの「既存から選択」タブ。検索 input + 種別ごとにグループ化した候補一覧。
+ * 候補行の見た目は取引先側と共通（CandidateListItem）。
+ */
 export function DonorSelectorContent({
   allDonors,
   selectedDonorId,
@@ -52,97 +66,78 @@ export function DonorSelectorContent({
   }, [filteredDonors]);
 
   const selectedDonor = allDonors.find((d) => d.id === selectedDonorId);
-
-  const renderDonorItem = (donor: Donor) => {
-    const isSelected = selectedDonorId === donor.id;
-    return (
-      <button
-        key={donor.id}
-        type="button"
-        onClick={() => onSelect(donor.id)}
-        className={`w-full text-left px-3 py-2 hover:bg-secondary transition-colors flex items-start gap-3 ${
-          isSelected ? "bg-secondary" : ""
-        }`}
-      >
-        <div
-          className={`w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5 flex-shrink-0 ${
-            isSelected ? "border-primary" : "border-gray-500"
-          }`}
-        >
-          {isSelected && <div className="w-2 h-2 rounded-full bg-primary" />}
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="text-foreground font-medium">{donor.name}</span>
-            <span className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">
-              {DONOR_TYPE_LABELS[donor.donorType]}
-            </span>
-          </div>
-          {donor.address && (
-            <span className="text-muted-foreground text-xs truncate block">{donor.address}</span>
-          )}
-          {donor.donorType === "individual" && donor.occupation && (
-            <span className="text-muted-foreground text-xs truncate block">
-              職業: {donor.occupation}
-            </span>
-          )}
-        </div>
-      </button>
-    );
-  };
-
-  const donorTypeOrder: DonorType[] = ["individual", "corporation", "political_organization"];
-  const visibleTypes = allowedDonorTypes.length > 0 ? allowedDonorTypes : donorTypeOrder;
+  const visibleTypes = allowedDonorTypes.length > 0 ? allowedDonorTypes : DONOR_TYPE_ORDER;
 
   return (
     <div className="space-y-4">
-      <div>
-        <Label htmlFor="donor-search">寄付者を検索</Label>
+      <div className="space-y-2">
+        <Label htmlFor="donor-search" className="text-xs font-bold">
+          寄付者を検索
+        </Label>
         <Input
           id="donor-search"
           type="text"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="名前、住所、職業で検索..."
+          className="border-[1.5px] text-[13px]"
         />
       </div>
 
       {selectedDonor && (
-        <div className="bg-primary/10 border border-primary rounded-lg p-3">
-          <p className="text-xs text-muted-foreground mb-1">選択中:</p>
+        <SelectedCandidateCard>
           <div className="flex items-center gap-2">
-            <p className="text-foreground font-medium">{selectedDonor.name}</p>
-            <span className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">
-              {DONOR_TYPE_LABELS[selectedDonor.donorType]}
-            </span>
+            <p className="text-[13px] font-semibold text-foreground">{selectedDonor.name}</p>
+            <DonorTypeBadge donorType={selectedDonor.donorType} />
           </div>
           {selectedDonor.address && (
-            <p className="text-muted-foreground text-xs">{selectedDonor.address}</p>
+            <p className="text-xs text-muted-foreground">{selectedDonor.address}</p>
           )}
-        </div>
+        </SelectedCandidateCard>
       )}
 
-      <div className="border border-border rounded-lg max-h-64 overflow-y-auto">
+      <CandidateList>
         {filteredDonors.length > 0 ? (
           visibleTypes.map((type) => {
             const donors = groupedDonors[type];
             if (donors.length === 0) return null;
 
             return (
-              <div key={type} className="py-1 border-b border-border last:border-b-0">
-                <div className="px-3 py-1 text-xs text-muted-foreground bg-secondary/30">
-                  {DONOR_TYPE_LABELS[type]} ({donors.length}件)
-                </div>
-                {donors.map(renderDonorItem)}
+              <div key={type} className="border-b border-border-soft last:border-b-0">
+                <CandidateGroupLabel>
+                  {DONOR_TYPE_LABELS[type]} (<span className="font-latin">{donors.length}</span>件)
+                </CandidateGroupLabel>
+                {donors.map((donor) => (
+                  <CandidateListItem
+                    key={donor.id}
+                    selected={selectedDonorId === donor.id}
+                    onSelect={() => onSelect(donor.id)}
+                  >
+                    <span className="flex items-center gap-2">
+                      <span className="text-[13px] font-semibold text-foreground">
+                        {donor.name}
+                      </span>
+                      <DonorTypeBadge donorType={donor.donorType} />
+                    </span>
+                    {donor.address && (
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {donor.address}
+                      </span>
+                    )}
+                    {donor.donorType === "individual" && donor.occupation && (
+                      <span className="block truncate text-xs text-muted-foreground">
+                        職業: {donor.occupation}
+                      </span>
+                    )}
+                  </CandidateListItem>
+                ))}
               </div>
             );
           })
         ) : (
-          <div className="px-3 py-4 text-center text-muted-foreground text-sm">
-            該当する寄付者がありません
-          </div>
+          <CandidateEmpty>該当する寄付者がありません</CandidateEmpty>
         )}
-      </div>
+      </CandidateList>
     </div>
   );
 }

--- a/admin/src/client/components/donor-assignment/TransactionWithDonorTable.tsx
+++ b/admin/src/client/components/donor-assignment/TransactionWithDonorTable.tsx
@@ -11,15 +11,29 @@ import {
   type RowSelectionState,
 } from "@tanstack/react-table";
 import type { TransactionWithDonor } from "@/server/contexts/report/domain/models/transaction-with-donor";
-import { DONOR_TYPE_LABELS } from "@/server/contexts/report/domain/models/donor";
-import { PL_CATEGORIES } from "@/shared/accounting/account-category";
 import { cn, formatDate, formatAmount } from "@/client/lib";
+import {
+  Button,
+  Checkbox,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/client/components/ui";
+import { CategoryPill } from "@/client/components/transactions/CategoryPill";
+import { DonorTypeBadge } from "@/client/components/donors/DonorTypeBadge";
+import { AssignmentStatusBadge } from "@/client/components/assignment/AssignmentStatusBadge";
+import { SortableColumnHeader } from "@/client/components/assignment/SortableColumnHeader";
+
+type SortField = "transactionDate" | "debitAmount" | "categoryKey";
 
 interface TransactionWithDonorTableProps {
   transactions: TransactionWithDonor[];
-  sortField: "transactionDate" | "debitAmount" | "categoryKey";
+  sortField: SortField;
   sortOrder: "asc" | "desc";
-  onSortChange: (field: "transactionDate" | "debitAmount" | "categoryKey") => void;
+  onSortChange: (field: SortField) => void;
   rowSelection: RowSelectionState;
   onRowSelectionChange: (selection: RowSelectionState) => void;
   onAssignClick: (transaction: TransactionWithDonor) => void;
@@ -27,29 +41,10 @@ interface TransactionWithDonorTableProps {
 
 const columnHelper = createColumnHelper<TransactionWithDonor>();
 
-const DEFAULT_CATEGORY_COLOR = "#64748B";
-
-function getCategoryInfo(categoryKey: string): {
-  label: string;
-  color: string;
-  type: string | undefined;
-} {
-  for (const [, value] of Object.entries(PL_CATEGORIES)) {
-    if (value.key === categoryKey) {
-      return {
-        label: value.shortLabel || value.category,
-        color: value.color || DEFAULT_CATEGORY_COLOR,
-        type: value.type,
-      };
-    }
-  }
-  return {
-    label: categoryKey,
-    color: DEFAULT_CATEGORY_COLOR,
-    type: undefined,
-  };
-}
-
+/**
+ * 寄付者紐付け対象の取引一覧。取引先紐付けと同じ語彙
+ * （ヘッダー下黒 1.5px・行 #E5E5E5・日付 `YYYY.MM.DD`・金額 Poppins 右寄せ・状態ピル）。
+ */
 export function TransactionWithDonorTable({
   transactions,
   sortField,
@@ -64,86 +59,76 @@ export function TransactionWithDonorTable({
       columnHelper.display({
         id: "select",
         header: ({ table }) => (
-          <input
-            type="checkbox"
+          <Checkbox
+            aria-label="すべての取引を選択"
             checked={table.getIsAllRowsSelected()}
-            onChange={table.getToggleAllRowsSelectedHandler()}
-            className="w-4 h-4 rounded border-border bg-input text-primary focus:ring-ring focus:ring-offset-0 cursor-pointer"
+            onCheckedChange={(checked) => table.toggleAllRowsSelected(checked === true)}
           />
         ),
         cell: ({ row }) => (
-          <input
-            type="checkbox"
+          <Checkbox
+            aria-label="この取引を選択"
             checked={row.getIsSelected()}
-            onChange={row.getToggleSelectedHandler()}
-            className="w-4 h-4 rounded border-border bg-input text-primary focus:ring-ring focus:ring-offset-0 cursor-pointer"
+            onCheckedChange={(checked) => row.toggleSelected(checked === true)}
           />
         ),
       }),
       columnHelper.accessor("transactionDate", {
         header: () => (
-          <button
-            type="button"
+          <SortableColumnHeader
+            label="日付"
+            active={sortField === "transactionDate"}
+            order={sortOrder}
             onClick={() => onSortChange("transactionDate")}
-            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
-          >
-            日付
-            {sortField === "transactionDate" && (
-              <span className="text-primary">{sortOrder === "asc" ? "↑" : "↓"}</span>
-            )}
-          </button>
+          />
         ),
-        cell: (info) => formatDate(info.getValue()),
+        cell: (info) => (
+          <span className="font-latin text-[13px]">{formatDate(info.getValue())}</span>
+        ),
       }),
       columnHelper.accessor("debitAmount", {
         header: () => (
-          <button
-            type="button"
+          <SortableColumnHeader
+            label="金額"
+            active={sortField === "debitAmount"}
+            order={sortOrder}
             onClick={() => onSortChange("debitAmount")}
-            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
-          >
-            金額
-            {sortField === "debitAmount" && (
-              <span className="text-primary">{sortOrder === "asc" ? "↑" : "↓"}</span>
-            )}
-          </button>
+            align="right"
+          />
         ),
-        cell: (info) => formatAmount(info.getValue()),
+        cell: (info) => (
+          <span className="font-latin text-[13px] font-semibold">
+            {formatAmount(info.getValue())}
+          </span>
+        ),
       }),
       columnHelper.accessor("categoryKey", {
         header: () => (
-          <button
-            type="button"
+          <SortableColumnHeader
+            label="カテゴリ"
+            active={sortField === "categoryKey"}
+            order={sortOrder}
             onClick={() => onSortChange("categoryKey")}
-            className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
-          >
-            カテゴリ
-            {sortField === "categoryKey" && (
-              <span className="text-primary">{sortOrder === "asc" ? "↑" : "↓"}</span>
-            )}
-          </button>
+          />
         ),
-        cell: (info) => {
-          const categoryInfo = getCategoryInfo(info.getValue());
-          return (
-            <div
-              className={`inline-block px-2 py-1 rounded text-xs font-medium ${
-                categoryInfo.type === "income" ? "text-black" : "text-white"
-              }`}
-              style={{ backgroundColor: categoryInfo.color }}
-            >
-              {categoryInfo.label}
-            </div>
-          );
-        },
+        cell: (info) => <CategoryPill categoryKey={info.getValue()} />,
       }),
       columnHelper.accessor("friendlyCategory", {
         header: "詳細区分",
-        cell: (info) => info.getValue() || "-",
+        cell: (info) => (
+          <span className="text-[13px] text-muted-foreground">{info.getValue() || "-"}</span>
+        ),
       }),
       columnHelper.accessor("description", {
         header: "摘要",
-        cell: (info) => info.getValue() || "-",
+        cell: (info) => (
+          <div
+            className="max-w-[240px] truncate text-xs text-muted-foreground"
+            title={info.getValue() || undefined}
+          >
+            {info.getValue() || "-"}
+          </div>
+        ),
       }),
       columnHelper.accessor("donor", {
         header: "寄付者",
@@ -151,29 +136,30 @@ export function TransactionWithDonorTable({
           const transaction = info.row.original;
           const donor = transaction.donor;
           return (
-            <button
-              type="button"
-              onClick={() => onAssignClick(transaction)}
-              className={`w-full text-left px-3 py-2 rounded-lg border transition-colors duration-200 hover:bg-secondary cursor-pointer ${
-                donor ? "bg-input border-border" : "bg-yellow-400/10 border-yellow-400/30"
-              }`}
-            >
+            <div className="flex items-center gap-3">
+              <AssignmentStatusBadge assigned={donor !== null} />
               {donor ? (
-                <div className="flex flex-col">
+                <div className="min-w-0 max-w-[260px]">
                   <div className="flex items-center gap-2">
-                    <span className="text-foreground font-medium truncate">{donor.name}</span>
-                    <span className="text-xs bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">
-                      {DONOR_TYPE_LABELS[donor.donorType]}
-                    </span>
+                    <p className="truncate text-[13px] font-semibold text-foreground">
+                      {donor.name}
+                    </p>
+                    <DonorTypeBadge donorType={donor.donorType} />
                   </div>
                   {donor.address && (
-                    <span className="text-muted-foreground text-xs truncate">{donor.address}</span>
+                    <p className="truncate text-xs text-muted-foreground">{donor.address}</p>
                   )}
                 </div>
-              ) : (
-                <span className="text-yellow-600">未設定</span>
-              )}
-            </button>
+              ) : null}
+              <Button
+                type="button"
+                variant={donor ? "outline" : "default"}
+                size="xs"
+                onClick={() => onAssignClick(transaction)}
+              >
+                {donor ? "変更" : "紐付け"}
+              </Button>
+            </div>
           );
         },
       }),
@@ -199,52 +185,44 @@ export function TransactionWithDonorTable({
 
   if (transactions.length === 0) {
     return (
-      <div className="text-center py-10">
-        <p className="text-muted-foreground">該当するTransactionがありません</p>
+      <div className="py-10 text-center">
+        <p className="text-muted-foreground">該当する取引がありません</p>
       </div>
     );
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id} className="border-b border-border">
-              {headerGroup.headers.map((header) => (
-                <th
-                  key={header.id}
-                  className="text-left py-2 px-4 text-muted-foreground font-medium whitespace-nowrap"
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(header.column.columnDef.header, header.getContext())}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr
-              key={row.id}
-              className="border-b border-border hover:bg-secondary/30 transition-colors"
-            >
-              {row.getVisibleCells().map((cell) => (
-                <td
-                  key={cell.id}
-                  className={cn(
-                    "py-2 px-4 text-foreground",
-                    cell.column.id !== "description" && "whitespace-nowrap",
-                  )}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <Table className="min-w-[880px]">
+      <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow key={headerGroup.id} className="hover:bg-transparent">
+            {headerGroup.headers.map((header) => (
+              <TableHead
+                key={header.id}
+                className={cn(header.column.id === "debitAmount" && "text-right")}
+              >
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(header.column.columnDef.header, header.getContext())}
+              </TableHead>
+            ))}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {table.getRowModel().rows.map((row) => (
+          <TableRow key={row.id} data-state={row.getIsSelected() ? "selected" : undefined}>
+            {row.getVisibleCells().map((cell) => (
+              <TableCell
+                key={cell.id}
+                className={cn("text-foreground", cell.column.id === "debitAmount" && "text-right")}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 }

--- a/admin/src/client/components/transactions/CategoryPill.tsx
+++ b/admin/src/client/components/transactions/CategoryPill.tsx
@@ -1,16 +1,25 @@
-import { type CategoryPillSource, resolveCategoryPill } from "@/client/lib";
+import {
+  type CategoryPillSource,
+  resolveCategoryPill,
+  resolveCategoryPillByKey,
+} from "@/client/lib";
 
-interface CategoryPillProps {
-  transaction: CategoryPillSource;
-}
+type CategoryPillProps =
+  | { transaction: CategoryPillSource; categoryKey?: never }
+  | { categoryKey: string; transaction?: never };
 
 /**
  * 勘定科目のカテゴリピル。表示ルールは webapp の取引テーブルと同一で、
- * 判定ロジックは `resolveCategoryPill` に集約している（admin 内で独自の色分岐を持たない）。
- * 色はデータ（PL_CATEGORIES）由来なので style で渡す。
+ * 判定ロジックは `resolveCategoryPill` / `resolveCategoryPillByKey` に集約している
+ * （admin 内で独自の色分岐を持たない）。色はデータ（PL_CATEGORIES）由来なので style で渡す。
+ *
+ * 勘定科目名を持つ取引は `transaction`、カテゴリキーだけを持つ取引（紐付け画面）は `categoryKey` で渡す。
  */
-export function CategoryPill({ transaction }: CategoryPillProps) {
-  const pill = resolveCategoryPill(transaction);
+export function CategoryPill(props: CategoryPillProps) {
+  const pill =
+    props.transaction !== undefined
+      ? resolveCategoryPill(props.transaction)
+      : resolveCategoryPillByKey(props.categoryKey);
 
   return (
     <span

--- a/admin/src/client/lib/assignment-status-badge.ts
+++ b/admin/src/client/lib/assignment-status-badge.ts
@@ -1,0 +1,22 @@
+interface AssignmentStatusBadge {
+  label: string;
+  /** ピルバッジの色クラス。紐付け済み = teal 系、未紐付け = グレー系（ブランド外の色は使わない） */
+  className: string;
+}
+
+/**
+ * 取引先・寄付者の紐付け状態をバッジ表示用のラベルと色クラスに解決する。
+ * 紐付け済み = teal（accent 背景・teal-deep 文字）、未紐付け = グレー（secondary 背景・muted 文字）。
+ */
+export function resolveAssignmentStatusBadge(assigned: boolean): AssignmentStatusBadge {
+  if (assigned) {
+    return {
+      label: "紐付け済み",
+      className: "border-primary-active text-primary-active bg-accent",
+    };
+  }
+  return {
+    label: "未紐付け",
+    className: "border-subtle-foreground text-muted-foreground bg-secondary",
+  };
+}

--- a/admin/src/client/lib/category-pill.ts
+++ b/admin/src/client/lib/category-pill.ts
@@ -88,3 +88,24 @@ export function resolveCategoryPill(source: CategoryPillSource): CategoryPillSty
     bgColor: isIncome ? FALLBACK_CATEGORY_COLOR : "#FFFFFF",
   };
 }
+
+/**
+ * カテゴリキー（`PL_CATEGORIES[*].key`。例: "individual-donations"）からカテゴリピルを解決する。
+ * 紐付け画面など、勘定科目名ではなくキーだけを持つ取引で使う。表示ルールは `resolveCategoryPill` と同一。
+ * 未知のキーはキー文字列をラベルにしたフォールバック色（支出扱い）で返す。
+ */
+export function resolveCategoryPillByKey(categoryKey: string): CategoryPillStyle {
+  const mapping = Object.values(PL_CATEGORIES).find((value) => value.key === categoryKey);
+  if (!mapping) {
+    return {
+      label: categoryKey,
+      fontColor: INCOME_FONT_COLOR,
+      borderColor: FALLBACK_CATEGORY_COLOR,
+      bgColor: "#FFFFFF",
+    };
+  }
+  const { color, shortLabel } = mapping;
+  return mapping.type === "income"
+    ? { label: shortLabel, fontColor: INCOME_FONT_COLOR, borderColor: color, bgColor: color }
+    : { label: shortLabel, fontColor: color, borderColor: color, bgColor: "#FFFFFF" };
+}

--- a/admin/src/client/lib/index.ts
+++ b/admin/src/client/lib/index.ts
@@ -1,6 +1,7 @@
 export { cn } from "./utils";
 export { formatDate, formatAmount, formatCurrency } from "./format";
-export { resolveCategoryPill } from "./category-pill";
+export { resolveCategoryPill, resolveCategoryPillByKey } from "./category-pill";
 export type { CategoryPillSource } from "./category-pill";
 export { resolveUserRoleBadge } from "./user-role-badge";
 export { resolveDonorTypeBadge } from "./donor-type-badge";
+export { resolveAssignmentStatusBadge } from "./assignment-status-badge";

--- a/admin/tests/client/lib/assignment-status-badge.test.ts
+++ b/admin/tests/client/lib/assignment-status-badge.test.ts
@@ -1,0 +1,25 @@
+import { resolveAssignmentStatusBadge } from "@/client/lib/assignment-status-badge";
+
+describe("resolveAssignmentStatusBadge", () => {
+  it("紐付け済みは teal 系のピル（accent 背景・teal-deep 文字）になる", () => {
+    const badge = resolveAssignmentStatusBadge(true);
+    expect(badge.label).toBe("紐付け済み");
+    expect(badge.className).toContain("bg-accent");
+    expect(badge.className).toContain("text-primary-active");
+  });
+
+  it("未紐付けはグレー系のピル（secondary 背景・muted 文字）になる", () => {
+    const badge = resolveAssignmentStatusBadge(false);
+    expect(badge.label).toBe("未紐付け");
+    expect(badge.className).toContain("bg-secondary");
+    expect(badge.className).toContain("text-muted-foreground");
+  });
+
+  it("旧テーマの Tailwind パレット直書きを含まない", () => {
+    for (const assigned of [true, false]) {
+      expect(resolveAssignmentStatusBadge(assigned).className).not.toMatch(
+        /(red|green|blue|yellow|purple|orange|gray|slate|amber)-\d{3}/,
+      );
+    }
+  });
+});

--- a/admin/tests/client/lib/category-pill.test.ts
+++ b/admin/tests/client/lib/category-pill.test.ts
@@ -1,4 +1,4 @@
-import { resolveCategoryPill } from "@/client/lib/category-pill";
+import { resolveCategoryPill, resolveCategoryPillByKey } from "@/client/lib/category-pill";
 import { PL_CATEGORIES } from "@/shared/accounting/account-category";
 
 const INCOME_ACCOUNT = "個人からの寄附";
@@ -110,5 +110,38 @@ describe("resolveCategoryPill", () => {
 
     expect(pill.label).toBe(PL_CATEGORIES[INCOME_ACCOUNT].shortLabel);
     expect(pill.bgColor).toBe(PL_CATEGORIES[INCOME_ACCOUNT].color);
+  });
+});
+
+describe("resolveCategoryPillByKey", () => {
+  it("収入カテゴリのキーは resolveCategoryPill の収入ルールと同じピルになる", () => {
+    const mapping = PL_CATEGORIES[INCOME_ACCOUNT];
+    expect(resolveCategoryPillByKey(mapping.key)).toEqual(
+      resolveCategoryPill({
+        debit_account: "普通預金",
+        credit_account: INCOME_ACCOUNT,
+        transaction_type: "income",
+      }),
+    );
+  });
+
+  it("支出カテゴリのキーは resolveCategoryPill の支出ルールと同じピルになる", () => {
+    const mapping = PL_CATEGORIES[EXPENSE_ACCOUNT];
+    expect(resolveCategoryPillByKey(mapping.key)).toEqual(
+      resolveCategoryPill({
+        debit_account: EXPENSE_ACCOUNT,
+        credit_account: "普通預金",
+        transaction_type: "expense",
+      }),
+    );
+  });
+
+  it("未知のキーはキー文字列をラベルにしたフォールバック色（白地）で返す", () => {
+    expect(resolveCategoryPillByKey("unknown-key")).toEqual({
+      label: "unknown-key",
+      fontColor: "#47474C",
+      borderColor: "#99F6E4",
+      bgColor: "#FFFFFF",
+    });
   });
 });


### PR DESCRIPTION
## 目的（Why）

admin 管理者が、取引先紐付け・寄付者紐付け画面だけ旧ダークテーマ前提の見た目（黄色の「未設定」ボックス、amber の必須バッジ、`bg-red-900/20` のエラー等）で、他の画面とブランドの一貫性がない状態を解消するため。
ハンドオフ [docs/reference/design_handoff_admin_redesign/README.md](../blob/main/docs/reference/design_handoff_admin_redesign/README.md) の「6. その他の画面」に従い、Transactions / Counterparts 画面の語彙を流用した。

## 変更内容

### 一覧（両画面）
- ページ全体を白カード黒枠 1 枚に集約し、団体 select・報告年 input・カテゴリ select・検索 input をピル（黒 1.5px 枠・13px）のツールバーに変更
- テーブルを `ui/Table` に置き換え（ヘッダー下黒 1.5px・行 `#E5E5E5`・選択行 accent）。日付 `YYYY.MM.DD`、金額 Poppins 右寄せ、チェックボックスは `ui/Checkbox`
- カテゴリピルを `CategoryPill` 経由に統一（`categoryKey` から解決する `resolveCategoryPillByKey` を追加。admin 独自の色分岐 `getCategoryInfo` を削除）
- 紐付け状態を `AssignmentStatusBadge`（紐付け済み = teal 系 / 未紐付け = グレー系）で表示し、操作は「紐付け」teal 小ピル / 「変更」黒枠小ピルに
- 「取引先必須」は赤枠白地の小ピル、ソート見出しは Phosphor キャレット、交付金ツールチップの手書き SVG を Phosphor `Question` に
- 選択件数 + 一括紐付け（teal）/ 選択解除（黒枠）を `AssignmentSelectionBar` に共通化

### 紐付けダイアログ（両画面）
- 選択中取引パネル・候補一覧（ラジオ風の丸は teal / 選択行 accent）・選択中カード・エラー表示を `client/components/assignment/` に共通化
- 確定 = teal 塗り、キャンセル = 黒枠白の 3 系統ボタン語彙。エラーは `border-destructive bg-destructive-hover`
- 寄付者の種別は `DonorTypeBadge` を再利用。紐付け側 `DonorFormContent` の旧パレット（`text-red-500` 等）を destructive 系へ

### 追加した lib
- `resolveAssignmentStatusBadge` / `resolveCategoryPillByKey`（ユニットテスト付き）

Closes #1295

## ローカルCI

`pnpm verify` 通過（admin: 78 suites / 908 tests、webapp: 16 suites / 135 tests、typecheck / lint / knip / depcruise すべて OK）。

E2E は未実行。`admin/e2e/tests` に紐付け画面を対象にした spec はなく、今回の変更は両画面の表示層とそこからのみ参照されるコンポーネントに限定され、共通 `ui/*`・ルーティング・認証には触れていないため。

## スコープアウトして起票した Issue

- #1323 寄付者フォーム（donors/DonorFormContent と donor-assignment/DonorFormContent）の重複統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 取引先・寄付者との紐付け画面を刷新し、候補者一覧、選択中の取引、エラー表示を見やすく整理。
  * 複数取引の一括紐付けと選択解除に対応。
  * 紐付け状態を「紐付け済み」「未紐付け」バッジで表示。
  * 日付・金額・カテゴリの並べ替え操作を改善。

* **改善**
  * 検索・カテゴリフィルター、空状態、フォーム、ナビゲーションの表示と操作性を改善。
  * 取引カテゴリや寄付者種別の表示を統一。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->