### PR TITLE
feat(admin): 報告書エクスポート画面をリデザインする

### DIFF
--- a/admin/src/app/(auth)/export-report/[orgId]/[year]/page.tsx
+++ b/admin/src/app/(auth)/export-report/[orgId]/[year]/page.tsx
@@ -34,11 +34,13 @@ export default async function ExportReportDetailPage({ params }: ExportReportDet
 
   let previewData: ReportPreviewData | null = null;
   let errorMessage: string | null = null;
+  let isProfileMissing = false;
 
   try {
     previewData = await loadReportPreviewData(orgId, financialYear);
   } catch (error) {
     if (error instanceof Error && error.message.includes("Profile not found")) {
+      isProfileMissing = true;
       errorMessage = `${financialYear}年の報告書プロフィールが登録されていません。先にプロフィールを登録してください。`;
     } else {
       errorMessage = error instanceof Error ? error.message : "不明なエラーが発生しました";
@@ -55,35 +57,41 @@ export default async function ExportReportDetailPage({ params }: ExportReportDet
         description="政治資金報告書をエクスポートします"
       />
 
-      <div className="bg-card rounded-xl p-4 space-y-6">
-        <ExportReportSelectors
-          organizations={organizations}
-          selectedOrgId={orgId}
-          selectedYear={financialYear}
-          currentYear={currentYear}
-        />
+      <div className="rounded-lg border border-border bg-card p-6">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <ExportReportSelectors
+            organizations={organizations}
+            selectedOrgId={orgId}
+            selectedYear={financialYear}
+            currentYear={currentYear}
+          />
+          {previewData && (
+            <DownloadButton politicalOrganizationId={orgId} financialYear={financialYear} />
+          )}
+        </div>
 
         {errorMessage ? (
-          <div className="rounded-lg px-3 py-2 bg-red-500/20 text-red-200">
-            {errorMessage}
-            {errorMessage.includes("プロフィール") && (
+          isProfileMissing ? (
+            <div className="rounded-lg border border-primary-active bg-accent p-3 text-sm text-accent-foreground">
+              {errorMessage}
               <Link
                 href={`/political-organizations/${orgId}/report-profile?year=${financialYear}`}
-                className="ml-2 underline hover:no-underline"
+                className="ml-2 font-bold underline hover:text-primary-hover"
               >
                 プロフィール登録ページへ
               </Link>
-            )}
-          </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive">
+              {errorMessage}
+            </div>
+          )
         ) : previewData ? (
-          <>
-            <DownloadButton politicalOrganizationId={orgId} financialYear={financialYear} />
-            <ExportReportPreview
-              xml={previewData.xml}
-              reportData={previewData.reportData}
-              summaryData={previewData.summaryData}
-            />
-          </>
+          <ExportReportPreview
+            xml={previewData.xml}
+            reportData={previewData.reportData}
+            summaryData={previewData.summaryData}
+          />
         ) : null}
       </div>
     </div>

--- a/admin/src/app/(auth)/export-report/page.tsx
+++ b/admin/src/app/(auth)/export-report/page.tsx
@@ -11,8 +11,8 @@ export default async function ExportReportPage() {
     return (
       <div>
         <PageHeader label="Report Export" title="報告書エクスポート" />
-        <div className="bg-card rounded-xl p-4">
-          <p className="text-muted-foreground">
+        <div className="rounded-lg border border-border bg-card p-6">
+          <p className="text-sm text-muted-foreground">
             政治団体が登録されていません。先に政治団体を作成してください。
           </p>
         </div>

--- a/admin/src/client/components/export-report/DownloadButton.tsx
+++ b/admin/src/client/components/export-report/DownloadButton.tsx
@@ -1,7 +1,9 @@
 "use client";
 import "client-only";
 
-import { useState, useTransition } from "react";
+import { useTransition } from "react";
+import { CircleNotch, DownloadSimple } from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
 import { Button } from "@/client/components/ui";
 import { apiClient } from "@/client/lib/api-client";
 
@@ -12,10 +14,8 @@ interface DownloadButtonProps {
 
 export function DownloadButton({ politicalOrganizationId, financialYear }: DownloadButtonProps) {
   const [isDownloading, startDownloadTransition] = useTransition();
-  const [status, setStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
 
   function handleDownload() {
-    setStatus(null);
     startDownloadTransition(async () => {
       try {
         const { blob, filename } = await apiClient.downloadReport({
@@ -33,37 +33,23 @@ export function DownloadButton({ politicalOrganizationId, financialYear }: Downl
         document.body.removeChild(link);
         setTimeout(() => window.URL.revokeObjectURL(url), 100);
 
-        setStatus({
-          type: "success",
-          message: "XMLファイルをダウンロードしました",
-        });
+        toast.success("XMLファイルをダウンロードしました");
       } catch (error) {
         console.error(error);
-        setStatus({
-          type: "error",
-          message: error instanceof Error ? error.message : "不明なエラーが発生しました",
-        });
+        toast.error(error instanceof Error ? error.message : "不明なエラーが発生しました");
       }
     });
   }
 
   return (
-    <div className="space-y-4">
-      <Button type="button" onClick={handleDownload} disabled={isDownloading}>
-        {isDownloading ? "ダウンロード中..." : "XMLをダウンロード"}
-      </Button>
-
-      {status && (
-        <div
-          className={`rounded-lg px-3 py-2 ${
-            status.type === "error"
-              ? "bg-red-500/20 text-red-200"
-              : "bg-green-500/20 text-green-200"
-          }`}
-        >
-          {status.message}
-        </div>
-      )}
-    </div>
+    <Button
+      type="button"
+      className="text-[13px] tracking-[0.06em]"
+      onClick={handleDownload}
+      disabled={isDownloading}
+    >
+      {isDownloading ? <CircleNotch className="animate-spin" /> : <DownloadSimple />}
+      {isDownloading ? "ダウンロード中..." : "XMLをダウンロード"}
+    </Button>
   );
 }

--- a/admin/src/client/components/export-report/ExportReportPreview.tsx
+++ b/admin/src/client/components/export-report/ExportReportPreview.tsx
@@ -13,12 +13,20 @@ interface ExportReportPreviewProps {
   summaryData: SummaryData;
 }
 
+/** アクティブタブを teal 系（teal-100 背景 + teal-deep 文字・枠）で示す */
+const ACTIVE_TAB_CLASS =
+  "data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:border-primary-active";
+
 export function ExportReportPreview({ xml, reportData, summaryData }: ExportReportPreviewProps) {
   return (
-    <Tabs defaultValue="table" className="w-full">
+    <Tabs defaultValue="table" className="w-full gap-4">
       <TabsList>
-        <TabsTrigger value="table">表形式プレビュー</TabsTrigger>
-        <TabsTrigger value="xml">XMLプレビュー</TabsTrigger>
+        <TabsTrigger value="table" className={ACTIVE_TAB_CLASS}>
+          表形式プレビュー
+        </TabsTrigger>
+        <TabsTrigger value="xml" className={ACTIVE_TAB_CLASS}>
+          XMLプレビュー
+        </TabsTrigger>
       </TabsList>
       <TabsContent value="table">
         <ReportDataPreview reportData={reportData} summaryData={summaryData} />

--- a/admin/src/client/components/export-report/ExportReportSelectors.tsx
+++ b/admin/src/client/components/export-report/ExportReportSelectors.tsx
@@ -4,8 +4,6 @@ import "client-only";
 import { useRouter } from "next/navigation";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import {
-  Card,
-  Label,
   Select,
   SelectContent,
   SelectItem,
@@ -38,35 +36,29 @@ export function ExportReportSelectors({
   }
 
   return (
-    <Card className="p-4">
-      <div className="flex flex-col md:flex-row md:items-end gap-4">
-        <div className="w-fit">
-          <PoliticalOrganizationSelect
-            organizations={organizations}
-            value={selectedOrgId}
-            onValueChange={handleOrganizationChange}
-            required
-          />
-        </div>
-        <div className="w-fit space-y-2">
-          <Label>報告年 (西暦)</Label>
-          <Select
-            value={selectedYear.toString()}
-            onValueChange={(v) => handleYearChange(Number.parseInt(v, 10))}
-          >
-            <SelectTrigger className="w-32">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {Array.from({ length: 10 }, (_, i) => currentYear - i).map((y) => (
-                <SelectItem key={y} value={y.toString()}>
-                  {y}年
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-    </Card>
+    <div className="flex flex-wrap items-center gap-3">
+      <PoliticalOrganizationSelect
+        organizations={organizations}
+        value={selectedOrgId}
+        onValueChange={handleOrganizationChange}
+        required
+        hideLabel
+      />
+      <Select
+        value={selectedYear.toString()}
+        onValueChange={(v) => handleYearChange(Number.parseInt(v, 10))}
+      >
+        <SelectTrigger aria-label="報告年 (西暦)" className="border-[1.5px] text-[13px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {Array.from({ length: 10 }, (_, i) => currentYear - i).map((y) => (
+            <SelectItem key={y} value={y.toString()}>
+              <span className="font-latin">{y}</span>年
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
   );
 }

--- a/admin/src/client/components/export-report/ReportDataPreview.tsx
+++ b/admin/src/client/components/export-report/ReportDataPreview.tsx
@@ -1,11 +1,11 @@
 import type { ReportData } from "@/server/contexts/report/domain/models/report-data";
 import type { SummaryData } from "@/server/contexts/report/domain/models/summary-data";
-import { DonationSection } from "./sections/DonationSection";
-import { IncomeSection } from "./sections/IncomeSection";
-import { PoliticalActivityExpenseSection } from "./sections/PoliticalActivityExpenseSection";
-import { ProfileSection } from "./sections/ProfileSection";
-import { RegularExpenseSection } from "./sections/RegularExpenseSection";
-import { SummarySection } from "./sections/SummarySection";
+import { DonationSection } from "@/client/components/export-report/sections/DonationSection";
+import { IncomeSection } from "@/client/components/export-report/sections/IncomeSection";
+import { PoliticalActivityExpenseSection } from "@/client/components/export-report/sections/PoliticalActivityExpenseSection";
+import { ProfileSection } from "@/client/components/export-report/sections/ProfileSection";
+import { RegularExpenseSection } from "@/client/components/export-report/sections/RegularExpenseSection";
+import { SummarySection } from "@/client/components/export-report/sections/SummarySection";
 
 interface ReportDataPreviewProps {
   reportData: ReportData;
@@ -18,8 +18,10 @@ export function ReportDataPreview({ reportData, summaryData }: ReportDataPreview
   return (
     <div className="space-y-8">
       <div>
-        <h2 className="text-lg font-medium text-foreground mb-1">表形式プレビュー</h2>
-        <p className="text-sm text-muted-foreground">報告書データを表形式で確認できます。</p>
+        <h2 className="text-base font-bold text-foreground">表形式プレビュー</h2>
+        <p className="mt-1 text-[13px] text-muted-foreground">
+          報告書データを表形式で確認できます。
+        </p>
       </div>
 
       <div className="space-y-8">

--- a/admin/src/client/components/export-report/XmlPreview.tsx
+++ b/admin/src/client/components/export-report/XmlPreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Check, Copy } from "@phosphor-icons/react/dist/ssr";
 import { Button } from "@/client/components/ui";
 
 interface XmlPreviewProps {
@@ -23,12 +24,13 @@ export function XmlPreview({ xml }: XmlPreviewProps) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-medium text-foreground">XMLプレビュー</h2>
-        <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
+        <h2 className="text-base font-bold text-foreground">XMLプレビュー</h2>
+        <Button type="button" variant="outline" size="sm" className="text-xs" onClick={handleCopy}>
+          {copied ? <Check /> : <Copy />}
           {copied ? "コピーしました" : "コピー"}
         </Button>
       </div>
-      <pre className="bg-black/30 rounded-lg p-4 text-sm overflow-auto flex-1 min-h-[300px] max-h-[600px] whitespace-pre-wrap text-muted-foreground">
+      <pre className="min-h-[300px] max-h-[600px] flex-1 overflow-auto rounded-lg border border-border-soft bg-background p-4 font-latin text-xs leading-relaxed whitespace-pre-wrap text-foreground">
         {xml || "プレビューを生成するとここにXMLが表示されます。"}
       </pre>
     </div>

--- a/admin/src/client/components/export-report/sections/DonationSection.tsx
+++ b/admin/src/client/components/export-report/sections/DonationSection.tsx
@@ -6,8 +6,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/client/components/ui";
-import { formatCurrency } from "@/client/lib";
-import { SectionWrapper } from "./SectionWrapper";
+import { SectionHeading } from "@/client/components/export-report/sections/SectionHeading";
+import { SectionWrapper } from "@/client/components/export-report/sections/SectionWrapper";
+import {
+  AmountCell,
+  AmountHead,
+  DateCell,
+  DateHead,
+  EmptyMessage,
+  RowNumberCell,
+  RowNumberHead,
+} from "@/client/components/export-report/sections/ReportTableCells";
 import type {
   PersonalDonationSection,
   PersonalDonationRow,
@@ -17,51 +26,38 @@ interface DonationSectionProps {
   personalDonations: PersonalDonationSection;
 }
 
-function formatDate(date: Date | null): string {
-  if (!date) return "";
-  const d = new Date(date);
-  const year = d.getFullYear();
-  const month = d.getMonth() + 1;
-  const day = d.getDate();
-  return `${year}/${month}/${day}`;
-}
-
 interface PersonalDonationTableProps {
   rows: PersonalDonationRow[];
 }
 
 function PersonalDonationTable({ rows }: PersonalDonationTableProps) {
   if (rows.length === 0) {
-    return <p className="text-gray-500 text-sm">明細はありません</p>;
+    return <EmptyMessage>明細はありません</EmptyMessage>;
   }
 
   return (
-    <Table className="border-collapse border border-black">
+    <Table>
       <TableHeader>
-        <TableRow className="border border-black">
-          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
-          <TableHead className="w-[150px] text-black border border-black">寄附者氏名</TableHead>
-          <TableHead className="w-[100px] text-right text-black border border-black">
-            金額
-          </TableHead>
-          <TableHead className="w-[100px] text-black border border-black">年月日</TableHead>
-          <TableHead className="w-[200px] text-black border border-black">住所</TableHead>
-          <TableHead className="w-[100px] text-black border border-black">職業</TableHead>
-          <TableHead className="w-[150px] text-black border border-black">備考</TableHead>
+        <TableRow>
+          <RowNumberHead />
+          <TableHead className="w-[150px]">寄附者氏名</TableHead>
+          <AmountHead />
+          <DateHead />
+          <TableHead className="w-[200px]">住所</TableHead>
+          <TableHead className="w-[100px]">職業</TableHead>
+          <TableHead className="w-[150px]">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border border-black">
-            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black border border-black">{row.kifusyaNm}</TableCell>
-            <TableCell className="text-right text-black border border-black">
-              {formatCurrency(row.kingaku)}
-            </TableCell>
-            <TableCell className="text-black border border-black">{formatDate(row.dt)}</TableCell>
-            <TableCell className="text-black border border-black">{row.adr}</TableCell>
-            <TableCell className="text-black border border-black">{row.syokugyo}</TableCell>
-            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo}>
+            <RowNumberCell value={row.ichirenNo} />
+            <TableCell>{row.kifusyaNm}</TableCell>
+            <AmountCell value={row.kingaku} />
+            <DateCell value={row.dt} />
+            <TableCell>{row.adr}</TableCell>
+            <TableCell>{row.syokugyo}</TableCell>
+            <TableCell className="text-muted-foreground">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -74,8 +70,13 @@ export function DonationSection({ personalDonations }: DonationSectionProps) {
     personalDonations.rows.length > 0 || personalDonations.totalAmount > 0;
 
   return (
-    <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">寄附 (SYUUSHI07_07)</h2>
+    <div className="space-y-4">
+      <SectionHeading>
+        寄附{" "}
+        <span className="font-latin text-sm font-semibold text-subtle-foreground">
+          SYUUSHI07_07
+        </span>
+      </SectionHeading>
 
       <SectionWrapper
         title="個人からの寄附"
@@ -88,7 +89,7 @@ export function DonationSection({ personalDonations }: DonationSectionProps) {
         {hasPersonalDonationData ? (
           <PersonalDonationTable rows={personalDonations.rows} />
         ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
+          <EmptyMessage>データなし</EmptyMessage>
         )}
       </SectionWrapper>
     </div>

--- a/admin/src/client/components/export-report/sections/ExpenseTable.tsx
+++ b/admin/src/client/components/export-report/sections/ExpenseTable.tsx
@@ -1,0 +1,58 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/client/components/ui";
+import {
+  AmountCell,
+  AmountHead,
+  DateCell,
+  DateHead,
+  EmptyMessage,
+  RowNumberCell,
+  RowNumberHead,
+} from "@/client/components/export-report/sections/ReportTableCells";
+import type { ExpenseRow } from "@/server/contexts/report/domain/models/expense-transaction";
+
+interface ExpenseTableProps {
+  rows: ExpenseRow[];
+}
+
+/** 経常経費・政治活動費で共通の支出明細テーブル（目的 / 金額 / 年月日 / 氏名 / 住所 / 備考） */
+export function ExpenseTable({ rows }: ExpenseTableProps) {
+  if (rows.length === 0) {
+    return <EmptyMessage>5万円以上の明細はありません</EmptyMessage>;
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <RowNumberHead />
+          <TableHead className="w-[200px]">目的</TableHead>
+          <AmountHead />
+          <DateHead />
+          <TableHead className="w-[150px]">氏名</TableHead>
+          <TableHead className="w-[200px]">住所</TableHead>
+          <TableHead className="w-[150px]">備考</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row) => (
+          <TableRow key={row.ichirenNo}>
+            <RowNumberCell value={row.ichirenNo} />
+            <TableCell>{row.mokuteki}</TableCell>
+            <AmountCell value={row.kingaku} />
+            <DateCell value={row.dt} />
+            <TableCell>{row.nm}</TableCell>
+            <TableCell>{row.adr}</TableCell>
+            <TableCell className="text-muted-foreground">{row.bikou || ""}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/admin/src/client/components/export-report/sections/IncomeSection.tsx
+++ b/admin/src/client/components/export-report/sections/IncomeSection.tsx
@@ -6,8 +6,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/client/components/ui";
-import { formatCurrency } from "@/client/lib";
-import { SectionWrapper } from "./SectionWrapper";
+import { SectionHeading } from "@/client/components/export-report/sections/SectionHeading";
+import { SectionWrapper } from "@/client/components/export-report/sections/SectionWrapper";
+import {
+  AmountCell,
+  AmountHead,
+  DateCell,
+  DateHead,
+  EmptyMessage,
+  RowNumberCell,
+  RowNumberHead,
+} from "@/client/components/export-report/sections/ReportTableCells";
 import type {
   BusinessIncomeSection,
   BusinessIncomeRow,
@@ -26,44 +35,32 @@ interface IncomeSectionProps {
   otherIncome: OtherIncomeSection;
 }
 
-function formatDate(date: Date): string {
-  const d = new Date(date);
-  const year = d.getFullYear();
-  const month = d.getMonth() + 1;
-  const day = d.getDate();
-  return `${year}/${month}/${day}`;
-}
-
 interface BusinessIncomeTableProps {
   rows: BusinessIncomeRow[];
 }
 
 function BusinessIncomeTable({ rows }: BusinessIncomeTableProps) {
   if (rows.length === 0) {
-    return <p className="text-gray-500 text-sm">明細はありません</p>;
+    return <EmptyMessage>明細はありません</EmptyMessage>;
   }
 
   return (
-    <Table className="border-collapse border border-black">
+    <Table>
       <TableHeader>
-        <TableRow className="border border-black">
-          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
-          <TableHead className="w-[250px] text-black border border-black">事業の種類</TableHead>
-          <TableHead className="w-[100px] text-right text-black border border-black">
-            金額
-          </TableHead>
-          <TableHead className="w-[200px] text-black border border-black">備考</TableHead>
+        <TableRow>
+          <RowNumberHead />
+          <TableHead className="w-[250px]">事業の種類</TableHead>
+          <AmountHead />
+          <TableHead className="w-[200px]">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border border-black">
-            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black border border-black">{row.gigyouSyurui}</TableCell>
-            <TableCell className="text-right text-black border border-black">
-              {formatCurrency(row.kingaku)}
-            </TableCell>
-            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo}>
+            <RowNumberCell value={row.ichirenNo} />
+            <TableCell>{row.gigyouSyurui}</TableCell>
+            <AmountCell value={row.kingaku} />
+            <TableCell className="text-muted-foreground">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -77,30 +74,26 @@ interface LoanIncomeTableProps {
 
 function LoanIncomeTable({ rows }: LoanIncomeTableProps) {
   if (rows.length === 0) {
-    return <p className="text-gray-500 text-sm">明細はありません</p>;
+    return <EmptyMessage>明細はありません</EmptyMessage>;
   }
 
   return (
-    <Table className="border-collapse border border-black">
+    <Table>
       <TableHeader>
-        <TableRow className="border border-black">
-          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
-          <TableHead className="w-[250px] text-black border border-black">借入先</TableHead>
-          <TableHead className="w-[100px] text-right text-black border border-black">
-            金額
-          </TableHead>
-          <TableHead className="w-[200px] text-black border border-black">備考</TableHead>
+        <TableRow>
+          <RowNumberHead />
+          <TableHead className="w-[250px]">借入先</TableHead>
+          <AmountHead />
+          <TableHead className="w-[200px]">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border border-black">
-            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black border border-black">{row.kariiresaki}</TableCell>
-            <TableCell className="text-right text-black border border-black">
-              {formatCurrency(row.kingaku)}
-            </TableCell>
-            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo}>
+            <RowNumberCell value={row.ichirenNo} />
+            <TableCell>{row.kariiresaki}</TableCell>
+            <AmountCell value={row.kingaku} />
+            <TableCell className="text-muted-foreground">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -114,34 +107,30 @@ interface GrantIncomeTableProps {
 
 function GrantIncomeTable({ rows }: GrantIncomeTableProps) {
   if (rows.length === 0) {
-    return <p className="text-gray-500 text-sm">明細はありません</p>;
+    return <EmptyMessage>明細はありません</EmptyMessage>;
   }
 
   return (
-    <Table className="border-collapse border border-black">
+    <Table>
       <TableHeader>
-        <TableRow className="border border-black">
-          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
-          <TableHead className="w-[200px] text-black border border-black">本支部名称</TableHead>
-          <TableHead className="w-[100px] text-right text-black border border-black">
-            金額
-          </TableHead>
-          <TableHead className="w-[100px] text-black border border-black">年月日</TableHead>
-          <TableHead className="w-[200px] text-black border border-black">事務所所在地</TableHead>
-          <TableHead className="w-[150px] text-black border border-black">備考</TableHead>
+        <TableRow>
+          <RowNumberHead />
+          <TableHead className="w-[200px]">本支部名称</TableHead>
+          <AmountHead />
+          <DateHead />
+          <TableHead className="w-[200px]">事務所所在地</TableHead>
+          <TableHead className="w-[150px]">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border border-black">
-            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black border border-black">{row.honsibuNm}</TableCell>
-            <TableCell className="text-right text-black border border-black">
-              {formatCurrency(row.kingaku)}
-            </TableCell>
-            <TableCell className="text-black border border-black">{formatDate(row.dt)}</TableCell>
-            <TableCell className="text-black border border-black">{row.jimuAdr}</TableCell>
-            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo}>
+            <RowNumberCell value={row.ichirenNo} />
+            <TableCell>{row.honsibuNm}</TableCell>
+            <AmountCell value={row.kingaku} />
+            <DateCell value={row.dt} />
+            <TableCell>{row.jimuAdr}</TableCell>
+            <TableCell className="text-muted-foreground">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -155,30 +144,26 @@ interface OtherIncomeTableProps {
 
 function OtherIncomeTable({ rows }: OtherIncomeTableProps) {
   if (rows.length === 0) {
-    return <p className="text-gray-500 text-sm">10万円以上の明細はありません</p>;
+    return <EmptyMessage>10万円以上の明細はありません</EmptyMessage>;
   }
 
   return (
-    <Table className="border-collapse border border-black">
+    <Table>
       <TableHeader>
-        <TableRow className="border border-black">
-          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
-          <TableHead className="w-[250px] text-black border border-black">摘要</TableHead>
-          <TableHead className="w-[100px] text-right text-black border border-black">
-            金額
-          </TableHead>
-          <TableHead className="w-[200px] text-black border border-black">備考</TableHead>
+        <TableRow>
+          <RowNumberHead />
+          <TableHead className="w-[250px]">摘要</TableHead>
+          <AmountHead />
+          <TableHead className="w-[200px]">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border border-black">
-            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black border border-black">{row.tekiyou}</TableCell>
-            <TableCell className="text-right text-black border border-black">
-              {formatCurrency(row.kingaku)}
-            </TableCell>
-            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo}>
+            <RowNumberCell value={row.ichirenNo} />
+            <TableCell>{row.tekiyou}</TableCell>
+            <AmountCell value={row.kingaku} />
+            <TableCell className="text-muted-foreground">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -198,8 +183,8 @@ export function IncomeSection({
   const hasOtherIncomeData = otherIncome.rows.length > 0 || otherIncome.totalAmount > 0;
 
   return (
-    <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">収入の部</h2>
+    <div className="space-y-4">
+      <SectionHeading>収入の部</SectionHeading>
 
       <SectionWrapper
         title="事業による収入"
@@ -210,7 +195,7 @@ export function IncomeSection({
         {hasBusinessIncomeData ? (
           <BusinessIncomeTable rows={businessIncome.rows} />
         ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
+          <EmptyMessage>データなし</EmptyMessage>
         )}
       </SectionWrapper>
 
@@ -223,7 +208,7 @@ export function IncomeSection({
         {hasLoanIncomeData ? (
           <LoanIncomeTable rows={loanIncome.rows} />
         ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
+          <EmptyMessage>データなし</EmptyMessage>
         )}
       </SectionWrapper>
 
@@ -236,7 +221,7 @@ export function IncomeSection({
         {hasGrantIncomeData ? (
           <GrantIncomeTable rows={grantIncome.rows} />
         ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
+          <EmptyMessage>データなし</EmptyMessage>
         )}
       </SectionWrapper>
 
@@ -250,7 +235,7 @@ export function IncomeSection({
         {hasOtherIncomeData ? (
           <OtherIncomeTable rows={otherIncome.rows} />
         ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
+          <EmptyMessage>データなし</EmptyMessage>
         )}
       </SectionWrapper>
     </div>

--- a/admin/src/client/components/export-report/sections/KeyValueTable.tsx
+++ b/admin/src/client/components/export-report/sections/KeyValueTable.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { cn } from "@/client/lib";
+
+/**
+ * 団体基本情報・収支総括表などの「項目名 | 値」形式テーブル。
+ * 罫線は行罫線 #E5E5E5、小見出し行は黒 1.5px の下罫線（ハンドオフのテーブル罫線ルール）。
+ */
+
+export function KeyValueTable({ children }: { children: ReactNode }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border-soft">
+      <table className="w-full border-collapse text-sm">
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}
+
+interface KeyValueRowProps {
+  label: string;
+  value: string;
+  /** 金額など、Poppins 右寄せで表示する場合 */
+  numeric?: boolean;
+}
+
+export function KeyValueRow({ label, value, numeric = false }: KeyValueRowProps) {
+  return (
+    <tr className="border-b border-border-soft last:border-b-0">
+      <th className="w-1/3 bg-background px-4 py-2.5 text-left text-xs font-bold text-foreground">
+        {label}
+      </th>
+      <td
+        className={cn(
+          "px-4 py-2.5 text-foreground",
+          numeric && "text-right font-latin font-semibold",
+        )}
+      >
+        {value}
+      </td>
+    </tr>
+  );
+}
+
+export function KeyValueGroupHeader({ title }: { title: string }) {
+  return (
+    <tr className="border-b-[1.5px] border-border">
+      <th
+        colSpan={2}
+        className="bg-card px-4 py-2.5 text-left text-[13px] font-bold text-foreground"
+      >
+        {title}
+      </th>
+    </tr>
+  );
+}

--- a/admin/src/client/components/export-report/sections/PoliticalActivityExpenseSection.tsx
+++ b/admin/src/client/components/export-report/sections/PoliticalActivityExpenseSection.tsx
@@ -1,13 +1,7 @@
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/client/components/ui";
-import { formatCurrency } from "@/client/lib";
-import { SectionWrapper } from "./SectionWrapper";
+import { ExpenseTable } from "@/client/components/export-report/sections/ExpenseTable";
+import { EmptyMessage } from "@/client/components/export-report/sections/ReportTableCells";
+import { SectionHeading } from "@/client/components/export-report/sections/SectionHeading";
+import { SectionWrapper } from "@/client/components/export-report/sections/SectionWrapper";
 import type {
   OrganizationExpenseSection,
   ElectionExpenseSection,
@@ -31,57 +25,6 @@ interface PoliticalActivityExpenseSectionProps {
   researchExpenses: ResearchExpenseSection[];
   donationGrantExpenses: DonationGrantExpenseSection[];
   otherPoliticalExpenses: OtherPoliticalExpenseSection[];
-}
-
-function formatDate(date: Date): string {
-  const d = new Date(date);
-  const year = d.getFullYear();
-  const month = d.getMonth() + 1;
-  const day = d.getDate();
-  return `${year}/${month}/${day}`;
-}
-
-interface PoliticalActivityExpenseTableProps {
-  rows: PoliticalActivityExpenseRow[];
-}
-
-function PoliticalActivityExpenseTable({ rows }: PoliticalActivityExpenseTableProps) {
-  if (rows.length === 0) {
-    return <p className="text-gray-500 text-sm">5万円以上の明細はありません</p>;
-  }
-
-  return (
-    <Table className="border-collapse border border-black">
-      <TableHeader>
-        <TableRow className="border border-black">
-          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
-          <TableHead className="w-[200px] text-black border border-black">目的</TableHead>
-          <TableHead className="w-[100px] text-right text-black border border-black">
-            金額
-          </TableHead>
-          <TableHead className="w-[100px] text-black border border-black">年月日</TableHead>
-          <TableHead className="w-[150px] text-black border border-black">氏名</TableHead>
-          <TableHead className="w-[200px] text-black border border-black">住所</TableHead>
-          <TableHead className="w-[150px] text-black border border-black">備考</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border border-black">
-            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black border border-black">{row.mokuteki}</TableCell>
-            <TableCell className="text-right text-black border border-black">
-              {formatCurrency(row.kingaku)}
-            </TableCell>
-            <TableCell className="text-black border border-black">{formatDate(row.dt)}</TableCell>
-            <TableCell className="text-black border border-black">{row.nm}</TableCell>
-            <TableCell className="text-black border border-black">{row.adr}</TableCell>
-            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
-  );
 }
 
 interface ExpenseArraySubSectionProps {
@@ -110,25 +53,21 @@ function ExpenseArraySubSection({ title, formId, sections }: ExpenseArraySubSect
       thresholdLabel="5万円未満の合計"
       isEmpty={!hasData}
     >
-      {hasData ? (
-        sections.length > 0 ? (
-          <div className="space-y-4">
-            {sections.map((section, index) => (
-              <div key={section.himoku || index}>
-                {section.himoku && (
-                  <h4 className="text-sm font-medium text-muted-foreground mb-2">
-                    費目: {section.himoku}
-                  </h4>
-                )}
-                <PoliticalActivityExpenseTable rows={section.rows} />
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
-        )
+      {hasData && sections.length > 0 ? (
+        <div className="space-y-4">
+          {sections.map((section, index) => (
+            <div key={section.himoku || index}>
+              {section.himoku && (
+                <h4 className="mb-2 text-[13px] font-bold text-muted-foreground">
+                  費目: {section.himoku}
+                </h4>
+              )}
+              <ExpenseTable rows={section.rows} />
+            </div>
+          ))}
+        </div>
       ) : (
-        <p className="text-gray-500 text-sm">データなし</p>
+        <EmptyMessage>データなし</EmptyMessage>
       )}
     </SectionWrapper>
   );
@@ -146,8 +85,13 @@ export function PoliticalActivityExpenseSection({
   otherPoliticalExpenses,
 }: PoliticalActivityExpenseSectionProps) {
   return (
-    <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">政治活動費 (SYUUSHI07_15)</h2>
+    <div className="space-y-4">
+      <SectionHeading>
+        政治活動費{" "}
+        <span className="font-latin text-sm font-semibold text-subtle-foreground">
+          SYUUSHI07_15
+        </span>
+      </SectionHeading>
 
       <ExpenseArraySubSection title="組織活動費" formId="KUBUN1" sections={organizationExpenses} />
 

--- a/admin/src/client/components/export-report/sections/ProfileSection.tsx
+++ b/admin/src/client/components/export-report/sections/ProfileSection.tsx
@@ -1,4 +1,10 @@
 import type { OrganizationReportProfile } from "@/server/contexts/report/domain/models/organization-report-profile";
+import {
+  KeyValueRow,
+  KeyValueTable,
+} from "@/client/components/export-report/sections/KeyValueTable";
+import { SectionCard } from "@/client/components/export-report/sections/SectionCard";
+import { SectionHeading } from "@/client/components/export-report/sections/SectionHeading";
 
 interface ProfileSectionProps {
   profile: OrganizationReportProfile;
@@ -46,22 +52,6 @@ function formatAddress(
   return address;
 }
 
-interface ProfileRowProps {
-  label: string;
-  value: string;
-}
-
-function ProfileRow({ label, value }: ProfileRowProps) {
-  return (
-    <tr className="border border-black">
-      <th className="py-2 px-4 text-left font-medium text-gray-700 bg-gray-50 w-1/3 border border-black">
-        {label}
-      </th>
-      <td className="py-2 px-4 text-gray-900 border border-black">{value}</td>
-    </tr>
-  );
-}
-
 export function ProfileSection({ profile }: ProfileSectionProps) {
   const { details } = profile;
 
@@ -76,35 +66,28 @@ export function ProfileSection({ profile }: ProfileSectionProps) {
       : "-";
 
   return (
-    <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">団体基本情報</h2>
+    <div className="space-y-4">
+      <SectionHeading>団体基本情報</SectionHeading>
 
-      <div className="bg-white border border-black overflow-hidden">
-        <div className="bg-gray-100 border-b border-black px-4 py-3">
-          <h3 className="text-lg font-semibold text-black">団体基本情報 (SYUUSHI07_01)</h3>
-        </div>
-        <div className="p-4">
-          <table className="w-full border-collapse border border-black">
-            <tbody>
-              <ProfileRow label="報告年" value={String(profile.financialYear)} />
-              <ProfileRow label="政治団体名称" value={profile.officialName || "-"} />
-              <ProfileRow label="ふりがな" value={profile.officialNameKana || "-"} />
-              <ProfileRow
-                label="主たる事務所の所在地"
-                value={formatAddress(profile.officeAddress, profile.officeAddressBuilding)}
-              />
-              <ProfileRow label="代表者氏名" value={formatFullName(details.representative)} />
-              <ProfileRow label="会計責任者氏名" value={formatFullName(details.accountant)} />
-              <ProfileRow label="事務担当者" value={contactPersonsDisplay} />
-              <ProfileRow label="活動区域" value={getActivityAreaLabel(details.activityArea)} />
-              <ProfileRow
-                label="国会議員関係政治団体の区分"
-                value={getDietMemberRelationTypeLabel(details.dietMemberRelation?.type)}
-              />
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <SectionCard title="団体基本情報" formId="SYUUSHI07_01">
+        <KeyValueTable>
+          <KeyValueRow label="報告年" value={String(profile.financialYear)} />
+          <KeyValueRow label="政治団体名称" value={profile.officialName || "-"} />
+          <KeyValueRow label="ふりがな" value={profile.officialNameKana || "-"} />
+          <KeyValueRow
+            label="主たる事務所の所在地"
+            value={formatAddress(profile.officeAddress, profile.officeAddressBuilding)}
+          />
+          <KeyValueRow label="代表者氏名" value={formatFullName(details.representative)} />
+          <KeyValueRow label="会計責任者氏名" value={formatFullName(details.accountant)} />
+          <KeyValueRow label="事務担当者" value={contactPersonsDisplay} />
+          <KeyValueRow label="活動区域" value={getActivityAreaLabel(details.activityArea)} />
+          <KeyValueRow
+            label="国会議員関係政治団体の区分"
+            value={getDietMemberRelationTypeLabel(details.dietMemberRelation?.type)}
+          />
+        </KeyValueTable>
+      </SectionCard>
     </div>
   );
 }

--- a/admin/src/client/components/export-report/sections/RegularExpenseSection.tsx
+++ b/admin/src/client/components/export-report/sections/RegularExpenseSection.tsx
@@ -1,75 +1,17 @@
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/client/components/ui";
-import { formatCurrency } from "@/client/lib";
-import { SectionWrapper } from "./SectionWrapper";
+import { ExpenseTable } from "@/client/components/export-report/sections/ExpenseTable";
+import { EmptyMessage } from "@/client/components/export-report/sections/ReportTableCells";
+import { SectionHeading } from "@/client/components/export-report/sections/SectionHeading";
+import { SectionWrapper } from "@/client/components/export-report/sections/SectionWrapper";
 import type {
   UtilityExpenseSection,
   SuppliesExpenseSection,
   OfficeExpenseSection,
-  ExpenseRow,
 } from "@/server/contexts/report/domain/models/expense-transaction";
 
 interface RegularExpenseSectionProps {
   utilityExpenses: UtilityExpenseSection;
   suppliesExpenses: SuppliesExpenseSection;
   officeExpenses: OfficeExpenseSection;
-}
-
-function formatDate(date: Date): string {
-  const d = new Date(date);
-  const year = d.getFullYear();
-  const month = d.getMonth() + 1;
-  const day = d.getDate();
-  return `${year}/${month}/${day}`;
-}
-
-interface ExpenseTableProps {
-  rows: ExpenseRow[];
-}
-
-function ExpenseTable({ rows }: ExpenseTableProps) {
-  if (rows.length === 0) {
-    return <p className="text-gray-500 text-sm">5万円以上の明細はありません</p>;
-  }
-
-  return (
-    <Table className="border-collapse border border-black">
-      <TableHeader>
-        <TableRow className="border border-black">
-          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
-          <TableHead className="w-[200px] text-black border border-black">目的</TableHead>
-          <TableHead className="w-[100px] text-right text-black border border-black">
-            金額
-          </TableHead>
-          <TableHead className="w-[100px] text-black border border-black">年月日</TableHead>
-          <TableHead className="w-[150px] text-black border border-black">氏名</TableHead>
-          <TableHead className="w-[200px] text-black border border-black">住所</TableHead>
-          <TableHead className="w-[150px] text-black border border-black">備考</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border border-black">
-            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black border border-black">{row.mokuteki}</TableCell>
-            <TableCell className="text-right text-black border border-black">
-              {formatCurrency(row.kingaku)}
-            </TableCell>
-            <TableCell className="text-black border border-black">{formatDate(row.dt)}</TableCell>
-            <TableCell className="text-black border border-black">{row.nm}</TableCell>
-            <TableCell className="text-black border border-black">{row.adr}</TableCell>
-            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
-  );
 }
 
 export function RegularExpenseSection({
@@ -82,8 +24,13 @@ export function RegularExpenseSection({
   const hasOfficeData = officeExpenses.rows.length > 0 || officeExpenses.totalAmount > 0;
 
   return (
-    <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">経常経費 (SYUUSHI07_14)</h2>
+    <div className="space-y-4">
+      <SectionHeading>
+        経常経費{" "}
+        <span className="font-latin text-sm font-semibold text-subtle-foreground">
+          SYUUSHI07_14
+        </span>
+      </SectionHeading>
 
       <SectionWrapper
         title="光熱水費"
@@ -95,7 +42,7 @@ export function RegularExpenseSection({
         {hasUtilityData ? (
           <ExpenseTable rows={utilityExpenses.rows} />
         ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
+          <EmptyMessage>データなし</EmptyMessage>
         )}
       </SectionWrapper>
 
@@ -109,7 +56,7 @@ export function RegularExpenseSection({
         {hasSuppliesData ? (
           <ExpenseTable rows={suppliesExpenses.rows} />
         ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
+          <EmptyMessage>データなし</EmptyMessage>
         )}
       </SectionWrapper>
 
@@ -123,7 +70,7 @@ export function RegularExpenseSection({
         {hasOfficeData ? (
           <ExpenseTable rows={officeExpenses.rows} />
         ) : (
-          <p className="text-gray-500 text-sm">データなし</p>
+          <EmptyMessage>データなし</EmptyMessage>
         )}
       </SectionWrapper>
     </div>

--- a/admin/src/client/components/export-report/sections/ReportTableCells.tsx
+++ b/admin/src/client/components/export-report/sections/ReportTableCells.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { TableCell, TableHead } from "@/client/components/ui";
+import { cn, formatCurrency, formatDate } from "@/client/lib";
+
+/**
+ * 報告書プレビューの明細テーブルで共通利用するセル群。
+ * 数字・日付は Poppins（font-latin）、金額は右寄せ、日付は YYYY.MM.DD（ハンドオフ準拠）。
+ */
+
+interface CellProps {
+  className?: string;
+}
+
+export function RowNumberHead({ className }: CellProps) {
+  return <TableHead className={cn("w-[50px]", className)}>行番号</TableHead>;
+}
+
+export function AmountHead({ className }: CellProps) {
+  return <TableHead className={cn("w-[100px] text-right", className)}>金額</TableHead>;
+}
+
+export function DateHead({ className }: CellProps) {
+  return <TableHead className={cn("w-[100px]", className)}>年月日</TableHead>;
+}
+
+export function RowNumberCell({ value }: { value: string }) {
+  return <TableCell className="font-latin text-xs text-muted-foreground">{value}</TableCell>;
+}
+
+export function AmountCell({ value }: { value: number }) {
+  return (
+    <TableCell className="text-right font-latin text-[13px] font-semibold">
+      {formatCurrency(value)}
+    </TableCell>
+  );
+}
+
+export function DateCell({ value }: { value: Date | null | undefined }) {
+  return <TableCell className="font-latin text-[13px]">{value ? formatDate(value) : ""}</TableCell>;
+}
+
+export function EmptyMessage({ children }: { children: ReactNode }) {
+  return <p className="text-sm text-muted-foreground">{children}</p>;
+}

--- a/admin/src/client/components/export-report/sections/SectionCard.tsx
+++ b/admin/src/client/components/export-report/sections/SectionCard.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { cn } from "@/client/lib";
+
+interface SectionCardProps {
+  title: string;
+  /** 様式ID（SYUUSHI07_03 / KUBUN1 など）。Poppins の英字ラベルとして表示する */
+  formId: string;
+  /** ヘッダー右側に置く補足（合計金額など） */
+  meta?: ReactNode;
+  /** データが無いセクションは見出しを控えめな色にする */
+  muted?: boolean;
+  children: ReactNode;
+}
+
+/** 白カード + 黒1px枠 + 角丸8px のセクション枠（ハンドオフ「6. その他の画面」の語彙） */
+export function SectionCard({ title, formId, meta, muted = false, children }: SectionCardProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <div
+        className={cn(
+          "flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border-b border-border bg-background px-4 py-3",
+          muted && "text-muted-foreground",
+        )}
+      >
+        <h3 className="text-[15px] font-bold">
+          {title}
+          <span className="ml-2 font-latin text-xs font-semibold tracking-[0.06em] text-subtle-foreground">
+            {formId}
+          </span>
+        </h3>
+        {meta && <div className="text-[13px]">{meta}</div>}
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}

--- a/admin/src/client/components/export-report/sections/SectionHeading.tsx
+++ b/admin/src/client/components/export-report/sections/SectionHeading.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+
+/** プレビュー内の大見出し（団体基本情報 / 収支総括表 / 収入の部 など） */
+export function SectionHeading({ children }: { children: ReactNode }) {
+  return <h2 className="text-[17px] font-bold text-foreground">{children}</h2>;
+}

--- a/admin/src/client/components/export-report/sections/SectionWrapper.tsx
+++ b/admin/src/client/components/export-report/sections/SectionWrapper.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { formatCurrency } from "@/client/lib";
+import { SectionCard } from "@/client/components/export-report/sections/SectionCard";
 
 interface SectionWrapperProps {
   title: string;
@@ -10,10 +12,7 @@ interface SectionWrapperProps {
   children: ReactNode;
 }
 
-function formatCurrency(amount: number): string {
-  return `¥${amount.toLocaleString("ja-JP")}`;
-}
-
+/** 合計金額付きの明細セクション枠 */
 export function SectionWrapper({
   title,
   formId,
@@ -24,23 +23,25 @@ export function SectionWrapper({
   children,
 }: SectionWrapperProps) {
   return (
-    <div className={`bg-white border border-black overflow-hidden ${isEmpty ? "opacity-50" : ""}`}>
-      <div className="bg-gray-100 border-b border-black px-4 py-3">
-        <div className="flex flex-col gap-1">
-          <h3 className="text-lg font-semibold text-black">
-            {title} ({formId})
-          </h3>
-          <div className="text-sm text-black">
-            <span className="font-medium">合計: {formatCurrency(totalAmount)}</span>
-            {underThresholdAmount !== undefined && underThresholdAmount > 0 && (
-              <span className="ml-4 text-gray-500">
-                ({thresholdLabel}: {formatCurrency(underThresholdAmount)})
-              </span>
-            )}
-          </div>
-        </div>
-      </div>
-      <div className="p-4">{children}</div>
-    </div>
+    <SectionCard
+      title={title}
+      formId={formId}
+      muted={isEmpty}
+      meta={
+        <>
+          <span>
+            合計: <span className="font-latin font-semibold">{formatCurrency(totalAmount)}</span>
+          </span>
+          {underThresholdAmount !== undefined && underThresholdAmount > 0 && (
+            <span className="ml-3 text-muted-foreground">
+              ({thresholdLabel}:{" "}
+              <span className="font-latin">{formatCurrency(underThresholdAmount)}</span>)
+            </span>
+          )}
+        </>
+      }
+    >
+      {children}
+    </SectionCard>
   );
 }

--- a/admin/src/client/components/export-report/sections/SummarySection.tsx
+++ b/admin/src/client/components/export-report/sections/SummarySection.tsx
@@ -1,11 +1,15 @@
 import type { SummaryData } from "@/server/contexts/report/domain/models/summary-data";
+import { formatCurrency } from "@/client/lib";
+import {
+  KeyValueGroupHeader,
+  KeyValueRow,
+  KeyValueTable,
+} from "@/client/components/export-report/sections/KeyValueTable";
+import { SectionCard } from "@/client/components/export-report/sections/SectionCard";
+import { SectionHeading } from "@/client/components/export-report/sections/SectionHeading";
 
 interface SummarySectionProps {
   summaryData: SummaryData;
-}
-
-function formatCurrency(amount: number): string {
-  return `¥${amount.toLocaleString("ja-JP")}`;
 }
 
 function formatNullableCurrency(amount: number | null): string {
@@ -15,74 +19,44 @@ function formatNullableCurrency(amount: number | null): string {
   return formatCurrency(amount);
 }
 
-interface SummaryRowProps {
-  label: string;
-  value: string;
-}
-
-function SummaryRow({ label, value }: SummaryRowProps) {
-  return (
-    <tr className="border border-black">
-      <th className="py-2 px-4 text-left font-medium text-gray-700 bg-gray-50 w-1/3 border border-black">
-        {label}
-      </th>
-      <td className="py-2 px-4 text-gray-900 text-right border border-black">{value}</td>
-    </tr>
-  );
-}
-
-interface SectionHeaderProps {
-  title: string;
-}
-
-function SectionHeader({ title }: SectionHeaderProps) {
-  return (
-    <tr className="border border-black">
-      <th
-        colSpan={2}
-        className="py-2 px-4 text-left font-bold text-gray-800 bg-gray-100 border border-black"
-      >
-        {title}
-      </th>
-    </tr>
-  );
-}
-
 export function SummarySection({ summaryData }: SummarySectionProps) {
   return (
-    <div className="space-y-6">
-      <h2 className="text-xl font-bold text-foreground">収支総括表</h2>
+    <div className="space-y-4">
+      <SectionHeading>収支総括表</SectionHeading>
 
-      <div className="bg-white border border-black overflow-hidden">
-        <div className="bg-gray-100 border-b border-black px-4 py-3">
-          <h3 className="text-lg font-semibold text-black">収支総括表 (SYUUSHI07_02)</h3>
-        </div>
-        <div className="p-4">
-          <table className="w-full border-collapse border border-black">
-            <tbody>
-              <SectionHeader title="【収支総括】" />
-              <SummaryRow label="収入総額" value={formatCurrency(summaryData.syunyuSgk)} />
-              <SummaryRow label="前年繰越額" value={formatCurrency(summaryData.zennenKksGk)} />
-              <SummaryRow label="本年収入額" value={formatCurrency(summaryData.honnenSyunyuGk)} />
-              <SummaryRow label="支出総額" value={formatCurrency(summaryData.sisyutuSgk)} />
-              <SummaryRow label="翌年繰越額" value={formatCurrency(summaryData.yokunenKksGk)} />
+      <SectionCard title="収支総括表" formId="SYUUSHI07_02">
+        <KeyValueTable>
+          <KeyValueGroupHeader title="【収支総括】" />
+          <KeyValueRow label="収入総額" value={formatCurrency(summaryData.syunyuSgk)} numeric />
+          <KeyValueRow label="前年繰越額" value={formatCurrency(summaryData.zennenKksGk)} numeric />
+          <KeyValueRow
+            label="本年収入額"
+            value={formatCurrency(summaryData.honnenSyunyuGk)}
+            numeric
+          />
+          <KeyValueRow label="支出総額" value={formatCurrency(summaryData.sisyutuSgk)} numeric />
+          <KeyValueRow
+            label="翌年繰越額"
+            value={formatCurrency(summaryData.yokunenKksGk)}
+            numeric
+          />
 
-              <SectionHeader title="【寄附の内訳】" />
-              <SummaryRow label="個人寄附" value={formatCurrency(summaryData.kojinKifuGk)} />
-              <SummaryRow
-                label="法人寄附"
-                value={formatNullableCurrency(summaryData.hojinKifuGk)}
-              />
-              <SummaryRow
-                label="政治団体寄附"
-                value={formatNullableCurrency(summaryData.seijiKifuGk)}
-              />
-              <SummaryRow label="寄附小計" value={formatCurrency(summaryData.kifuSkeiGk)} />
-              <SummaryRow label="寄附合計" value={formatCurrency(summaryData.kifuGkeiGk)} />
-            </tbody>
-          </table>
-        </div>
-      </div>
+          <KeyValueGroupHeader title="【寄附の内訳】" />
+          <KeyValueRow label="個人寄附" value={formatCurrency(summaryData.kojinKifuGk)} numeric />
+          <KeyValueRow
+            label="法人寄附"
+            value={formatNullableCurrency(summaryData.hojinKifuGk)}
+            numeric
+          />
+          <KeyValueRow
+            label="政治団体寄附"
+            value={formatNullableCurrency(summaryData.seijiKifuGk)}
+            numeric
+          />
+          <KeyValueRow label="寄附小計" value={formatCurrency(summaryData.kifuSkeiGk)} numeric />
+          <KeyValueRow label="寄附合計" value={formatCurrency(summaryData.kifuGkeiGk)} numeric />
+        </KeyValueTable>
+      </SectionCard>
     </div>
   );
 }


### PR DESCRIPTION
## 目的（Why）

admin リデザイン（土台 #1289 / ページヘッダー #1291）の一環として、報告書エクスポート画面だけが旧ダークテーマ前提の見た目（黒罫線グリッド、`bg-red-500/20` 等のパレット直書き）で残っており、他画面と統一感がない状態を解消するため。

## 変更内容

- **団体・年度の選択**: ネストしたカードを廃止し、ピル select（黒1.5px枠・13px）を並べたツールバーに。年は Poppins 表示
- **ダウンロードボタン**: teal 塗りピル + `DownloadSimple` アイコン、処理中は `CircleNotch` スピナー。結果通知はインラインの色付き div から `toast.success/error`（sonner）へ
- **タブ**: アクティブタブを teal-100 背景 + teal-deep 文字・枠で表示（`ExportReportPreview` のローカル上書き。共通化の判断は #1325 に切り出し）
- **データプレビュー**: 各セクションを白カード + 黒1px枠 + 角丸8px（`SectionCard` / `SectionWrapper`）に。明細テーブルは `ui/Table` の罫線ルール（ヘッダー下 黒1.5px、行罫線 `#E5E5E5`）をそのまま使い、セル単位の `border border-black` を除去
  - 金額: Poppins 右寄せ `font-semibold`（`AmountCell`）
  - 日付: `YYYY.MM.DD`（共通 `formatDate` を使用、各セクション内の `YYYY/M/D` 実装を削除）
  - 行番号: Poppins 12px `#666`
  - 団体基本情報 / 収支総括表は `KeyValueTable`（項目名 | 値）に統一
  - 空セクションは `opacity-50` ではなく見出しを `text-muted-foreground` に
- **XML プレビュー**: `bg-black/30` を `bg-background` + `border-border-soft` のコードブロックに。コピーボタンに `Copy` / `Check` アイコン
- **警告 / エラー**: プロフィール未登録の注意は teal-100 背景（`border-primary-active bg-accent text-accent-foreground`）、その他エラーは赤（`border-destructive bg-destructive-hover text-destructive`）
- 共通化のため `sections/` に `SectionCard` / `SectionHeading` / `KeyValueTable` / `ReportTableCells` / `ExpenseTable` を追加（経常経費・政治活動費で同一だった `ExpenseTable` を統合）。相対 import を `@/` 絶対パスに修正
- 旧テーマの Tailwind パレット直書き（gray / red / green / black）は export-report 配下から全て除去（grep で確認済み）

XML 生成ロジック・レポートデータ集計ロジック・ダウンロード API 呼び出しには変更なし。

Closes #1296

## ローカルCI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ 全て通過
- E2E: 未実行。export-report 画面には E2E テストがなく、認証・ルーティング・フォーム導線に変更がないため

## スコープアウトして起票した Issue

- #1325 design(admin): ui/tabs のアクティブタブ表示を teal 系に統一するか判断する（`loop:human`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - エクスポートレポートの収入・支出・プロフィール・概要表示を、統一されたカードや表形式で確認できるよう改善。
  - XMLプレビューのコピー操作で、コピー完了状態をアイコンで表示。
- **改善**
  - プロフィール未登録時に専用メッセージと登録ページへのリンクを表示。
  - ダウンロード結果をトースト通知で案内し、処理中はスピナーを表示。
  - レポート選択画面、空データ表示、タブ切り替えのレイアウトと視認性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->