### PR TITLE
feat(admin): ログイン・パスワード再設定・初期セットアップの公開画面をブランドに合わせる

### DIFF
--- a/admin/src/app/(public)/auth/reset-password/page.tsx
+++ b/admin/src/app/(public)/auth/reset-password/page.tsx
@@ -3,6 +3,7 @@ import { getCurrentUser } from "@/server/contexts/auth/presentation/loaders/load
 import { resetPassword } from "@/server/contexts/auth/presentation/actions/reset-password";
 import { redirect } from "next/navigation";
 import SetupForm from "@/client/components/auth/SetupForm";
+import { PublicAuthCard } from "@/client/components/auth/PublicAuthCard";
 
 export const dynamic = "force-dynamic";
 
@@ -14,18 +15,8 @@ export default async function ResetPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-foreground">
-            パスワードを変更
-          </h2>
-          <p className="mt-2 text-center text-sm text-muted-foreground">
-            新しいパスワードを設定してください。
-          </p>
-        </div>
-        <SetupForm userEmail={user.email} setupPasswordAction={resetPassword} />
-      </div>
-    </div>
+    <PublicAuthCard title="パスワードを変更" description="新しいパスワードを設定してください。">
+      <SetupForm userEmail={user.email} setupPasswordAction={resetPassword} />
+    </PublicAuthCard>
   );
 }

--- a/admin/src/app/(public)/auth/setup/page.tsx
+++ b/admin/src/app/(public)/auth/setup/page.tsx
@@ -3,6 +3,7 @@ import { getCurrentUser } from "@/server/contexts/auth/presentation/loaders/load
 import { setupPassword } from "@/server/contexts/auth/presentation/actions/setup-password";
 import { redirect } from "next/navigation";
 import SetupForm from "@/client/components/auth/SetupForm";
+import { PublicAuthCard } from "@/client/components/auth/PublicAuthCard";
 
 // 認証チェックでcookiesを使用するため動的レンダリングを強制
 export const dynamic = "force-dynamic";
@@ -25,19 +26,12 @@ export default async function SetupPage({ searchParams }: SetupPageProps) {
   if (fromInvite) {
     // This is an invited user who needs to set up their password
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-md w-full space-y-8">
-          <div>
-            <h2 className="mt-6 text-center text-3xl font-extrabold text-foreground">
-              アカウント設定
-            </h2>
-            <p className="mt-2 text-center text-sm text-muted-foreground">
-              「みらいまる見え政治資金」に招待されました。パスワードを設定して利用を開始してください。
-            </p>
-          </div>
-          <SetupForm userEmail={user.email} setupPasswordAction={setupPassword} />
-        </div>
-      </div>
+      <PublicAuthCard
+        title="アカウント設定"
+        description="「みらいまる見え政治資金」に招待されました。パスワードを設定して利用を開始してください。"
+      >
+        <SetupForm userEmail={user.email} setupPasswordAction={setupPassword} />
+      </PublicAuthCard>
     );
   }
 

--- a/admin/src/app/(public)/forgot-password/page.tsx
+++ b/admin/src/app/(public)/forgot-password/page.tsx
@@ -2,15 +2,9 @@ import "server-only";
 import Link from "next/link";
 import { requestPasswordReset } from "@/server/contexts/auth/presentation/actions/request-password-reset";
 import ForgotPasswordForm from "@/client/components/auth/ForgotPasswordForm";
+import { PublicAuthCard } from "@/client/components/auth/PublicAuthCard";
 import ToastNotifier from "@/client/components/auth/ToastNotifier";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardDescription,
-  Button,
-} from "@/client/components/ui";
+import { Button } from "@/client/components/ui";
 
 interface ForgotPasswordPageProps {
   searchParams: Promise<{ sent?: string }>;
@@ -22,29 +16,19 @@ export default async function ForgotPasswordPage({ searchParams }: ForgotPasswor
 
   if (sent) {
     return (
-      <div className="h-full flex items-center justify-center">
+      <>
         <ToastNotifier type="success" message="パスワードリセット用のメールを送信しました" />
-        <Card className="w-full max-w-md">
-          <CardHeader className="px-8 pt-8 pb-4">
-            <CardTitle className="text-2xl">メールを送信しました</CardTitle>
-            <CardDescription>
-              パスワードリセット用のリンクをメールで送信しました。
-              メールが届かない場合は、迷惑メールフォルダをご確認ください。
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="px-8 pb-8">
-            <Link href="/login">
-              <Button className="w-full">ログイン画面に戻る</Button>
-            </Link>
-          </CardContent>
-        </Card>
-      </div>
+        <PublicAuthCard
+          title="メールを送信しました"
+          description="パスワードリセット用のリンクをメールで送信しました。メールが届かない場合は、迷惑メールフォルダをご確認ください。"
+        >
+          <Button asChild className="w-full">
+            <Link href="/login">ログイン画面に戻る</Link>
+          </Button>
+        </PublicAuthCard>
+      </>
     );
   }
 
-  return (
-    <div className="h-full flex items-center justify-center">
-      <ForgotPasswordForm action={requestPasswordReset} />
-    </div>
-  );
+  return <ForgotPasswordForm action={requestPasswordReset} />;
 }

--- a/admin/src/app/(public)/layout.tsx
+++ b/admin/src/app/(public)/layout.tsx
@@ -1,5 +1,13 @@
 import "server-only";
 
+/**
+ * サイドバーなしの公開画面（ログイン・パスワード再設定・初期セットアップ）の共通レイアウト。
+ * 背景 #F8F8F8 の中央に白カード（PublicAuthCard）を置く。
+ */
 export default function PublicLayout({ children }: { children: React.ReactNode }) {
-  return <main className="h-screen bg-background">{children}</main>;
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-4 py-12">
+      {children}
+    </main>
+  );
 }

--- a/admin/src/app/(public)/login/InviteTokenHandler.tsx
+++ b/admin/src/app/(public)/login/InviteTokenHandler.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { ProcessingNotice } from "@/client/components/auth/ProcessingNotice";
 import { completeInviteSession } from "@/server/contexts/auth/presentation/actions/complete-invite-session";
 
 export default function InviteTokenHandler() {
@@ -38,9 +39,9 @@ export default function InviteTokenHandler() {
   if (!processing) return null;
 
   return (
-    <div className="bg-card rounded-xl p-4 mt-4">
-      <h2>Processing Invitation...</h2>
-      <p>Please wait while we set up your account.</p>
-    </div>
+    <ProcessingNotice
+      title="招待を処理しています..."
+      description="アカウントの準備をしています。しばらくお待ちください。"
+    />
   );
 }

--- a/admin/src/app/(public)/login/page.tsx
+++ b/admin/src/app/(public)/login/page.tsx
@@ -19,7 +19,7 @@ export default async function LoginPage({
   const { showPasswordLogin, showGoogleLogin } = await loadLoginProviders();
 
   return (
-    <div className="h-full flex items-center justify-center">
+    <>
       {error && <ToastNotifier type="error" message={error} />}
       <LoginForm
         action={loginWithPassword}
@@ -32,6 +32,6 @@ export default async function LoginPage({
       <InviteTokenHandler />
       <RecoveryTokenHandler />
       <RecoveryCodeHandler />
-    </div>
+    </>
   );
 }

--- a/admin/src/client/components/auth/ForgotPasswordForm.tsx
+++ b/admin/src/client/components/auth/ForgotPasswordForm.tsx
@@ -2,16 +2,8 @@
 import "client-only";
 import { useActionState } from "react";
 import Link from "next/link";
-import {
-  Button,
-  Input,
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardDescription,
-  Label,
-} from "@/client/components/ui";
+import { Button, Input, Label } from "@/client/components/ui";
+import { PublicAuthCard } from "@/client/components/auth/PublicAuthCard";
 
 interface ForgotPasswordFormProps {
   action: (formData: FormData) => Promise<void>;
@@ -24,29 +16,27 @@ export default function ForgotPasswordForm({ action }: ForgotPasswordFormProps) 
   }, null);
 
   return (
-    <Card className="w-full max-w-md">
-      <CardHeader className="px-8 pt-8 pb-4">
-        <CardTitle className="text-2xl">パスワードをリセット</CardTitle>
-        <CardDescription>
-          登録されているメールアドレスにリセット用のリンクを送信します。
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="px-8 pb-8">
-        <form action={formAction} className="grid gap-4">
-          <div className="space-y-3">
-            <Label htmlFor="email">Email</Label>
-            <Input id="email" name="email" type="email" required />
-          </div>
-          <Button type="submit" disabled={isPending} className="mt-4 w-full">
-            {isPending ? "送信中..." : "リセットメールを送信"}
-          </Button>
-          <div className="text-center mt-2">
-            <Link href="/login" className="text-sm text-muted-foreground hover:underline">
-              ログイン画面に戻る
-            </Link>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+    <PublicAuthCard
+      title="パスワードをリセット"
+      description="登録されているメールアドレスにリセット用のリンクを送信します。"
+    >
+      <form action={formAction} className="grid gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" name="email" type="email" autoComplete="email" required />
+        </div>
+        <Button type="submit" disabled={isPending} className="mt-2 w-full">
+          {isPending ? "送信中..." : "リセットメールを送信"}
+        </Button>
+        <div className="mt-2 text-center">
+          <Link
+            href="/login"
+            className="text-[13px] text-primary-active transition-colors duration-150 ease-out hover:text-primary-hover hover:underline"
+          >
+            ログイン画面に戻る
+          </Link>
+        </div>
+      </form>
+    </PublicAuthCard>
   );
 }

--- a/admin/src/client/components/auth/LoginForm.tsx
+++ b/admin/src/client/components/auth/LoginForm.tsx
@@ -2,15 +2,8 @@
 import "client-only";
 import { useState } from "react";
 import Link from "next/link";
-import {
-  Button,
-  Input,
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  Label,
-} from "@/client/components/ui";
+import { Button, Input, Label } from "@/client/components/ui";
+import { PublicAuthCard } from "@/client/components/auth/PublicAuthCard";
 
 interface LoginFormProps {
   action: (formData: FormData) => Promise<void>;
@@ -44,55 +37,60 @@ export default function LoginForm({
   };
 
   return (
-    <Card className="w-full max-w-md">
-      <CardHeader className="px-8 pt-8 pb-4">
-        <CardTitle className="text-2xl">ログイン</CardTitle>
-      </CardHeader>
-      <CardContent className="px-8 pb-8">
-        {showPasswordLogin && (
-          <form onSubmit={handleSubmit} className="grid gap-4">
-            <div className="space-y-3">
-              <Label htmlFor="email">Email</Label>
-              <Input id="email" name="email" type="email" required />
-            </div>
-            <div className="space-y-3">
-              <Label htmlFor="password">Password</Label>
-              <Input id="password" name="password" type="password" required />
-            </div>
-            {forgotPasswordHref && (
-              <div className="text-right">
-                <Link
-                  href={forgotPasswordHref}
-                  className="text-sm text-muted-foreground hover:underline"
-                >
-                  パスワードを忘れた場合
-                </Link>
-              </div>
-            )}
-            <Button type="submit" disabled={isLoading} className="mt-4 w-full">
-              {isLoading ? "ログイン中..." : "ログイン"}
-            </Button>
-          </form>
-        )}
-        {showPasswordLogin && showGoogleLogin && (
-          <div className="relative my-6">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-border" />
-            </div>
-            <div className="relative flex justify-center">
-              <span className="bg-card px-3 text-sm text-muted-foreground">または</span>
-            </div>
+    <PublicAuthCard title="ログイン">
+      {showPasswordLogin && (
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" name="email" type="email" autoComplete="email" required />
           </div>
-        )}
-        {showGoogleLogin && googleAction && (
-          <form action={googleAction}>
-            <Button type="submit" variant="outline" className="w-full">
-              Google でログイン
-            </Button>
-          </form>
-        )}
-        {error && <div className="text-muted-foreground mt-4">{error}</div>}
-      </CardContent>
-    </Card>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+            />
+          </div>
+          {forgotPasswordHref && (
+            <div className="text-right">
+              <Link
+                href={forgotPasswordHref}
+                className="text-[13px] text-primary-active transition-colors duration-150 ease-out hover:text-primary-hover hover:underline"
+              >
+                パスワードを忘れた場合
+              </Link>
+            </div>
+          )}
+          <Button type="submit" disabled={isLoading} className="mt-2 w-full">
+            {isLoading ? "ログイン中..." : "ログイン"}
+          </Button>
+        </form>
+      )}
+      {showPasswordLogin && showGoogleLogin && (
+        <div className="relative my-6">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-border-soft" />
+          </div>
+          <div className="relative flex justify-center">
+            <span className="bg-card px-3 text-xs text-subtle-foreground">または</span>
+          </div>
+        </div>
+      )}
+      {showGoogleLogin && googleAction && (
+        <form action={googleAction}>
+          <Button type="submit" variant="outline" className="w-full">
+            Google でログイン
+          </Button>
+        </form>
+      )}
+      {error && (
+        <p role="alert" className="mt-4 text-center text-sm text-destructive">
+          {error}
+        </p>
+      )}
+    </PublicAuthCard>
   );
 }

--- a/admin/src/client/components/auth/ProcessingNotice.tsx
+++ b/admin/src/client/components/auth/ProcessingNotice.tsx
@@ -1,0 +1,25 @@
+import { CircleNotch } from "@phosphor-icons/react/dist/ssr";
+
+interface ProcessingNoticeProps {
+  title: string;
+  description: string;
+}
+
+/**
+ * ログイン画面で招待・パスワード再設定トークンを処理中に、カードの下に出す通知。
+ * 白カード（黒1px枠・角丸8px）+ teal スピナー。
+ */
+export function ProcessingNotice({ title, description }: ProcessingNoticeProps) {
+  return (
+    <div
+      role="status"
+      className="flex w-full max-w-md items-center gap-3 rounded-lg border border-border bg-card px-6 py-4"
+    >
+      <CircleNotch size={20} className="shrink-0 animate-spin text-primary" aria-hidden="true" />
+      <div>
+        <p className="text-[13px] font-bold text-foreground">{title}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/admin/src/client/components/auth/PublicAuthCard.tsx
+++ b/admin/src/client/components/auth/PublicAuthCard.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { Card, CardContent, CardHeader } from "@/client/components/ui";
+import { BrandWordmark } from "@/client/components/layout/BrandWordmark";
+import { cn } from "@/client/lib";
+
+interface PublicAuthCardProps {
+  /** カードの見出し。例: "ログイン" */
+  title: string;
+  /** 見出し下の補足文 */
+  description?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * サイドバーなしの公開画面（ログイン・パスワード再設定・初期セットアップ）で使う白カード。
+ * 黒1px枠・角丸8pxのカード上部に文字ヘッダー（BrandWordmark）を置き、
+ * その下に teal-soft 下線付きの見出しと本文を並べる。
+ */
+export function PublicAuthCard({ title, description, children, className }: PublicAuthCardProps) {
+  return (
+    <Card className={cn("w-full max-w-md gap-0 py-8", className)}>
+      <CardHeader className="gap-0 px-8">
+        <BrandWordmark />
+        <h1 className="mt-6 text-[22px] font-bold leading-[1.4] tracking-[0.06em] text-foreground">
+          <span className="underline decoration-teal-soft decoration-[3px] underline-offset-[6px]">
+            {title}
+          </span>
+        </h1>
+        {description && (
+          <p className="mt-3 text-[13px] leading-relaxed text-muted-foreground">{description}</p>
+        )}
+      </CardHeader>
+      <CardContent className="mt-6 px-8">{children}</CardContent>
+    </Card>
+  );
+}

--- a/admin/src/client/components/auth/RecoveryCodeHandler.tsx
+++ b/admin/src/client/components/auth/RecoveryCodeHandler.tsx
@@ -2,6 +2,7 @@
 import "client-only";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { ProcessingNotice } from "@/client/components/auth/ProcessingNotice";
 import { exchangeCodeForSession } from "@/server/contexts/auth/presentation/actions/exchange-code-for-session";
 
 export default function RecoveryCodeHandler() {
@@ -36,9 +37,6 @@ export default function RecoveryCodeHandler() {
   if (!processing) return null;
 
   return (
-    <div className="bg-card rounded-xl p-4 mt-4">
-      <h2>パスワードリセット処理中...</h2>
-      <p>しばらくお待ちください。</p>
-    </div>
+    <ProcessingNotice title="パスワードリセット処理中..." description="しばらくお待ちください。" />
   );
 }

--- a/admin/src/client/components/auth/RecoveryTokenHandler.tsx
+++ b/admin/src/client/components/auth/RecoveryTokenHandler.tsx
@@ -1,7 +1,7 @@
 "use client";
 import "client-only";
 import { useEffect, useState } from "react";
-import { Card, CardHeader, CardTitle, CardDescription } from "@/client/components/ui";
+import { ProcessingNotice } from "@/client/components/auth/ProcessingNotice";
 import { completeRecoverySession } from "@/server/contexts/auth/presentation/actions/complete-recovery-session";
 
 export default function RecoveryTokenHandler() {
@@ -43,11 +43,6 @@ export default function RecoveryTokenHandler() {
   if (!processing) return null;
 
   return (
-    <Card className="mt-4">
-      <CardHeader>
-        <CardTitle>パスワードリセット処理中...</CardTitle>
-        <CardDescription>しばらくお待ちください。</CardDescription>
-      </CardHeader>
-    </Card>
+    <ProcessingNotice title="パスワードリセット処理中..." description="しばらくお待ちください。" />
   );
 }

--- a/admin/src/client/components/auth/SetupForm.tsx
+++ b/admin/src/client/components/auth/SetupForm.tsx
@@ -2,16 +2,7 @@
 import "client-only";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import {
-  Button,
-  Input,
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardDescription,
-  Label,
-} from "@/client/components/ui";
+import { Button, Input, Label } from "@/client/components/ui";
 
 interface SetupFormProps {
   userEmail: string;
@@ -20,6 +11,10 @@ interface SetupFormProps {
   ) => Promise<{ ok: boolean; error?: string; redirectTo?: string }>;
 }
 
+/**
+ * パスワード設定フォーム（初期セットアップ・パスワード再設定で共用）。
+ * カード・見出しは呼び出し側の PublicAuthCard が持ち、ここはフォーム本体のみを描く。
+ */
 export default function SetupForm({ userEmail, setupPasswordAction }: SetupFormProps) {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -63,47 +58,45 @@ export default function SetupForm({ userEmail, setupPasswordAction }: SetupFormP
   };
 
   return (
-    <Card className="w-full max-w-md">
-      <CardHeader>
-        <CardTitle className="text-2xl">アカウント設定</CardTitle>
-        <CardDescription>
-          アカウント設定中: <strong>{userEmail}</strong>
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <form className="space-y-6" onSubmit={handleSubmit}>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="password">パスワード</Label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                placeholder="パスワードを入力"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword">パスワード（確認）</Label>
-              <Input
-                id="confirmPassword"
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                required
-                placeholder="パスワードを再入力"
-              />
-            </div>
-          </div>
+    <form className="grid gap-4" onSubmit={handleSubmit}>
+      <p className="text-[13px] text-muted-foreground">
+        対象アカウント:{" "}
+        <span className="font-latin font-semibold text-foreground">{userEmail}</span>
+      </p>
+      <div className="space-y-2">
+        <Label htmlFor="password">パスワード</Label>
+        <Input
+          id="password"
+          type="password"
+          autoComplete="new-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          placeholder="パスワードを入力"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="confirmPassword">パスワード（確認）</Label>
+        <Input
+          id="confirmPassword"
+          type="password"
+          autoComplete="new-password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          placeholder="パスワードを再入力"
+        />
+      </div>
 
-          {error && <div className="text-destructive text-sm text-center">{error}</div>}
+      {error && (
+        <p role="alert" className="text-center text-sm text-destructive">
+          {error}
+        </p>
+      )}
 
-          <Button type="submit" disabled={isLoading} className="w-full">
-            {isLoading ? "設定中..." : "設定完了"}
-          </Button>
-        </form>
-      </CardContent>
-    </Card>
+      <Button type="submit" disabled={isLoading} className="mt-2 w-full">
+        {isLoading ? "設定中..." : "設定完了"}
+      </Button>
+    </form>
   );
 }

--- a/admin/src/client/components/layout/BrandWordmark.tsx
+++ b/admin/src/client/components/layout/BrandWordmark.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/client/lib";
+
+interface BrandWordmarkProps {
+  className?: string;
+}
+
+/**
+ * 「みらいまる見え政治資金」+「ADMIN CONSOLE」の文字ヘッダー。
+ * ロゴ画像は置かず文字のみで表現する（ブランドガイド上、ロゴの改変・多用を避けるため）。
+ * サイドバーと公開画面（ログイン等）のカードで同じ表現を共有する。
+ * 値はデザインハンドオフ（docs/reference/design_handoff_admin_redesign/README.md「1. サイドバー」）が正。
+ */
+export function BrandWordmark({ className }: BrandWordmarkProps) {
+  return (
+    <div className={cn("min-w-0", className)}>
+      <div className="whitespace-nowrap text-[13px] font-bold tracking-[0.06em] text-foreground">
+        みらいまる見え政治資金
+      </div>
+      <div className="mt-0.5 font-latin text-[10px] font-semibold tracking-[0.14em] text-primary-hover">
+        ADMIN CONSOLE
+      </div>
+    </div>
+  );
+}

--- a/admin/src/client/components/layout/Sidebar.tsx
+++ b/admin/src/client/components/layout/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   Users,
 } from "@phosphor-icons/react/dist/ssr";
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@/client/components/ui";
+import { BrandWordmark } from "@/client/components/layout/BrandWordmark";
 import { cn } from "@/client/lib/index";
 import {
   getVisibleNavSections,
@@ -100,16 +101,7 @@ export default function Sidebar({
           collapsed ? "justify-center" : "justify-between",
         )}
       >
-        {!collapsed && (
-          <div className="min-w-0">
-            <div className="whitespace-nowrap text-[13px] font-bold tracking-[0.06em] text-foreground">
-              みらいまる見え政治資金
-            </div>
-            <div className="mt-0.5 font-latin text-[10px] font-semibold tracking-[0.14em] text-primary-hover">
-              ADMIN CONSOLE
-            </div>
-          </div>
-        )}
+        {!collapsed && <BrandWordmark />}
         <button
           type="button"
           onClick={onToggleCollapsed}


### PR DESCRIPTION
## 目的（Why）

admin リデザイン（#1289）の一環として、サイドバーなしの公開 4 画面（ログイン / パスワードを忘れた / パスワード再設定 / 初期セットアップ）が旧テーマの見た目のまま残っており、認証後の画面とブランドの一貫性が取れていない状態を解消する。

## 変更内容

- **`PublicAuthCard`（新規）**: 背景 `#F8F8F8` の中央に置く白カード（黒 1px 枠・角丸 8px）。上部に文字ヘッダー、その下に teal-soft 下線付きの見出しと補足文を配置。4 画面すべてがこのカードを使う
- **`BrandWordmark`（新規）**: 「みらいまる見え政治資金」(13px/700) + 「ADMIN CONSOLE」(Poppins 10px/600/letter-spacing 0.14em/`#089781`) の文字ヘッダーを `Sidebar` から切り出し、サイドバーと公開画面で共有（ロゴ画像は置かない）
- **`ProcessingNotice`（新規）**: 招待・リカバリトークン処理中の表示（`InviteTokenHandler` / `RecoveryTokenHandler` / `RecoveryCodeHandler`）を 1 つに集約。黒枠白カード + teal スピナー
- **`LoginForm` / `ForgotPasswordForm` / `SetupForm`**: 自前の `Card` 装飾を外し、入力は既存 `ui/input` のピル、送信は既存 `ui/button` の teal 塗りピル、補助リンクは `text-primary-active`（`#0F8472`）、エラーは `text-destructive`（`#E63946`）に統一。`autoComplete` を付与
- **`SetupForm`**: 見出し・説明をページ側（`PublicAuthCard`）に寄せ、これまで外側 h2 とカード内タイトルで二重になっていた見出しを 1 つに整理。対象メールアドレスはフォーム冒頭に Poppins で表示
- **`(public)/layout.tsx`**: `min-h-screen` の中央寄せレイアウトに変更し、各ページの個別ラッパーを削除
- **`forgot-password` 送信完了画面**: `Link` の中に `Button` を入れる構造を `Button asChild` に修正

認証フロー・バリデーション・ラベル文言（E2E が `getByLabel("Email"/"Password")` で参照）は変更していません。

## ローカルCI

- `pnpm verify`: ✅ test（admin 908 / webapp 135）・typecheck・lint・knip・depcruise すべて通過
- admin E2E（`playwright test --workers=1`）: ✅ 42 passed

## スコープアウトして起票した Issue

なし

Closes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)