### PR TITLE
feat(admin): CSV アップロード画面と取引取り込みプレビュー画面をリデザインする

### DIFF
--- a/admin/src/app/(auth)/upload-csv/page.tsx
+++ b/admin/src/app/(auth)/upload-csv/page.tsx
@@ -12,13 +12,11 @@ export default async function UploadCsvPage() {
   return (
     <div>
       <PageHeader label="Data Import" title="CSVアップロード" />
-      <div className="bg-card rounded-xl p-4">
-        <CsvUploadClient
-          organizations={organizations}
-          uploadAction={uploadCsv}
-          previewAction={previewCsv}
-        />
-      </div>
+      <CsvUploadClient
+        organizations={organizations}
+        uploadAction={uploadCsv}
+        previewAction={previewCsv}
+      />
     </div>
   );
 }

--- a/admin/src/client/components/csv-import/CsvPreview.tsx
+++ b/admin/src/client/components/csv-import/CsvPreview.tsx
@@ -1,245 +1,143 @@
 "use client";
 import "client-only";
 
-import { useEffect, useRef, useState } from "react";
+import { useState, type ReactNode } from "react";
 import type { PreviewMfCsvResult } from "@/server/contexts/data-import/presentation/types";
 import type { PreviewTransaction } from "@/server/contexts/data-import/domain/models/preview-transaction";
-import type { PreviewCsvRequest } from "@/server/contexts/data-import/presentation/actions/preview-csv";
-import TransactionRow from "./TransactionRow";
+import { Button, Table, TableBody, TableHead, TableHeader, TableRow } from "@/client/components/ui";
+import { cn, resolvePreviewStatusBadge } from "@/client/lib";
 import { ClientPagination } from "@/client/components/ui/ClientPagination";
-import StatisticsTable from "./StatisticsTable";
-import { Button } from "@/client/components/ui";
+import TransactionRow from "@/client/components/csv-import/TransactionRow";
+import StatisticsTable from "@/client/components/csv-import/StatisticsTable";
+
+type PreviewStatus = PreviewTransaction["status"];
+type PreviewTab = "all" | PreviewStatus;
+
+const TABS: PreviewTab[] = ["all", "insert", "update", "invalid", "skip"];
+const STATUS_ORDER: Record<PreviewStatus, number> = { insert: 1, update: 2, invalid: 3, skip: 4 };
+const PER_PAGE = 10;
 
 interface CsvPreviewProps {
-  file: File | null;
-  politicalOrganizationId: string;
-  onPreviewComplete?: (result: PreviewMfCsvResult) => void;
-  previewAction: (data: PreviewCsvRequest) => Promise<PreviewMfCsvResult>;
+  result: PreviewMfCsvResult;
+  /** カード右下に置くアクション（保存ボタンなど） */
+  footer?: ReactNode;
 }
 
-export default function CsvPreview({
-  file,
-  politicalOrganizationId,
-  onPreviewComplete,
-  previewAction,
-}: CsvPreviewProps) {
-  const [previewResult, setPreviewResult] = useState<PreviewMfCsvResult | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+function tabLabel(tab: PreviewTab): string {
+  return tab === "all" ? "全件" : resolvePreviewStatusBadge(tab).label;
+}
+
+/**
+ * CSV 取り込みプレビュー（白カード・テーブル罫線ルールは取引一覧と同一）。
+ * プレビューの取得は親（CsvUploadClient）が行い、本コンポーネントは表示のみを担う。
+ */
+export default function CsvPreview({ result, footer }: CsvPreviewProps) {
   const [currentPage, setCurrentPage] = useState(1);
-  const [activeTab, setActiveTab] = useState<"all" | "insert" | "update" | "invalid" | "skip">(
-    "all",
+  const [activeTab, setActiveTab] = useState<PreviewTab>("all");
+
+  const sortedTransactions = [...result.transactions].sort(
+    (a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status],
   );
-  const perPage = 10;
-  const onPreviewCompleteRef = useRef(onPreviewComplete);
-
-  // Always update the ref to the latest callback
-  onPreviewCompleteRef.current = onPreviewComplete;
-
-  useEffect(() => {
-    if (!file || !politicalOrganizationId) {
-      setPreviewResult(null);
-      setError(null);
-      setCurrentPage(1);
-      setActiveTab("all");
-      return;
-    }
-
-    const previewFile = async () => {
-      setLoading(true);
-      setError(null);
-      setCurrentPage(1);
-      setActiveTab("all");
-
-      try {
-        const result = await previewAction({
-          file,
-          politicalOrganizationId,
-        });
-
-        setPreviewResult(result);
-        onPreviewCompleteRef.current?.(result);
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : "CSVのプレビューに失敗しました";
-        setError(errorMessage);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    previewFile();
-  }, [file, politicalOrganizationId, previewAction]);
+  const filteredTransactions =
+    activeTab === "all"
+      ? sortedTransactions
+      : sortedTransactions.filter((transaction) => transaction.status === activeTab);
+  const totalPages = Math.ceil(filteredTransactions.length / PER_PAGE);
+  const startIndex = (currentPage - 1) * PER_PAGE;
+  const currentRecords = filteredTransactions.slice(startIndex, startIndex + PER_PAGE);
 
   const handlePageChange = (page: number) => {
-    if (!previewResult) return;
-    const filteredTransactions = getFilteredTransactions();
-    const totalPages = Math.ceil(filteredTransactions.length / perPage);
     if (page >= 1 && page <= totalPages) {
       setCurrentPage(page);
     }
   };
 
-  const handleTabChange = (tab: "all" | "insert" | "update" | "invalid" | "skip") => {
+  const handleTabChange = (tab: PreviewTab) => {
     setActiveTab(tab);
     setCurrentPage(1);
   };
 
-  const getFilteredTransactions = (): PreviewTransaction[] => {
-    if (!previewResult) return [];
+  const tabCount = (tab: PreviewTab) =>
+    tab === "all"
+      ? result.summary.totalCount
+      : result.transactions.filter((t) => t.status === tab).length;
 
-    const sortedTransactions = getSortedTransactions();
-
-    if (activeTab === "all") {
-      return sortedTransactions;
-    }
-
-    return sortedTransactions.filter((transaction) => transaction.status === activeTab);
-  };
-
-  const getSortedTransactions = (): PreviewTransaction[] => {
-    if (!previewResult) return [];
-
-    const statusOrder = { insert: 1, update: 2, invalid: 3, skip: 4 };
-    return [...previewResult.transactions].sort((a, b) => {
-      const aOrder = statusOrder[a.status] || 4;
-      const bOrder = statusOrder[b.status] || 4;
-      return aOrder - bOrder;
-    });
-  };
-
-  const getCurrentPageRecords = (): PreviewTransaction[] => {
-    const filteredTransactions = getFilteredTransactions();
-    const startIndex = (currentPage - 1) * perPage;
-    const endIndex = startIndex + perPage;
-    return filteredTransactions.slice(startIndex, endIndex);
-  };
-
-  const totalPages = previewResult ? Math.ceil(getFilteredTransactions().length / perPage) : 0;
-
-  if (!file) return null;
-
-  if (loading) {
+  if (result.transactions.length === 0) {
     return (
-      <div className="bg-card rounded-xl p-4 mt-4">
-        <h3 className="text-lg font-medium text-foreground mb-2">CSVプレビュー</h3>
-        <p className="text-muted-foreground">ファイルを処理中...</p>
+      <div className="rounded-lg border border-border bg-card p-6">
+        <h2 className="text-base font-bold text-foreground">取り込みプレビュー</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          取り込み対象の取引が見つかりませんでした。
+        </p>
       </div>
     );
   }
-
-  if (error) {
-    return (
-      <div className="bg-card rounded-xl p-4 mt-4">
-        <h3 className="text-lg font-medium text-foreground mb-2">CSVプレビュー</h3>
-        <div className="text-red-500 mt-2">エラー: {error}</div>
-      </div>
-    );
-  }
-
-  if (!previewResult || previewResult.transactions.length === 0) return null;
-
-  const currentRecords = getCurrentPageRecords();
-  const filteredTransactions = getFilteredTransactions();
-
-  const getTabCount = (tab: "all" | "insert" | "update" | "invalid" | "skip") => {
-    if (tab === "all") return previewResult.summary.totalCount;
-    return previewResult.transactions.filter((t) => t.status === tab).length;
-  };
-
-  const getTabLabel = (tab: "insert" | "update" | "invalid" | "skip") => {
-    switch (tab) {
-      case "insert":
-        return "挿入";
-      case "update":
-        return "更新";
-      case "invalid":
-        return "無効";
-      case "skip":
-        return "スキップ";
-    }
-  };
 
   return (
-    <div className="bg-card rounded-xl p-4 mt-4">
-      <h3 className="text-lg font-medium text-foreground mb-4">CSVプレビュー</h3>
+    <div className="rounded-lg border border-border bg-card p-6">
+      <h2 className="text-base font-bold text-foreground">取り込みプレビュー</h2>
 
-      <StatisticsTable statistics={previewResult.statistics} />
-
-      {/* タブフィルター */}
-      <div className="mb-4">
-        <div className="flex gap-2">
-          {[
-            { key: "all" as const, label: "全件", color: "text-foreground" },
-            { key: "insert" as const, label: "挿入", color: "text-green-500" },
-            { key: "update" as const, label: "更新", color: "text-primary-active" },
-            { key: "invalid" as const, label: "無効", color: "text-red-500" },
-            {
-              key: "skip" as const,
-              label: "スキップ",
-              color: "text-yellow-500",
-            },
-          ].map(({ key, label, color }) => (
-            <Button
-              type="button"
-              key={key}
-              variant={activeTab === key ? "outline" : "ghost"}
-              size="sm"
-              onClick={() => handleTabChange(key)}
-              className={activeTab === key ? `${color} border-white bg-white/10` : ""}
-            >
-              {label} ({getTabCount(key)})
-            </Button>
-          ))}
-        </div>
+      <div className="mt-4">
+        <StatisticsTable statistics={result.statistics} />
       </div>
 
-      <div className="mb-4">
-        <p className="text-muted-foreground">
-          {activeTab === "all" ? "全" : getTabLabel(activeTab)} {filteredTransactions.length} 件中{" "}
-          {filteredTransactions.length > 0 ? (currentPage - 1) * perPage + 1 : 0} -{" "}
-          {Math.min(currentPage * perPage, filteredTransactions.length)} 件を表示
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2" role="tablist" aria-label="取り込み状態で絞り込み">
+          {TABS.map((tab) => {
+            const isActive = activeTab === tab;
+            return (
+              <Button
+                type="button"
+                key={tab}
+                role="tab"
+                aria-selected={isActive}
+                variant="outline"
+                size="sm"
+                onClick={() => handleTabChange(tab)}
+                className={cn(
+                  "text-xs",
+                  isActive && "border-primary-active bg-accent text-primary-active hover:bg-accent",
+                )}
+              >
+                {tabLabel(tab)}
+                <span className="font-latin">({tabCount(tab)})</span>
+              </Button>
+            );
+          })}
+        </div>
+        <p className="text-[13px] text-muted-foreground">
+          {activeTab === "all" ? "全" : tabLabel(activeTab)} {filteredTransactions.length} 件中{" "}
+          {filteredTransactions.length > 0 ? startIndex + 1 : 0} -{" "}
+          {Math.min(startIndex + PER_PAGE, filteredTransactions.length)} 件を表示
         </p>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse">
-          <thead>
-            <tr className="border-b border-border">
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">状態</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">取引日</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                借方勘定科目
-              </th>
-              <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
-                借方金額
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                貸方勘定科目
-              </th>
-              <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">
-                貸方金額
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">種別</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                カテゴリ
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+      <div className="mt-4">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead>状態</TableHead>
+              <TableHead>取引日</TableHead>
+              <TableHead>借方勘定科目</TableHead>
+              <TableHead className="text-right">借方金額</TableHead>
+              <TableHead>貸方勘定科目</TableHead>
+              <TableHead className="text-right">貸方金額</TableHead>
+              <TableHead>種別</TableHead>
+              <TableHead>カテゴリ</TableHead>
+              <TableHead>
+                摘要{" "}
+                <span className="font-normal text-muted-foreground">
+                  ※サービスには表示されません
+                </span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {currentRecords.map((record, index) => (
-              <TransactionRow
-                key={`${(currentPage - 1) * perPage + index}-${record.transaction_date}-${record.debit_account}-${record.credit_account}-${record.debit_amount || 0}`}
-                record={record}
-                index={index}
-                currentPage={currentPage}
-                perPage={perPage}
-              />
+              <TransactionRow key={`${record.hash}-${startIndex + index}`} record={record} />
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
 
       <ClientPagination
@@ -247,6 +145,8 @@ export default function CsvPreview({
         totalPages={totalPages}
         onPageChange={handlePageChange}
       />
+
+      {footer && <div className="mt-6 flex justify-end">{footer}</div>}
     </div>
   );
 }

--- a/admin/src/client/components/csv-import/StatisticsTable.tsx
+++ b/admin/src/client/components/csv-import/StatisticsTable.tsx
@@ -2,143 +2,90 @@
 import "client-only";
 
 import type { PreviewMfCsvResult } from "@/server/contexts/data-import/presentation/types";
+import type { PreviewTransaction } from "@/server/contexts/data-import/domain/models/preview-transaction";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/client/components/ui";
+import { cn, formatCurrency, resolvePreviewStatusBadge } from "@/client/lib";
+
+type PreviewStatistics = PreviewMfCsvResult["statistics"];
+type StatisticsRow = PreviewStatistics[PreviewTransaction["status"]];
+type StatisticsColumn = keyof StatisticsRow;
 
 interface StatisticsTableProps {
-  statistics: PreviewMfCsvResult["statistics"];
+  statistics: PreviewStatistics;
 }
 
+const ROWS: PreviewTransaction["status"][] = ["insert", "update", "invalid", "skip"];
+const COLUMNS: { key: StatisticsColumn; label: string }[] = [
+  { key: "income", label: "収入" },
+  { key: "expense", label: "支出" },
+  { key: "offset_income", label: "収入（相殺）" },
+  { key: "offset_expense", label: "支出（相殺）" },
+];
+
+/** 取り込み状態 × 取引種別ごとの件数・金額サマリ。 */
 export default function StatisticsTable({ statistics }: StatisticsTableProps) {
-  const formatAmount = (amount: number) => {
-    return new Intl.NumberFormat("ja-JP", {
-      style: "currency",
-      currency: "JPY",
-    }).format(amount);
-  };
-
-  const formatCell = (count: number, amount: number) => {
-    if (count === 0) return "–";
-    return `${formatAmount(amount)} (${count}件)`;
-  };
-
   return (
-    <div className="mb-4">
-      <h4 className="text-md font-medium text-foreground mb-3">取引種別別統計</h4>
-      <div>
-        <table className="border-collapse border border-border rounded-lg overflow-hidden">
-          <thead>
-            <tr className="bg-input">
-              <th className="border border-border px-4 py-2 text-left text-xs font-semibold text-foreground">
-                状態
-              </th>
-              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-foreground">
-                収入
-              </th>
-              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-foreground">
-                支出
-              </th>
-              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-foreground">
-                収入（相殺）
-              </th>
-              <th className="border border-border px-4 py-2 text-center text-xs font-semibold text-foreground">
-                支出（相殺）
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="border border-border px-4 py-2 text-xs text-green-500 font-medium">
-                挿入
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(statistics.insert.income.count, statistics.insert.income.amount)}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(statistics.insert.expense.count, statistics.insert.expense.amount)}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(
-                  statistics.insert.offset_income.count,
-                  statistics.insert.offset_income.amount,
-                )}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(
-                  statistics.insert.offset_expense.count,
-                  statistics.insert.offset_expense.amount,
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td className="border border-border px-4 py-2 text-xs text-primary-active font-medium">
-                更新
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(statistics.update.income.count, statistics.update.income.amount)}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(statistics.update.expense.count, statistics.update.expense.amount)}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(
-                  statistics.update.offset_income.count,
-                  statistics.update.offset_income.amount,
-                )}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(
-                  statistics.update.offset_expense.count,
-                  statistics.update.offset_expense.amount,
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td className="border border-border px-4 py-2 text-xs text-red-500 font-medium">
-                無効
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(statistics.invalid.income.count, statistics.invalid.income.amount)}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(statistics.invalid.expense.count, statistics.invalid.expense.amount)}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(
-                  statistics.invalid.offset_income.count,
-                  statistics.invalid.offset_income.amount,
-                )}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(
-                  statistics.invalid.offset_expense.count,
-                  statistics.invalid.offset_expense.amount,
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td className="border border-border px-4 py-2 text-xs text-yellow-500 font-medium">
-                スキップ
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(statistics.skip.income.count, statistics.skip.income.amount)}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(statistics.skip.expense.count, statistics.skip.expense.amount)}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(
-                  statistics.skip.offset_income.count,
-                  statistics.skip.offset_income.amount,
-                )}
-              </td>
-              <td className="border border-border px-4 py-2 text-xs text-foreground text-center">
-                {formatCell(
-                  statistics.skip.offset_expense.count,
-                  statistics.skip.offset_expense.amount,
-                )}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+    <div>
+      <h3 className="text-[13px] font-bold text-foreground">取引種別別統計</h3>
+      <div className="mt-2 max-w-[880px]">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="w-[120px]">状態</TableHead>
+              {COLUMNS.map((column) => (
+                <TableHead key={column.key} className="text-right">
+                  {column.label}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {ROWS.map((status) => {
+              const badge = resolvePreviewStatusBadge(status);
+              return (
+                <TableRow key={status}>
+                  <TableCell>
+                    <span
+                      className={cn(
+                        "inline-block rounded-full border-[1.5px] px-3 py-[3px] text-[11px] font-bold leading-none tracking-[0.04em] whitespace-nowrap",
+                        badge.className,
+                      )}
+                    >
+                      {badge.label}
+                    </span>
+                  </TableCell>
+                  {COLUMNS.map((column) => {
+                    const { count, amount } = statistics[status][column.key];
+                    return (
+                      <TableCell
+                        key={column.key}
+                        className="font-latin text-right text-[13px] text-foreground"
+                      >
+                        {count === 0 ? (
+                          <span className="text-subtle-foreground">–</span>
+                        ) : (
+                          <>
+                            <span className="font-semibold">{formatCurrency(amount)}</span>
+                            <span className="ml-1.5 text-xs text-muted-foreground">
+                              ({count}件)
+                            </span>
+                          </>
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
       </div>
     </div>
   );

--- a/admin/src/client/components/csv-import/TransactionRow.tsx
+++ b/admin/src/client/components/csv-import/TransactionRow.tsx
@@ -2,147 +2,79 @@
 import "client-only";
 
 import type { PreviewTransaction } from "@/server/contexts/data-import/domain/models/preview-transaction";
+import { TableCell, TableRow } from "@/client/components/ui";
+import { cn, formatAmount, formatDate, resolvePreviewStatusBadge } from "@/client/lib";
 import { CategoryPill } from "@/client/components/transactions/CategoryPill";
+import { TransactionTypeBadge } from "@/client/components/transactions/TransactionTypeBadge";
 
 interface TransactionRowProps {
   record: PreviewTransaction;
-  index: number;
-  currentPage: number;
-  perPage: number;
 }
 
-function getTypeLabel(type: string): string {
-  switch (type) {
-    case "income":
-      return "現金収入";
-    case "expense":
-      return "現金支出";
-    case "non_cash_journal":
-      return "非現金仕訳";
-    case "offset_income":
-      return "相殺収入";
-    case "offset_expense":
-      return "相殺支出";
-    case "invalid":
-      return "無効";
-    default:
-      return "不明";
-  }
-}
+/** 取り込みプレビューの 1 行。種別バッジ・カテゴリピル・日付・金額の見た目は取引一覧と同一。 */
+export default function TransactionRow({ record }: TransactionRowProps) {
+  const status = resolvePreviewStatusBadge(record.status);
 
-function getTypeBadgeClass(type: string): string {
-  switch (type) {
-    case "income":
-    case "offset_income":
-      return "bg-green-600";
-    case "expense":
-    case "offset_expense":
-      return "bg-red-600";
-    case "non_cash_journal":
-      return "bg-gray-500";
-    case "invalid":
-      return "bg-orange-600";
-    default:
-      return "bg-gray-600";
-  }
-}
-
-function getStatusBgClass(status: PreviewTransaction["status"]) {
-  switch (status) {
-    case "insert":
-      return "bg-green-600";
-    case "update":
-      return "bg-gray-500";
-    case "invalid":
-      return "bg-red-600";
-    case "skip":
-      return "bg-yellow-600";
-    default:
-      return "bg-gray-600";
-  }
-}
-
-function getStatusText(status: PreviewTransaction["status"]) {
-  switch (status) {
-    case "insert":
-      return "挿入";
-    case "update":
-      return "更新";
-    case "invalid":
-      return "無効";
-    case "skip":
-      return "スキップ";
-    default:
-      return "不明";
-  }
-}
-
-export default function TransactionRow({
-  record,
-  index,
-  currentPage,
-  perPage,
-}: TransactionRowProps) {
   return (
-    <tr
-      key={`${(currentPage - 1) * perPage + index}-${record.transaction_date}-${record.debit_account}-${record.credit_account}-${record.debit_amount || 0}`}
-      className="border-b border-border"
-    >
-      <td className="px-2 py-3 text-sm">
+    <TableRow>
+      <TableCell className="whitespace-normal align-top">
         <span
-          className={`px-2 py-1 rounded text-white text-xs font-semibold ${getStatusBgClass(record.status)}`}
+          className={cn(
+            "inline-block rounded-full border-[1.5px] px-3 py-[3px] text-[11px] font-bold leading-none tracking-[0.04em] whitespace-nowrap",
+            status.className,
+          )}
         >
-          {getStatusText(record.status)}
+          {status.label}
         </span>
         {record.errors.length > 0 && (
-          <div
-            className={`text-xs mt-1 ${
-              record.status === "skip" ? "text-yellow-500" : "text-red-500"
-            }`}
-          >
+          <div className={cn("mt-1.5 max-w-[240px] text-xs", status.messageClassName)}>
             {record.errors.map((error, errorIndex) => (
               <div key={`error-${errorIndex}-${error}`}>{error}</div>
             ))}
           </div>
         )}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
-        {new Date(record.transaction_date).toLocaleDateString("ja-JP")}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
+      </TableCell>
+      <TableCell className="font-latin text-[13px]">
+        {formatDate(record.transaction_date)}
+      </TableCell>
+      <TableCell className="text-[13px]">
         {record.debit_account}
         {record.debit_sub_account && (
-          <div className="text-muted-foreground text-xs">{record.debit_sub_account}</div>
+          <div className="text-xs text-muted-foreground">{record.debit_sub_account}</div>
         )}
-      </td>
-      <td className="px-2 py-3 text-sm text-right text-foreground">
-        {record.debit_amount ? `¥${record.debit_amount.toLocaleString()}` : "-"}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
+      </TableCell>
+      <TableCell className="font-latin text-right text-[13px] font-semibold">
+        {record.debit_amount ? formatAmount(record.debit_amount) : "-"}
+      </TableCell>
+      <TableCell className="text-[13px]">
         {record.credit_account}
         {record.credit_sub_account && (
-          <div className="text-muted-foreground text-xs">{record.credit_sub_account}</div>
+          <div className="text-xs text-muted-foreground">{record.credit_sub_account}</div>
         )}
-      </td>
-      <td className="px-2 py-3 text-sm text-right text-foreground">
-        {record.credit_amount ? `¥${record.credit_amount.toLocaleString()}` : "-"}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
-        <span
-          className={`px-2 py-1 rounded text-white text-xs font-medium ${getTypeBadgeClass(record.transaction_type || "unknown")}`}
-        >
-          {getTypeLabel(record.transaction_type || "unknown")}
-        </span>
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
+      </TableCell>
+      <TableCell className="font-latin text-right text-[13px] font-semibold">
+        {record.credit_amount ? formatAmount(record.credit_amount) : "-"}
+      </TableCell>
+      <TableCell>
+        {record.transaction_type ? (
+          <TransactionTypeBadge type={record.transaction_type} />
+        ) : (
+          <span className="text-xs text-muted-foreground">-</span>
+        )}
+      </TableCell>
+      <TableCell>
         <CategoryPill transaction={record} />
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
-        {record.description || "-"}
+      </TableCell>
+      <TableCell className="max-w-[200px] text-xs text-muted-foreground">
+        <div className="truncate" title={record.description || undefined}>
+          {record.description || "-"}
+        </div>
         {record.label && (
-          <div className="text-muted-foreground text-xs mt-1">ラベル: {record.label}</div>
+          <div className="mt-1 truncate" title={record.label}>
+            ラベル: {record.label}
+          </div>
         )}
-      </td>
-    </tr>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/admin/src/client/components/csv-upload/CsvDropzone.tsx
+++ b/admin/src/client/components/csv-upload/CsvDropzone.tsx
@@ -1,0 +1,103 @@
+"use client";
+import "client-only";
+
+import { useId, useRef, useState, type DragEvent } from "react";
+import { UploadSimple } from "@phosphor-icons/react/dist/ssr";
+import { Button } from "@/client/components/ui";
+import { cn } from "@/client/lib";
+
+interface CsvDropzoneProps {
+  file: File | null;
+  onFileChange: (file: File | null) => void;
+  disabled?: boolean;
+  /** 対応形式・上限サイズなどの注記（Poppins 11px） */
+  note: string;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * CSV ファイルのドロップゾーン（ハンドオフ「5. CSVアップロード」）。
+ * ドラッグ＆ドロップと「ファイルを選択」ボタンの両方で同じ hidden input に載せる。
+ */
+export function CsvDropzone({ file, onFileChange, disabled = false, note }: CsvDropzoneProps) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (disabled) return;
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    if (disabled) return;
+    const dropped = e.dataTransfer.files?.[0] ?? null;
+    if (!dropped) return;
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+    onFileChange(dropped);
+  };
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: ドロップ先の領域。操作は内側の button / input が担う
+    <div
+      data-slot="csv-dropzone"
+      data-dragging={isDragging || undefined}
+      onDragOver={handleDragOver}
+      onDragEnter={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className={cn(
+        "flex flex-col items-center rounded-lg border-[1.5px] border-dashed border-primary bg-accent px-6 py-12 text-center transition-colors duration-150 ease-out",
+        isDragging && "border-primary-active bg-teal-soft/30",
+        disabled && "opacity-100 border-disabled-border bg-secondary",
+      )}
+    >
+      <UploadSimple aria-hidden className="size-9 text-primary-active" />
+      <p className="mt-2.5 text-sm font-bold text-foreground">CSVファイルをドラッグ＆ドロップ</p>
+      <p className="mt-1 text-xs text-muted-foreground">または</p>
+      <Button
+        type="button"
+        variant="outline"
+        className="mt-3.5 text-[13px]"
+        disabled={disabled}
+        onClick={() => inputRef.current?.click()}
+      >
+        ファイルを選択
+      </Button>
+      <input
+        ref={inputRef}
+        id={inputId}
+        type="file"
+        accept=".csv,text/csv"
+        aria-label="CSVファイル"
+        className="sr-only"
+        disabled={disabled}
+        onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+      />
+      <p className="font-latin mt-3.5 text-[11px] text-subtle-foreground">{note}</p>
+      {file && (
+        <p className="mt-3 text-[13px] text-foreground" data-slot="csv-dropzone-file">
+          <span className="font-bold">{file.name}</span>
+          <span className="font-latin ml-2 text-xs text-muted-foreground">
+            {formatFileSize(file.size)}
+          </span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/admin/src/client/components/csv-upload/CsvUploadClient.tsx
+++ b/admin/src/client/components/csv-upload/CsvUploadClient.tsx
@@ -1,10 +1,13 @@
 "use client";
 import "client-only";
 
-import { useId, useState, useEffect } from "react";
+import { useEffect, useId, useState } from "react";
+import { ArrowRight, CircleNotch } from "@phosphor-icons/react/dist/ssr";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
-import { Button, Input, Label } from "@/client/components/ui";
+import { Button, Label, NativeSelect } from "@/client/components/ui";
+import { cn } from "@/client/lib";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
+import { CsvDropzone } from "@/client/components/csv-upload/CsvDropzone";
 import CsvPreview from "@/client/components/csv-import/CsvPreview";
 import type { PreviewMfCsvResult } from "@/server/contexts/data-import/presentation/types";
 import type {
@@ -19,17 +22,26 @@ interface CsvUploadClientProps {
   previewAction: (data: PreviewCsvRequest) => Promise<PreviewMfCsvResult>;
 }
 
+/** 現在サポートしているデータソース。取り込みロジックは MF クラウド会計のみ */
+const DATA_SOURCES = [{ value: "mf", label: "MFクラウド会計" }] as const;
+
+/** 対応形式と上限サイズ（上限は next.config.ts の serverActions.bodySizeLimit に合わせる） */
+const FILE_NOTE = "UTF-8 / Shift-JIS ・ 最大 100MB";
+
 export default function CsvUploadClient({
   organizations,
   uploadAction,
   previewAction,
 }: CsvUploadClientProps) {
-  const csvFileInputId = useId();
+  const dataSourceSelectId = useId();
   const [file, setFile] = useState<File | null>(null);
   const [politicalOrganizationId, setPoliticalOrganizationId] = useState<string>("");
+  const [dataSource, setDataSource] = useState<string>(DATA_SOURCES[0].value);
   const [message, setMessage] = useState<string>("");
   const [errors, setErrors] = useState<string[]>([]);
   const [hasError, setHasError] = useState<boolean>(false);
+  const [previewing, setPreviewing] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [previewResult, setPreviewResult] = useState<PreviewMfCsvResult | null>(null);
 
@@ -40,25 +52,53 @@ export default function CsvUploadClient({
     }
   }, [organizations, politicalOrganizationId]);
 
-  const handlePreviewComplete = (result: PreviewMfCsvResult) => {
-    setPreviewResult(result);
+  // ファイルや政治団体が変わったら、古いプレビューは破棄する
+  const resetPreview = () => {
+    setPreviewResult(null);
+    setPreviewError(null);
   };
 
-  async function onSubmit(e: React.FormEvent) {
+  const handleFileChange = (next: File | null) => {
+    setFile(next);
+    setMessage("");
+    setErrors([]);
+    setHasError(false);
+    resetPreview();
+  };
+
+  const handleOrganizationChange = (next: string) => {
+    setPoliticalOrganizationId(next);
+    resetPreview();
+  };
+
+  async function onPreview(e: React.FormEvent) {
     e.preventDefault();
     if (!file || !politicalOrganizationId) return;
+    setPreviewing(true);
+    setPreviewError(null);
+    setMessage("");
+    setErrors([]);
+    setHasError(false);
+
+    try {
+      const result = await previewAction({ file, politicalOrganizationId });
+      setPreviewResult(result);
+    } catch (err) {
+      setPreviewResult(null);
+      setPreviewError(err instanceof Error ? err.message : "CSVのプレビューに失敗しました");
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  async function onSave() {
+    if (!file || !politicalOrganizationId || !previewResult) return;
     setUploading(true);
     setMessage("");
     setErrors([]);
     setHasError(false);
 
     try {
-      if (!previewResult) {
-        setMessage("Preview data not available");
-        setHasError(true);
-        return;
-      }
-
       const validTransactions = previewResult.transactions.filter(
         (t) => t.status === "insert" || t.status === "update",
       );
@@ -86,14 +126,8 @@ export default function CsvUploadClient({
         `Successfully processed ${result.processedCount} records and saved ${result.savedCount} transactions`;
 
       setMessage(`"${uploadedFileName}" の取り込み結果: ${serverMessage}`);
-
       setFile(null);
-      setPreviewResult(null);
-
-      const fileInput = document.getElementById(csvFileInputId) as HTMLInputElement;
-      if (fileInput) {
-        fileInput.value = "";
-      }
+      resetPreview();
     } catch (err) {
       console.error("Upload error:", err);
       setMessage(`Error: ${err instanceof Error ? err.message : String(err)}`);
@@ -107,72 +141,134 @@ export default function CsvUploadClient({
     }
   }
 
+  const canPreview = Boolean(file) && Boolean(politicalOrganizationId) && !previewing && !uploading;
+  const canSave =
+    Boolean(previewResult) &&
+    (previewResult?.summary.insertCount ?? 0) + (previewResult?.summary.updateCount ?? 0) > 0 &&
+    !uploading &&
+    !previewing;
+
   return (
-    <form onSubmit={onSubmit} className="space-y-3">
-      <PoliticalOrganizationSelect
-        organizations={organizations}
-        value={politicalOrganizationId}
-        onValueChange={setPoliticalOrganizationId}
-        required
-      />
-      <div>
-        <Label htmlFor={csvFileInputId}>CSV File:</Label>
-        <Input
-          id={csvFileInputId}
-          className="h-10 border-0 bg-transparent shadow-none file:mr-4 file:h-full file:px-6 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 file:cursor-pointer"
-          type="file"
-          accept=".csv,text/csv"
-          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-          required
-        />
-      </div>
-
-      <CsvPreview
-        file={file}
-        politicalOrganizationId={politicalOrganizationId}
-        onPreviewComplete={handlePreviewComplete}
-        previewAction={previewAction}
-      />
-
-      {(() => {
-        const isDisabled =
-          !file ||
-          !politicalOrganizationId ||
-          !previewResult ||
-          previewResult.summary.insertCount + previewResult.summary.updateCount === 0 ||
-          uploading;
-
-        return (
-          <Button disabled={isDisabled} type="submit">
-            {uploading ? "Processing…" : "このデータを保存する"}
-          </Button>
-        );
-      })()}
-
-      {message && (
-        <div
-          className={`mt-3 p-3 rounded border ${
-            hasError
-              ? "text-red-500 bg-red-900/20 border-red-900/30"
-              : "text-green-500 bg-green-900/20 border-green-900/30"
-          }`}
-        >
-          {message}
+    <div className="space-y-6">
+      <form
+        onSubmit={onPreview}
+        className="max-w-[720px] rounded-lg border border-border bg-card p-7"
+      >
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs font-bold">
+              政治団体 <span className="text-destructive">*</span>
+            </Label>
+            <PoliticalOrganizationSelect
+              organizations={organizations}
+              value={politicalOrganizationId}
+              onValueChange={handleOrganizationChange}
+              required
+              hideLabel
+              className="w-full"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={dataSourceSelectId} className="text-xs font-bold">
+              データソース <span className="text-destructive">*</span>
+            </Label>
+            <NativeSelect
+              id={dataSourceSelectId}
+              value={dataSource}
+              onChange={(e) => setDataSource(e.target.value)}
+              required
+              wrapperClassName="w-full"
+              className="border-[1.5px] text-[13px]"
+            >
+              {DATA_SOURCES.map((source) => (
+                <option key={source.value} value={source.value}>
+                  {source.label}
+                </option>
+              ))}
+            </NativeSelect>
+          </div>
         </div>
-      )}
 
-      {errors.length > 0 && (
-        <div className="mt-3 p-3 rounded border text-red-500 bg-red-900/20 border-red-900/30">
-          <div className="font-semibold mb-2">エラー詳細:</div>
-          {errors.map((error) => (
-            <div key={error} className="mb-2 last:mb-0">
-              <pre className="whitespace-pre-wrap text-xs font-mono bg-red-950/30 p-2 rounded overflow-x-auto">
+        <div className="mt-6">
+          <CsvDropzone
+            file={file}
+            onFileChange={handleFileChange}
+            disabled={previewing || uploading}
+            note={FILE_NOTE}
+          />
+        </div>
+
+        {previewError && (
+          <div
+            role="alert"
+            className="mt-4 rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive"
+          >
+            プレビューに失敗しました: {previewError}
+          </div>
+        )}
+
+        {message && (
+          <div
+            role="status"
+            className={cn(
+              "mt-4 rounded-lg border p-3 text-sm",
+              hasError
+                ? "border-destructive bg-destructive-hover text-destructive"
+                : "border-primary-active bg-accent text-primary-active",
+            )}
+          >
+            {message}
+          </div>
+        )}
+
+        {errors.length > 0 && (
+          <div className="mt-3 rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive">
+            <div className="mb-2 font-bold">エラー詳細:</div>
+            {errors.map((error) => (
+              <pre
+                key={error}
+                className="mb-2 overflow-x-auto rounded border border-border-soft bg-card p-2 font-mono text-xs whitespace-pre-wrap text-foreground last:mb-0"
+              >
                 {error}
               </pre>
-            </div>
-          ))}
+            ))}
+          </div>
+        )}
+
+        <div className="mt-6 flex justify-end">
+          <Button type="submit" disabled={!canPreview} className="tracking-[0.06em]">
+            {previewing ? (
+              <>
+                <CircleNotch aria-hidden className="animate-spin" />
+                プレビュー中…
+              </>
+            ) : (
+              <>
+                プレビューを表示
+                <ArrowRight aria-hidden />
+              </>
+            )}
+          </Button>
         </div>
+      </form>
+
+      {previewResult && (
+        <CsvPreview
+          result={previewResult}
+          footer={
+            <Button type="button" disabled={!canSave} onClick={onSave}>
+              {uploading ? (
+                <>
+                  <CircleNotch aria-hidden className="animate-spin" />
+                  保存中…
+                </>
+              ) : (
+                "このデータを保存する"
+              )}
+            </Button>
+          }
+        />
       )}
-    </form>
+    </div>
   );
 }

--- a/admin/src/client/components/political-organizations/PoliticalOrganizationSelect.tsx
+++ b/admin/src/client/components/political-organizations/PoliticalOrganizationSelect.tsx
@@ -1,4 +1,5 @@
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
+import { cn } from "@/client/lib";
 import {
   Label,
   Select,
@@ -15,6 +16,8 @@ interface PoliticalOrganizationSelectProps {
   required?: boolean;
   /** ラベルを描画せず aria-label で代替する（ツールバー等でインライン配置する場合） */
   hideLabel?: boolean;
+  /** SelectTrigger に追加するクラス（幅や枠線の太さを配置先に合わせる場合） */
+  className?: string;
 }
 
 export function PoliticalOrganizationSelect({
@@ -23,6 +26,7 @@ export function PoliticalOrganizationSelect({
   onValueChange,
   required,
   hideLabel = false,
+  className,
 }: PoliticalOrganizationSelectProps) {
   const options = organizations.map((org) => ({
     value: org.id,
@@ -35,7 +39,7 @@ export function PoliticalOrganizationSelect({
       <Select value={value} onValueChange={onValueChange} required={required}>
         <SelectTrigger
           aria-label={hideLabel ? "政治団体" : undefined}
-          className={hideLabel ? "border-[1.5px] text-[13px]" : undefined}
+          className={cn(hideLabel && "border-[1.5px] text-[13px]", className)}
         >
           <SelectValue placeholder="政治団体を選択してください" />
         </SelectTrigger>

--- a/admin/src/client/lib/index.ts
+++ b/admin/src/client/lib/index.ts
@@ -5,3 +5,4 @@ export type { CategoryPillSource } from "./category-pill";
 export { resolveUserRoleBadge } from "./user-role-badge";
 export { resolveDonorTypeBadge } from "./donor-type-badge";
 export { resolveAssignmentStatusBadge } from "./assignment-status-badge";
+export { resolvePreviewStatusBadge } from "./preview-status-badge";

--- a/admin/src/client/lib/preview-status-badge.ts
+++ b/admin/src/client/lib/preview-status-badge.ts
@@ -1,0 +1,43 @@
+import type { PreviewTransaction } from "@/server/contexts/data-import/domain/models/preview-transaction";
+
+type PreviewStatus = PreviewTransaction["status"];
+
+interface PreviewStatusBadge {
+  label: string;
+  /** ピルバッジの色クラス。挿入・更新 = teal 系、スキップ = グレー系、無効 = 赤系（ブランド外の色は使わない） */
+  className: string;
+  /** 行に付随するエラー/理由文の文字色クラス */
+  messageClassName: string;
+}
+
+const PREVIEW_STATUS_BADGES: Record<PreviewStatus, PreviewStatusBadge> = {
+  insert: {
+    label: "挿入",
+    className: "border-primary-active text-primary-active bg-accent",
+    messageClassName: "text-muted-foreground",
+  },
+  update: {
+    label: "更新",
+    className: "border-primary-active text-primary-active bg-card",
+    messageClassName: "text-muted-foreground",
+  },
+  skip: {
+    label: "スキップ",
+    className: "border-subtle-foreground text-muted-foreground bg-secondary",
+    messageClassName: "text-muted-foreground",
+  },
+  invalid: {
+    label: "無効",
+    className: "border-destructive text-destructive bg-card",
+    messageClassName: "text-destructive",
+  },
+};
+
+/**
+ * CSV 取り込みプレビューの行状態（挿入 / 更新 / スキップ / 無効）を
+ * バッジ表示用のラベルと色クラスに解決する。
+ * 語彙は teal（取り込まれる）/ グレー（変更なし）/ 赤（取り込めない）の 3 系統に限定する。
+ */
+export function resolvePreviewStatusBadge(status: PreviewStatus): PreviewStatusBadge {
+  return PREVIEW_STATUS_BADGES[status];
+}

--- a/admin/tests/client/lib/preview-status-badge.test.ts
+++ b/admin/tests/client/lib/preview-status-badge.test.ts
@@ -1,0 +1,40 @@
+import { resolvePreviewStatusBadge } from "@/client/lib/preview-status-badge";
+
+describe("resolvePreviewStatusBadge", () => {
+  it("挿入は teal 塗り（accent 背景・teal-deep 文字）になる", () => {
+    const badge = resolvePreviewStatusBadge("insert");
+    expect(badge.label).toBe("挿入");
+    expect(badge.className).toContain("bg-accent");
+    expect(badge.className).toContain("text-primary-active");
+  });
+
+  it("更新は teal 枠の白地になる", () => {
+    const badge = resolvePreviewStatusBadge("update");
+    expect(badge.label).toBe("更新");
+    expect(badge.className).toContain("border-primary-active");
+    expect(badge.className).toContain("bg-card");
+  });
+
+  it("スキップはグレー系（secondary 背景・muted 文字）になる", () => {
+    const badge = resolvePreviewStatusBadge("skip");
+    expect(badge.label).toBe("スキップ");
+    expect(badge.className).toContain("bg-secondary");
+    expect(badge.messageClassName).toBe("text-muted-foreground");
+  });
+
+  it("無効は赤枠・赤文字になり、理由文も赤になる", () => {
+    const badge = resolvePreviewStatusBadge("invalid");
+    expect(badge.label).toBe("無効");
+    expect(badge.className).toContain("border-destructive");
+    expect(badge.messageClassName).toBe("text-destructive");
+  });
+
+  it("旧テーマの Tailwind パレット直書きを含まない", () => {
+    for (const status of ["insert", "update", "skip", "invalid"] as const) {
+      const badge = resolvePreviewStatusBadge(status);
+      expect(`${badge.className} ${badge.messageClassName}`).not.toMatch(
+        /(red|green|blue|yellow|purple|orange|gray|slate|amber)-\d{3}/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## 目的（Why）

admin リデザインの一環として、CSV アップロード画面と取引取り込みプレビュー画面がまだ旧テーマ（ダーク前提の Tailwind パレット直書き・ネイティブ file input）のまま残っており、他の画面と見た目が食い違っている状態を解消するため。
正はハンドオフ `docs/reference/design_handoff_admin_redesign/README.md` の「5. CSVアップロード」節。

## 変更内容

- **CSV アップロード画面**（`CsvUploadClient`）
  - max-width 720px の白カード（黒1px枠・角丸8px・padding 28px）
  - 政治団体 / データソースの 2 select（ラベル 12px/700 + 赤 `*`、黒1.5px枠のピル select）。データソースは現状 MF クラウド会計のみ（表示用で取り込みロジックは変更なし）
  - 新規 `CsvDropzone`: `1.5px dashed` teal・`bg-accent`・padding `48px 24px` 中央寄せ、`UploadSimple` 36px、「CSVファイルをドラッグ＆ドロップ」14px/700、「ファイルを選択」黒枠白ピル、注記「UTF-8 / Shift-JIS ・ 最大 100MB」（上限は `serverActions.bodySizeLimit` に合わせた）。ドラッグ＆ドロップとファイル選択の両方に対応
  - 右下に「プレビューを表示」teal 塗りピル + `ArrowRight`。クリックでプレビューを取得する（従来はファイル選択と同時に自動取得していたが、モックのボタンに合わせて明示操作にした。取得処理そのものは同じ server action）
  - 結果・エラー表示を teal / 赤の語彙に置き換え
- **取り込みプレビュー**（`CsvPreview` / `TransactionRow` / `StatisticsTable`）
  - 白カード + `ui/table` の罫線ルール（ヘッダー下 黒1.5px、行罫線 `#E5E5E5`）
  - 種別バッジは `TransactionTypeBadge`、カテゴリピルは `CategoryPill` を共用（取引一覧と同一）。日付は `formatDate`（`YYYY.MM.DD`）、金額は Poppins 右寄せ
  - 取り込み状態（挿入 / 更新 / スキップ / 無効）を `resolvePreviewStatusBadge` に集約し、teal / グレー / 赤の 3 語彙に統一。旧テーマの `bg-green-600` 等の直書きを全廃
  - プレビュー取得を親（`CsvUploadClient`）に移し、`CsvPreview` は表示専用に整理（ref/effect のコールバック受け渡しを削除）
- `PoliticalOrganizationSelect` に trigger 用の `className` を追加（幅・枠線を配置先に合わせるため）

Closes #1298

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ 通過
- admin E2E（`playwright test --workers=1`）: 42 件中 41 件成功。唯一の失敗は `report-profile.spec.ts` の年度切り替え（既知の flaky #1307、本 PR の変更範囲外）で、単独再実行では通過
- 実ブラウザでのスモーク確認: ファイル選択 → 「プレビューを表示」→ 55 件のプレビュー表示・タブ絞り込み・「このデータを保存する」活性化まで動作を確認

## スコープアウトして起票した Issue

- #1328 refactor(admin): ClientPagination をハンドオフのピル仕様に揃える（プレビュー下部の共通ページネーションが旧語彙のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - CSVアップロードに、ファイル選択・プレビュー・保存の2段階フローを追加しました。
  - ドラッグ＆ドロップ対応のファイル選択エリアを追加しました。
  - プレビュー結果に、追加・更新・スキップ・エラーの状態を分かりやすく表示します。
  - 保存可能な取引がない場合は保存操作を無効化します。
- **改善**
  - CSVプレビューと取引一覧の表示を統一し、金額や日付を見やすく整形しました。
  - 空のプレビューや処理中、エラー発生時の表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->