### PR TITLE
refactor(admin): ローダーの unstable_cache を除去し保存アクションと整合させる

### DIFF
--- a/admin/src/server/contexts/auth/presentation/loaders/load-all-users.ts
+++ b/admin/src/server/contexts/auth/presentation/loaders/load-all-users.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { redirect } from "next/navigation";
 import { GetAllUsersUsecase } from "@/server/contexts/auth/application/usecases/get-all-users-usecase";
 import { SupabaseAuthProvider } from "@/server/contexts/auth/infrastructure/supabase/supabase-auth-provider";
@@ -9,23 +8,9 @@ import { PrismaUserRepository } from "@/server/contexts/shared/infrastructure/re
 import type { User } from "@/server/contexts/shared/domain/repositories/user-repository.interface";
 import { AuthError } from "@/server/contexts/auth/domain/errors/auth-error";
 
-const CACHE_REVALIDATE_SECONDS = 60;
-
-/**
- * ユーザー一覧を取得する内部関数（キャッシュ対象）
- */
-const fetchAllUsers = unstable_cache(
-  async (): Promise<User[]> => {
-    const userRepository = new PrismaUserRepository(prisma);
-    return await userRepository.findAll();
-  },
-  ["all-users"],
-  { revalidate: CACHE_REVALIDATE_SECONDS, tags: ["users"] },
-);
-
 /**
  * 全ユーザー一覧を取得するローダー（admin権限必須）
- * 認可チェック後にキャッシュされたユーザー一覧を返す
+ * 認可チェック後にユーザー一覧を返す
  */
 export async function loadAllUsers(): Promise<User[]> {
   const authProvider = new SupabaseAuthProvider();
@@ -33,10 +18,7 @@ export async function loadAllUsers(): Promise<User[]> {
   const usecase = new GetAllUsersUsecase(authProvider, userRepository);
 
   try {
-    // 認可チェックのみ実行（キャッシュなし）
-    await usecase.checkPermission();
-    // 認可が通った場合のみ、キャッシュされたデータを返す
-    return await fetchAllUsers();
+    return await usecase.execute();
   } catch (e) {
     if (e instanceof AuthError) {
       if (e.code === "AUTH_FAILED" || e.code === "INSUFFICIENT_PERMISSION") {

--- a/admin/src/server/contexts/report/presentation/loaders/counterpart-detail-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/counterpart-detail-loader.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaReportTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository";
 import {
@@ -9,8 +8,6 @@ import {
   type GetCounterpartTransactionsResult,
 } from "@/server/contexts/report/application/usecases/get-counterpart-transactions-usecase";
 
-const CACHE_REVALIDATE_SECONDS = 60;
-
 type LoadCounterpartTransactionsInput = GetCounterpartTransactionsInput;
 
 type LoadCounterpartTransactionsResult = GetCounterpartTransactionsResult;
@@ -18,29 +15,7 @@ type LoadCounterpartTransactionsResult = GetCounterpartTransactionsResult;
 export async function loadCounterpartTransactionsData(
   input: LoadCounterpartTransactionsInput,
 ): Promise<LoadCounterpartTransactionsResult> {
-  const page = input.page ?? 1;
-  const perPage = input.perPage ?? 50;
-
-  const cacheKey = [
-    "counterpart-transactions",
-    input.counterpartId,
-    input.politicalOrganizationId ?? "",
-    String(input.financialYear ?? ""),
-    String(page),
-    String(perPage),
-    input.sortField ?? "transactionDate",
-    input.sortOrder ?? "desc",
-  ];
-
-  const cachedLoader = unstable_cache(
-    async (): Promise<LoadCounterpartTransactionsResult> => {
-      const repository = new PrismaReportTransactionRepository(prisma);
-      const usecase = new GetCounterpartTransactionsUsecase(repository);
-      return usecase.execute(input);
-    },
-    cacheKey,
-    { revalidate: CACHE_REVALIDATE_SECONDS },
-  );
-
-  return cachedLoader();
+  const repository = new PrismaReportTransactionRepository(prisma);
+  const usecase = new GetCounterpartTransactionsUsecase(repository);
+  return usecase.execute(input);
 }

--- a/admin/src/server/contexts/report/presentation/loaders/counterparts-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/counterparts-loader.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
 import {
@@ -12,8 +11,6 @@ import type {
   CounterpartWithUsage,
   Counterpart,
 } from "@/server/contexts/report/domain/models/counterpart";
-
-const CACHE_REVALIDATE_SECONDS = 60;
 
 interface LoadCounterpartsInput {
   searchQuery?: string;
@@ -34,32 +31,23 @@ export async function loadCounterpartsData(
   const page = input.page ?? 1;
   const perPage = input.perPage ?? 50;
   const searchQuery = input.searchQuery ?? "";
+  const offset = (page - 1) * perPage;
 
-  const cachedLoader = unstable_cache(
-    async (searchQuery: string, page: number, perPage: number): Promise<LoadCounterpartsResult> => {
-      const offset = (page - 1) * perPage;
+  const repository = new PrismaCounterpartRepository(prisma);
+  const usecase = new GetCounterpartsUsecase(repository);
 
-      const repository = new PrismaCounterpartRepository(prisma);
-      const usecase = new GetCounterpartsUsecase(repository);
+  const result = await usecase.execute({
+    searchQuery: searchQuery || undefined,
+    limit: perPage,
+    offset,
+  });
 
-      const result = await usecase.execute({
-        searchQuery: searchQuery || undefined,
-        limit: perPage,
-        offset,
-      });
-
-      return {
-        counterparts: result.counterparts,
-        total: result.total,
-        page,
-        perPage,
-      };
-    },
-    ["counterparts-data", searchQuery, String(page), String(perPage)],
-    { revalidate: CACHE_REVALIDATE_SECONDS },
-  );
-
-  return cachedLoader(searchQuery, page, perPage);
+  return {
+    counterparts: result.counterparts,
+    total: result.total,
+    page,
+    perPage,
+  };
 }
 
 interface LoadCounterpartDetailPageResult {
@@ -71,29 +59,13 @@ interface LoadCounterpartDetailPageResult {
 export async function loadCounterpartDetailPageData(
   id: string,
 ): Promise<LoadCounterpartDetailPageResult> {
-  const cachedLoader = unstable_cache(
-    async (id: string): Promise<LoadCounterpartDetailPageResult> => {
-      const repository = new PrismaCounterpartRepository(prisma);
-      const usecase = new GetCounterpartDetailUsecase(repository);
-      return usecase.execute(id);
-    },
-    ["counterpart-detail-page-data", id],
-    { revalidate: CACHE_REVALIDATE_SECONDS },
-  );
-
-  return cachedLoader(id);
+  const repository = new PrismaCounterpartRepository(prisma);
+  const usecase = new GetCounterpartDetailUsecase(repository);
+  return usecase.execute(id);
 }
 
 export async function loadAllCounterpartsData(): Promise<Counterpart[]> {
-  const cachedLoader = unstable_cache(
-    async (): Promise<Counterpart[]> => {
-      const repository = new PrismaCounterpartRepository(prisma);
-      const usecase = new GetAllCounterpartsUsecase(repository);
-      return usecase.execute();
-    },
-    ["all-counterparts-data"],
-    { revalidate: CACHE_REVALIDATE_SECONDS },
-  );
-
-  return cachedLoader();
+  const repository = new PrismaCounterpartRepository(prisma);
+  const usecase = new GetAllCounterpartsUsecase(repository);
+  return usecase.execute();
 }

--- a/admin/src/server/contexts/report/presentation/loaders/donors-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/donors-loader.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-donor.repository";
 import { GetDonorsUsecase } from "@/server/contexts/report/application/usecases/manage-donor-usecase";
@@ -9,8 +8,6 @@ import type {
   DonorWithUsage,
   DonorType,
 } from "@/server/contexts/report/domain/models/donor";
-
-const CACHE_REVALIDATE_SECONDS = 60;
 
 interface LoadDonorsInput {
   searchQuery?: string;
@@ -30,51 +27,27 @@ export async function loadDonorsData(input: LoadDonorsInput = {}): Promise<LoadD
   const page = input.page ?? 1;
   const perPage = input.perPage ?? 50;
   const searchQuery = input.searchQuery ?? "";
-  const donorType = input.donorType;
+  const offset = (page - 1) * perPage;
 
-  const cachedLoader = unstable_cache(
-    async (
-      searchQuery: string,
-      donorType: DonorType | undefined,
-      page: number,
-      perPage: number,
-    ): Promise<LoadDonorsResult> => {
-      const offset = (page - 1) * perPage;
+  const repository = new PrismaDonorRepository(prisma);
+  const usecase = new GetDonorsUsecase(repository);
 
-      const repository = new PrismaDonorRepository(prisma);
-      const usecase = new GetDonorsUsecase(repository);
+  const result = await usecase.execute({
+    searchQuery: searchQuery || undefined,
+    donorType: input.donorType,
+    limit: perPage,
+    offset,
+  });
 
-      const result = await usecase.execute({
-        searchQuery: searchQuery || undefined,
-        donorType,
-        limit: perPage,
-        offset,
-      });
-
-      return {
-        donors: result.donors,
-        total: result.total,
-        page,
-        perPage,
-      };
-    },
-    ["donors-data", searchQuery, donorType ?? "", String(page), String(perPage)],
-    { revalidate: CACHE_REVALIDATE_SECONDS },
-  );
-
-  return cachedLoader(searchQuery, donorType, page, perPage);
+  return {
+    donors: result.donors,
+    total: result.total,
+    page,
+    perPage,
+  };
 }
 
 export async function loadAllDonorsData(): Promise<Donor[]> {
-  const cachedLoader = unstable_cache(
-    async (): Promise<Donor[]> => {
-      const repository = new PrismaDonorRepository(prisma);
-      const donors = await repository.findAll({ limit: 1000 });
-      return donors;
-    },
-    ["all-donors-data"],
-    { revalidate: CACHE_REVALIDATE_SECONDS },
-  );
-
-  return cachedLoader();
+  const repository = new PrismaDonorRepository(prisma);
+  return repository.findAll({ limit: 1000 });
 }

--- a/admin/src/server/contexts/report/presentation/loaders/organization-profile-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/organization-profile-loader.ts
@@ -1,26 +1,19 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaOrganizationReportProfileRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-organization-report-profile.repository";
 import { GetOrganizationProfileUsecase } from "@/server/contexts/report/application/usecases/get-organization-profile-usecase";
 import type { OrganizationReportProfile } from "@/server/contexts/report/domain/models/organization-report-profile";
 
-const CACHE_REVALIDATE_SECONDS = 60;
+export async function loadOrganizationProfileData(
+  politicalOrganizationId: string,
+  financialYear: number,
+): Promise<OrganizationReportProfile | null> {
+  const repository = new PrismaOrganizationReportProfileRepository(prisma);
+  const usecase = new GetOrganizationProfileUsecase(repository);
 
-export const loadOrganizationProfileData = unstable_cache(
-  async (
-    politicalOrganizationId: string,
-    financialYear: number,
-  ): Promise<OrganizationReportProfile | null> => {
-    const repository = new PrismaOrganizationReportProfileRepository(prisma);
-    const usecase = new GetOrganizationProfileUsecase(repository);
-
-    return usecase.execute({
-      politicalOrganizationId,
-      financialYear,
-    });
-  },
-  ["organization-profile-data"],
-  { revalidate: CACHE_REVALIDATE_SECONDS },
-);
+  return usecase.execute({
+    politicalOrganizationId,
+    financialYear,
+  });
+}

--- a/admin/src/server/contexts/report/presentation/loaders/report-preview-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/report-preview-loader.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaReportTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository";
 import { PrismaOrganizationReportProfileRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-organization-report-profile.repository";
@@ -14,44 +13,38 @@ import {
 } from "@/server/contexts/report/domain/models/report-data";
 import type { SummaryData } from "@/server/contexts/report/domain/models/summary-data";
 
-const CACHE_REVALIDATE_SECONDS = 60;
-
 export interface ReportPreviewData {
   xml: string;
   reportData: ReportData;
   summaryData: SummaryData;
 }
 
-export const loadReportPreviewData = unstable_cache(
-  async (politicalOrganizationId: string, financialYear: number): Promise<ReportPreviewData> => {
-    const transactionRepository = new PrismaReportTransactionRepository(prisma);
-    const profileRepository = new PrismaOrganizationReportProfileRepository(prisma);
-    const donationAssembler = new DonationAssembler(transactionRepository);
-    const incomeAssembler = new IncomeAssembler(transactionRepository);
-    const expenseAssembler = new ExpenseAssembler(transactionRepository);
-    const usecase = new XmlExportUsecase(
-      profileRepository,
-      donationAssembler,
-      incomeAssembler,
-      expenseAssembler,
-    );
+export async function loadReportPreviewData(
+  politicalOrganizationId: string,
+  financialYear: number,
+): Promise<ReportPreviewData> {
+  const transactionRepository = new PrismaReportTransactionRepository(prisma);
+  const profileRepository = new PrismaOrganizationReportProfileRepository(prisma);
+  const donationAssembler = new DonationAssembler(transactionRepository);
+  const incomeAssembler = new IncomeAssembler(transactionRepository);
+  const expenseAssembler = new ExpenseAssembler(transactionRepository);
+  const usecase = new XmlExportUsecase(
+    profileRepository,
+    donationAssembler,
+    incomeAssembler,
+    expenseAssembler,
+  );
 
-    const result = await usecase.execute({
-      politicalOrganizationId,
-      financialYear,
-    });
+  const result = await usecase.execute({
+    politicalOrganizationId,
+    financialYear,
+  });
 
-    const summaryData = ReportDataModel.getSummary(result.reportData);
+  const summaryData = ReportDataModel.getSummary(result.reportData);
 
-    return {
-      xml: result.xml,
-      reportData: result.reportData,
-      summaryData,
-    };
-  },
-  ["report-preview"],
-  {
-    revalidate: CACHE_REVALIDATE_SECONDS,
-    tags: ["report-preview"],
-  },
-);
+  return {
+    xml: result.xml,
+    reportData: result.reportData,
+    summaryData,
+  };
+}

--- a/admin/src/server/contexts/report/presentation/loaders/transactions-with-counterparts-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/transactions-with-counterparts-loader.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaReportTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository";
 import {
@@ -9,8 +8,6 @@ import {
   type GetTransactionsWithCounterpartsResult,
 } from "@/server/contexts/report/application/usecases/get-transactions-with-counterparts-usecase";
 
-const CACHE_REVALIDATE_SECONDS = 60;
-
 type LoadTransactionsWithCounterpartsInput = GetTransactionsWithCounterpartsInput;
 
 type LoadTransactionsWithCounterpartsResult = GetTransactionsWithCounterpartsResult;
@@ -18,32 +15,7 @@ type LoadTransactionsWithCounterpartsResult = GetTransactionsWithCounterpartsRes
 export async function loadTransactionsWithCounterpartsData(
   input: LoadTransactionsWithCounterpartsInput,
 ): Promise<LoadTransactionsWithCounterpartsResult> {
-  const page = input.page ?? 1;
-  const perPage = input.perPage ?? 50;
-
-  const cacheKey = [
-    "transactions-with-counterparts",
-    input.politicalOrganizationId,
-    String(input.financialYear),
-    String(input.unassignedOnly ?? false),
-    String(input.requiresCounterpartOnly ?? false),
-    input.categoryKey ?? "",
-    input.searchQuery ?? "",
-    String(page),
-    String(perPage),
-    input.sortField ?? "transactionDate",
-    input.sortOrder ?? "asc",
-  ];
-
-  const cachedLoader = unstable_cache(
-    async (): Promise<LoadTransactionsWithCounterpartsResult> => {
-      const repository = new PrismaReportTransactionRepository(prisma);
-      const usecase = new GetTransactionsWithCounterpartsUsecase(repository);
-      return usecase.execute(input);
-    },
-    cacheKey,
-    { revalidate: CACHE_REVALIDATE_SECONDS },
-  );
-
-  return cachedLoader();
+  const repository = new PrismaReportTransactionRepository(prisma);
+  const usecase = new GetTransactionsWithCounterpartsUsecase(repository);
+  return usecase.execute(input);
 }

--- a/admin/src/server/contexts/report/presentation/loaders/transactions-with-donors-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/transactions-with-donors-loader.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaTransactionWithDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-transaction-with-donor.repository";
 import {
@@ -9,8 +8,6 @@ import {
   type GetTransactionsWithDonorsResult,
 } from "@/server/contexts/report/application/usecases/get-transactions-with-donors-usecase";
 
-const CACHE_REVALIDATE_SECONDS = 60;
-
 type LoadTransactionsWithDonorsInput = GetTransactionsWithDonorsInput;
 
 type LoadTransactionsWithDonorsResult = GetTransactionsWithDonorsResult;
@@ -18,31 +15,7 @@ type LoadTransactionsWithDonorsResult = GetTransactionsWithDonorsResult;
 export async function loadTransactionsWithDonorsData(
   input: LoadTransactionsWithDonorsInput,
 ): Promise<LoadTransactionsWithDonorsResult> {
-  const page = input.page ?? 1;
-  const perPage = input.perPage ?? 50;
-
-  const cacheKey = [
-    "transactions-with-donors",
-    input.politicalOrganizationId,
-    String(input.financialYear),
-    String(input.unassignedOnly ?? false),
-    input.categoryKey ?? "",
-    input.searchQuery ?? "",
-    String(page),
-    String(perPage),
-    input.sortField ?? "transactionDate",
-    input.sortOrder ?? "asc",
-  ];
-
-  const cachedLoader = unstable_cache(
-    async (): Promise<LoadTransactionsWithDonorsResult> => {
-      const repository = new PrismaTransactionWithDonorRepository(prisma);
-      const usecase = new GetTransactionsWithDonorsUsecase(repository);
-      return usecase.execute(input);
-    },
-    cacheKey,
-    { revalidate: CACHE_REVALIDATE_SECONDS },
-  );
-
-  return cachedLoader();
+  const repository = new PrismaTransactionWithDonorRepository(prisma);
+  const usecase = new GetTransactionsWithDonorsUsecase(repository);
+  return usecase.execute(input);
 }

--- a/admin/src/server/contexts/shared/presentation/loaders/load-political-organization-data.ts
+++ b/admin/src/server/contexts/shared/presentation/loaders/load-political-organization-data.ts
@@ -1,30 +1,23 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
 import { GetPoliticalOrganizationUsecase } from "@/server/contexts/shared/application/usecases/get-political-organization-usecase";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 
-const CACHE_REVALIDATE_SECONDS = 60;
+export async function loadPoliticalOrganizationData(id: string): Promise<PoliticalOrganization> {
+  try {
+    const organizationId = parseInt(id, 10);
 
-export const loadPoliticalOrganizationData = unstable_cache(
-  async (id: string): Promise<PoliticalOrganization> => {
-    try {
-      const organizationId = parseInt(id, 10);
-
-      if (Number.isNaN(organizationId)) {
-        throw new Error("Invalid organization ID");
-      }
-
-      const repository = new PrismaPoliticalOrganizationRepository(prisma);
-      const usecase = new GetPoliticalOrganizationUsecase(repository);
-      return await usecase.execute(BigInt(organizationId));
-    } catch (error) {
-      console.error("Error fetching political organization:", error);
-      throw new Error(error instanceof Error ? error.message : "政治団体の取得に失敗しました");
+    if (Number.isNaN(organizationId)) {
+      throw new Error("Invalid organization ID");
     }
-  },
-  ["political-organization-data"],
-  { revalidate: CACHE_REVALIDATE_SECONDS },
-);
+
+    const repository = new PrismaPoliticalOrganizationRepository(prisma);
+    const usecase = new GetPoliticalOrganizationUsecase(repository);
+    return await usecase.execute(BigInt(organizationId));
+  } catch (error) {
+    console.error("Error fetching political organization:", error);
+    throw new Error(error instanceof Error ? error.message : "政治団体の取得に失敗しました");
+  }
+}

--- a/admin/src/server/contexts/shared/presentation/loaders/load-political-organizations-data.ts
+++ b/admin/src/server/contexts/shared/presentation/loaders/load-political-organizations-data.ts
@@ -1,24 +1,17 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
 import { GetPoliticalOrganizationsUsecase } from "@/server/contexts/shared/application/usecases/get-political-organizations-usecase";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 
-const CACHE_REVALIDATE_SECONDS = 60;
-
-export const loadPoliticalOrganizationsData = unstable_cache(
-  async (): Promise<PoliticalOrganization[]> => {
-    try {
-      const repository = new PrismaPoliticalOrganizationRepository(prisma);
-      const usecase = new GetPoliticalOrganizationsUsecase(repository);
-      return await usecase.execute();
-    } catch (error) {
-      console.error("Error fetching political organizations:", error);
-      throw new Error("政治団体の取得に失敗しました");
-    }
-  },
-  ["political-organizations-data"],
-  { revalidate: CACHE_REVALIDATE_SECONDS },
-);
+export async function loadPoliticalOrganizationsData(): Promise<PoliticalOrganization[]> {
+  try {
+    const repository = new PrismaPoliticalOrganizationRepository(prisma);
+    const usecase = new GetPoliticalOrganizationsUsecase(repository);
+    return await usecase.execute();
+  } catch (error) {
+    console.error("Error fetching political organizations:", error);
+    throw new Error("政治団体の取得に失敗しました");
+  }
+}

--- a/docs/backend-architecture-guide.md
+++ b/docs/backend-architecture-guide.md
@@ -134,9 +134,11 @@ contexts/{コンテキスト名}/
 ### 4.1 Presentation層（loaders / actions）
 
 #### loaders
-- **責務**: サーバーコンポーネントからのデータ取得、キャッシング
-- **実装**: `unstable_cache` でラップし、リポジトリとUsecaseを組み立てる
-- **キャッシュキー**: 明示的に指定する
+- **責務**: サーバーコンポーネントからのデータ取得（必要な場合のみキャッシング）
+- **実装**: リポジトリとUsecaseを組み立てて呼び出す
+- **キャッシュ**: admin（認証必須・低トラフィック）では原則 `unstable_cache` を使わず DB を直接読む。
+  webapp（公開・高トラフィック）などでキャッシュが本当に必要な場合のみ `unstable_cache` でラップし、
+  キャッシュキーと `tags` を明示する（詳細は [6.4 キャッシング](#64-キャッシング)）
 
 #### actions
 - **責務**: フォーム送信、データ更新、バリデーション、キャッシュ無効化
@@ -299,8 +301,12 @@ Domain層でエラーを扱う場合は、拡張エラー型とエラーコー�
 
 ### 6.4 キャッシング
 
-- **loaders**: `unstable_cache` でラップ、キャッシュキーとtagsを明示
-- **actions**: 処理成功後に `revalidateTag`/`revalidatePath` で無効化
+- **原則**: admin の loaders は `unstable_cache` を使わない。認証必須・低トラフィックの管理画面では
+  60秒キャッシュの利益がほぼ無く、更新直後に古いデータが表示される実バグの温床になる
+- **キャッシュする場合**（webapp の公開ページなど）: `unstable_cache` に必ず `tags` を付与し、
+  対応する更新アクションで `revalidateTag` を呼んで整合させる。
+  `revalidatePath` は `unstable_cache` のエントリを無効化しない（無効化は tag か revalidate 時間経過のみ）
+- **actions**: 処理成功後に `revalidatePath`（キャッシュを残す場合はあわせて `revalidateTag`）で無効化
 - **外部キャッシュ**: インターフェース経由でベストエフォート無効化
 
 ---
@@ -328,7 +334,7 @@ Domain層でエラーを扱う場合は、拡張エラー型とエラーコー�
 - [ ] 単一エンティティのロジックはDomain Modelに、複数エンティティのロジックはDomain Serviceに分けられている
 
 ### キャッシング
-- [ ] loadersで`unstable_cache`を使用している
+- [ ] admin の loaders で `unstable_cache` を使っていない（使う場合は `tags` を付与し、更新アクションの `revalidateTag` と整合している）
 - [ ] actionsで適切に`revalidateTag`/`revalidatePath`を呼び出している
 - [ ] 外部キャッシュの無効化はインターフェース経由で行っている
 


### PR DESCRIPTION
## 目的（Why）

admin の管理者が、取引先・寄付者・政治団体・報告書プロフィールなどを保存した直後に**最大60秒間古いデータが表示される**状態を解消するため。

各ローダーが `unstable_cache`（revalidate 60秒）で DB 読み取りをラップしている一方、対応する保存アクションは `revalidatePath` しか呼んでおらず、`unstable_cache` のエントリは無効化されない（無効化は tag か時間経過のみ）。#1302 で報告書プロフィールの e2e が落ちる形で顕在化した。admin は認証必須・低トラフィックの管理画面で、60秒キャッシュの利益はほぼ無い。

## 変更内容

- admin の全ローダー（10ファイル）から `unstable_cache` を除去し、DB を直接読む plain な async 関数にする
  - auth: `load-all-users.ts`（`usecase.execute()` に集約）
  - shared: `load-political-organization(s)-data.ts`
  - report: `counterparts-loader.ts` / `counterpart-detail-loader.ts` / `donors-loader.ts` / `organization-profile-loader.ts` / `report-preview-loader.ts` / `transactions-with-counterparts-loader.ts` / `transactions-with-donors-loader.ts`
- 残したキャッシュは無し（tags + `revalidateTag` の整合が必要なケースは admin には存在しなかった。`users` / `report-preview` の tags はどこからも `revalidateTag` されていなかった）
- `docs/backend-architecture-guide.md` のキャッシング方針を更新（admin の loaders は原則 `unstable_cache` を使わない、使う場合は tags + `revalidateTag` で整合させる）
- webapp（公開・高トラフィック）の `unstable_cache` は対象外（Issue のスコープ外）

Closes #1304
Closes #1302

## ローカルCIの実行結果

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ green
- admin E2E（`playwright test --workers=1`、ローカル supabase + `db:reset`）: ✅ 42 passed
  - `report-profile.spec.ts` の年度切り替えテスト（#1302 / #1307 で落ちていたもの）も通過

## スコープアウトして起票したIssue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - 管理画面のユーザー、取引、寄付者、団体、レポート関連データは、キャッシュを介さずリクエストごとに最新情報を取得するようになりました。
  - 認証・権限確認後にデータを取得する処理を維持し、認証エラー時のリダイレクトも継続します。

- **ドキュメント**
  - 管理画面におけるデータ取得とキャッシュ利用の方針を更新しました。
  - 必要に応じたキャッシュ設定や更新処理に関する指針を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->