### PR TITLE
fix(admin): report-profile の年度切り替え E2E を年度フォームのマウント待ちで安定化する

### DIFF
--- a/admin/e2e/tests/report-profile.spec.ts
+++ b/admin/e2e/tests/report-profile.spec.ts
@@ -1,7 +1,25 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * 選択した年度のフォームがマウント済みになるまで待つ。
+ *
+ * 年度切り替えは `router.push` による App Router のソフトナビゲーションで、
+ * `ReportProfileForm` は `key={financialYear}` で年度ごとに再マウントされる。
+ * URL の変化だけを待つと「URL は新年度だがフォームはまだ旧年度」の瞬間を
+ * 掴む余地があるため、フォーム自身が持つ `data-financial-year` で待つ。
+ */
+async function expectFormForYear(page: Page, year: string) {
+	await expect(page.locator(`form[data-financial-year="${year}"]`)).toBeVisible();
+}
 
 test.describe("報告書プロフィール", () => {
 	test.describe("年度切り替え", () => {
+		// 経緯: このテストは 2026-08 に CI で繰り返し失敗していた（#1307）。原因はテストの
+		// 待ち方ではなく、Actions キャッシュで持ち越された `.next/cache/fetch-cache`
+		// （unstable_cache のエントリ）が db:reset 後に再割り当てされた団体 ID と衝突し、
+		// 前ランの団体名が表示されていたこと。#1305（CI でビルド前に fetch-cache を削除）と
+		// #1330（admin ローダーから unstable_cache を除去）で根本解消済み。
+		// 「DB に無い値が表示される」形で再び落ちた場合は、まずサーバー側キャッシュを疑うこと。
 		test("年度を切り替えてもフォームが正しく同期し、他の年度を上書きしない", async ({ page }) => {
 			// 既存シードや他テストと干渉しないよう、テスト専用の政治団体を作成
 			const uniqueSlug = `report-profile-year-${Date.now()}`;
@@ -43,6 +61,7 @@ test.describe("報告書プロフィール", () => {
 			// yearA で新規保存
 			await yearSelect.selectOption(yearA!);
 			await expect(page).toHaveURL(new RegExp(`year=${yearA}`));
+			await expectFormForYear(page, yearA!);
 			await expect(officialNameInput).toHaveValue("");
 
 			const yearAName = `${yearA}年の団体名 ${Date.now()}`;
@@ -54,6 +73,7 @@ test.describe("報告書プロフィール", () => {
 			// （バグ再発時は yearA の入力値が残り、保存で yearA が上書きされる）
 			await yearSelect.selectOption(yearB!);
 			await expect(page).toHaveURL(new RegExp(`year=${yearB}`));
+			await expectFormForYear(page, yearB!);
 			await expect(officialNameInput).toHaveValue("");
 
 			// yearB で別の値を保存
@@ -66,11 +86,13 @@ test.describe("報告書プロフィール", () => {
 			// （バグ再発時は yearB の保存で yearA が上書きされて yearBName が表示される）
 			await yearSelect.selectOption(yearA!);
 			await expect(page).toHaveURL(new RegExp(`year=${yearA}`));
+			await expectFormForYear(page, yearA!);
 			await expect(officialNameInput).toHaveValue(yearAName);
 
 			// yearB に戻す → yearB の保存内容も残っていること
 			await yearSelect.selectOption(yearB!);
 			await expect(page).toHaveURL(new RegExp(`year=${yearB}`));
+			await expectFormForYear(page, yearB!);
 			await expect(officialNameInput).toHaveValue(yearBName);
 		});
 	});

--- a/admin/src/client/components/report-profile/ReportProfileForm.tsx
+++ b/admin/src/client/components/report-profile/ReportProfileForm.tsx
@@ -85,8 +85,11 @@ export function ReportProfileForm({
     }));
   };
 
+  // data-financial-year: このフォームがどの報告年に紐付いているかを DOM 上で示す。
+  // 年度切り替え時は key で再マウントされるため、E2E は URL ではなくこの属性で
+  // 「選択した年度のフォームが表示済み」であることを待つ。
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={handleSubmit} className="space-y-6" data-financial-year={financialYear}>
       {error && (
         <div className="rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive">
           {error}


### PR DESCRIPTION
## 目的（Why）

CI を回す全員（renovate など無関係な PR を含む）が `report-profile.spec.ts` の年度切り替えテストの flaky で落とされる状態を解消し、retry 無しで安定して通るようにするため。

## 調査結果

2026-08 の CI 失敗ログを確認したところ、失敗はすべて 1 回目の `toHaveValue("")` で、Received 値は当該ランより数時間前のタイムスタンプを含む団体名（前ランで保存された値）でした。原因はテストの待ち方ではなく、Actions キャッシュで持ち越された `admin/.next/cache/fetch-cache`（`unstable_cache` のエントリ）が、`db:reset` 後に再割り当てされた団体 ID と衝突して前ランのデータを返していたことです。

この根本原因は既に解消されています。

- #1305: e2e ジョブでビルド前に `fetch-cache` を削除
- #1330: admin の全ローダーから `unstable_cache` を除去

#1305 以降の main の CI（7 ラン以上）は E2E が retry 無し（flaky 0）で通過しています。

## 変更内容

- `ReportProfileForm` の `<form>` に `data-financial-year` を追加（UI 上の見た目に変更なし）
- 年度切り替えテストは、URL の変化に加えて **選択した年度のフォームがマウント済み** であることを `data-financial-year` で待ってから値の検証・入力を行うようにした。URL だけを待つと「URL は新年度だがフォームは旧年度」の瞬間を掴む余地が理論上残るため
- 過去の flaky の経緯と、再発時に最初に疑うべき点（サーバー側キャッシュ）をテストにコメントとして記録

Closes #1307

## ローカル CI

- `pnpm verify`: 通過（test 913 + 135 件 / typecheck / lint / knip / depcruise）
- `playwright test e2e/tests/report-profile.spec.ts --workers=1 --repeat-each 5`: 5/5 通過（retries 0）
- admin E2E 全体 `--workers=1`: 42 passed

## スコープアウトして起票した Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 報告年度を切り替えた際、選択した年度のフォームが正しく表示されるまで待機するよう改善しました。
  * 年度切り替え後の入力値確認の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->