### PR TITLE
ci(e2e): Supabase の起動をバックグラウンド化し不要サービスを除外して e2e ジョブを短縮する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # Supabase の起動（docker イメージの pull + コンテナ起動）はこのジョブで最も時間がかかる。
+      # 依存インストール・Playwright ブラウザのインストール・Prisma Client 生成とは独立しているため、
+      # ここでバックグラウンドで開始し、それらの完了後に「Wait for Supabase」ステップで合流する。
+      # 出力をファイルへリダイレクトしないとステップがプロセス終了まで待ってしまうため必ずリダイレクトする。
+      - name: Start Supabase (background)
+        run: |
+          # Enable API and use default ports for CI
+          sed -i 's/^\[api\]$/[api]/' supabase/config.toml
+          sed -i '/^\[api\]$/,/^\[/{s/^enabled = false$/enabled = true/}' supabase/config.toml
+          sed -i 's/^port = 54332$/port = 54322/' supabase/config.toml
+
+          # admin E2E が必要とするのは db / kong / gotrue（認証）/ postgrest（疎通確認）と、
+          # gotrue の SMTP 先である mailpit のみ。storage-api（pull が最も遅い）・realtime・
+          # postgres-meta（studio 専用）・logflare（analytics）は使わないので除外する。
+          nohup bash -c '
+            supabase start --exclude imgproxy,edge-runtime,vector,studio,storage-api,realtime,postgres-meta,logflare
+            echo $? > /tmp/supabase-start.exit
+          ' > /tmp/supabase-start.log 2>&1 &
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
@@ -316,23 +340,23 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter admin exec playwright install chromium --with-deps
 
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
       - name: Generate Prisma Client
         run: pnpm db:generate
 
-      - name: Start Supabase
+      - name: Wait for Supabase
         run: |
-          # Enable API and use default ports for CI
-          sed -i 's/^\[api\]$/[api]/' supabase/config.toml
-          sed -i '/^\[api\]$/,/^\[/{s/^enabled = false$/enabled = true/}' supabase/config.toml
-          sed -i 's/^port = 54332$/port = 54322/' supabase/config.toml
+          # バックグラウンドの supabase start は子プロセスではないため wait できない。
+          # 終了コードを書き出すファイルの出現をポーリングして完了を待つ。
+          echo "Waiting for supabase start to finish..."
+          timeout 300 bash -c 'until [ -f /tmp/supabase-start.exit ]; do sleep 2; done' \
+            || { echo "::error::supabase start timed out"; cat /tmp/supabase-start.log; exit 1; }
 
-          # Start Supabase
-          supabase start --exclude imgproxy,edge-runtime,vector,studio
+          cat /tmp/supabase-start.log
+          exit_code=$(cat /tmp/supabase-start.exit)
+          if [ "$exit_code" != "0" ]; then
+            echo "::error::supabase start failed with exit code $exit_code"
+            exit "$exit_code"
+          fi
 
           # Wait for Supabase API to be ready
           echo "Waiting for Supabase API..."


### PR DESCRIPTION
## 目的（Why）

CI の e2e ジョブで Supabase の起動に約 74 秒（ジョブ全体の約 3 割）かかっており、テスト本体ではなくインフラのセットアップで待たされる状態を解消するため。

## 変更内容

直近の main の e2e ジョブ（run 34295118053）の Start Supabase ステップ 74 秒の内訳は次のとおりでした。

| フェーズ | 時間 |
|---|---|
| docker イメージの pull（並列、最遅は storage-api の 42 秒、次に postgres の 30 秒） | 42 秒 |
| Starting database | 16 秒 |
| Starting containers + health check | 13 秒 |

これを踏まえて `.github/workflows/ci.yml` の e2e ジョブを次のように変更しました。

- **Supabase の起動をバックグラウンド化**: Supabase CLI のセットアップと `supabase start` を Checkout 直後に移し、`nohup ... &` で起動する。依存インストール・Playwright ブラウザインストール・Prisma Client 生成（合計 40〜50 秒）と並行して pull / 起動が進む。
- **不要サービスの追加 exclude**: admin E2E が使うのは db / kong / gotrue（認証）/ postgrest（疎通確認）と gotrue の SMTP 先である mailpit のみ。`storage-api`（pull が最遅）、`realtime`、`postgres-meta`（studio 専用）、`logflare`（analytics。`--exclude vector` では止まらず pull されていた）を追加で除外。
- **Wait for Supabase ステップ**: バックグラウンドプロセスは子プロセスではなく `wait` できないため、終了コードを書き出したファイルの出現をポーリングし、失敗時はログを出して同じ終了コードで落とす。

期待値: Start Supabase の 74 秒のうち大半が他ステップと重なり、e2e ジョブは 1 分弱短縮される見込み。実測値はこの PR の CI 結果で確認します。

調査したが採用しなかった案: docker イメージの Actions キャッシュ（`docker save` / `load`）。postgres イメージが 1GB 超で、キャッシュ復元と `docker load` に pull と同程度の時間がかかる見込みのため見送り。

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: pass
- ローカル Supabase を新しい exclude リストで再起動 → `supabase status --output json` で ANON_KEY / SERVICE_ROLE_KEY 取得 → `pnpm db:reset`（gotrue admin API 経由の seed）→ admin E2E `--workers=1`: 42 passed

## スコープアウトして起票した Issue

なし

Closes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)