### PR TITLE
test(e2e): import-donors のインポート確定テストを同一ワーカーで順次実行し並列時のデータ競合を防ぐ

### DIFF
--- a/admin/e2e/tests/import-donors.spec.ts
+++ b/admin/e2e/tests/import-donors.spec.ts
@@ -148,6 +148,12 @@ test.describe("寄付者一括インポート", () => {
 		});
 
 		test.describe("CSVインポート確定", () => {
+			// この describe 配下の 2 テストは同じ寄付者 CSV を実際に DB へ書き込む。
+			// fullyParallel のまま並列に走ると同じ寄付者を同時に createMany して
+			// 一意制約違反で失敗するため、describe 単位で fullyParallel を解除し
+			// 同一ワーカーで順番に実行する（serial と違い、1 件失敗しても以降は skip されない）。
+			test.describe.configure({ mode: "default" });
+
 			test("有効な行がある場合、インポートボタンが表示される", async ({
 				page,
 			}) => {


### PR DESCRIPTION
## 目的（Why）

ローカルで admin E2E を workers 既定（並列）で回す開発者・ループが、`import-donors.spec.ts` の「CSVインポート確定」配下で発生する寄付者の一意制約違反（無関係な失敗）に切り分けコストを払わされている状態を解消するため。

## 変更内容

- `admin/e2e/tests/import-donors.spec.ts` の「CSVインポート確定」describe に `test.describe.configure({ mode: "default" })` を追加
  - fullyParallel を describe 単位で解除し、実際に DB へ書き込む 2 テスト（＋ボタン表示確認 1 テスト）を同一ワーカーで順番に実行する
  - `serial` ではなく `default` を選んだ理由: serial は 1 件失敗すると以降がスキップされるが、default は順序保証のみで各テストが独立して失敗・リトライできる（Playwright 公式ドキュメントでも serial は非推奨）
- 他の describe（読み込み・CSVプレビュー）は読み取りのみなので並列のまま
- CI（`workers: 1`）の挙動は変わらない

Closes #1313

## ローカルCIの実行結果

- `pnpm verify`: pass（test 913+135 / typecheck / lint / knip / depcruise）
- admin E2E を workers 既定（並列）で 2 回連続実行: 42 passed / 42 passed
- JSON レポーターで確認: 「CSVインポート確定」の 3 テストが同一ワーカー（worker=2）で開始時刻が重ならず順次実行され、他の spec は別ワーカーで並列実行されている
- 参考: 元コードで DB リセット→並列フル実行を 4 回試したが、手元では競合は再現しなかった（タイミング依存）。修正は同時書き込みの経路そのものを塞ぐもの

## スコープアウトして起票したIssue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 寄付者CSVインポートの関連テストを同一ワーカーで順番に実行するよう調整しました。
  * 並列実行時に発生するデータ登録エラーを防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->