### PR TITLE
feat(admin): 寄付者一括インポート・残高登録・取引一括削除画面をリデザインする

### DIFF
--- a/admin/e2e/tests/import-donors.spec.ts
+++ b/admin/e2e/tests/import-donors.spec.ts
@@ -10,7 +10,7 @@ test.describe("寄付者一括インポート", () => {
 				page.getByRole("heading", { name: "寄付者一括インポート" }),
 			).toBeVisible();
 			await expect(page.getByRole("combobox")).toBeVisible();
-			await expect(page.getByLabel("CSV File:")).toBeVisible();
+			await expect(page.getByLabel("CSVファイル", { exact: true })).toBeVisible();
 		});
 
 		test("政治団体セレクターが表示される", async ({ page }) => {
@@ -32,7 +32,7 @@ test.describe("寄付者一括インポート", () => {
 		}) => {
 			await page.goto("/import-donors");
 
-			const fileInput = page.getByLabel("CSV File:");
+			const fileInput = page.getByLabel("CSVファイル", { exact: true });
 			const csvPath = path.resolve(
 				process.cwd(),
 				"../data/sample_donor_import.csv",
@@ -60,7 +60,7 @@ test.describe("寄付者一括インポート", () => {
 		test("プレビューテーブルにデータが表示される", async ({ page }) => {
 			await page.goto("/import-donors");
 
-			const fileInput = page.getByLabel("CSV File:");
+			const fileInput = page.getByLabel("CSVファイル", { exact: true });
 			const csvPath = path.resolve(
 				process.cwd(),
 				"../data/sample_donor_import.csv",
@@ -97,7 +97,7 @@ test.describe("寄付者一括インポート", () => {
 		test("タブをクリックするとフィルタリングされる", async ({ page }) => {
 			await page.goto("/import-donors");
 
-			const fileInput = page.getByLabel("CSV File:");
+			const fileInput = page.getByLabel("CSVファイル", { exact: true });
 			const csvPath = path.resolve(
 				process.cwd(),
 				"../data/sample_donor_import.csv",
@@ -128,7 +128,7 @@ test.describe("寄付者一括インポート", () => {
 		test("ツールチップが表示される", async ({ page }) => {
 			await page.goto("/import-donors");
 
-			const fileInput = page.getByLabel("CSV File:");
+			const fileInput = page.getByLabel("CSVファイル", { exact: true });
 			const csvPath = path.resolve(
 				process.cwd(),
 				"../data/sample_donor_import.csv",
@@ -159,7 +159,7 @@ test.describe("寄付者一括インポート", () => {
 			}) => {
 				await page.goto("/import-donors");
 
-				const fileInput = page.getByLabel("CSV File:");
+				const fileInput = page.getByLabel("CSVファイル", { exact: true });
 				const csvPath = path.resolve(
 					process.cwd(),
 					"../data/sample_donor_import.csv",
@@ -180,7 +180,7 @@ test.describe("寄付者一括インポート", () => {
 			}) => {
 				await page.goto("/import-donors");
 
-				const fileInput = page.getByLabel("CSV File:");
+				const fileInput = page.getByLabel("CSVファイル", { exact: true });
 				const csvPath = path.resolve(
 					process.cwd(),
 					"../data/sample_donor_import.csv",
@@ -214,7 +214,7 @@ test.describe("寄付者一括インポート", () => {
 			}) => {
 				await page.goto("/import-donors");
 
-				const fileInput = page.getByLabel("CSV File:");
+				const fileInput = page.getByLabel("CSVファイル", { exact: true });
 				const csvPath = path.resolve(
 					process.cwd(),
 					"../data/sample_donor_import.csv",

--- a/admin/src/app/(auth)/balance-snapshots/page.tsx
+++ b/admin/src/app/(auth)/balance-snapshots/page.tsx
@@ -10,9 +10,7 @@ export default async function BalanceSnapshotsPage() {
   return (
     <div>
       <PageHeader label="Balance Snapshots" title="残高登録" />
-      <div className="bg-card rounded-xl p-4">
-        <BalanceSnapshotsClient organizations={organizations} />
-      </div>
+      <BalanceSnapshotsClient organizations={organizations} />
     </div>
   );
 }

--- a/admin/src/app/(auth)/import-donors/page.tsx
+++ b/admin/src/app/(auth)/import-donors/page.tsx
@@ -12,13 +12,11 @@ export default async function ImportDonorsPage() {
   return (
     <div>
       <PageHeader label="Donor Import" title="寄付者一括インポート" />
-      <div className="bg-card rounded-xl p-4">
-        <DonorCsvImportClient
-          organizations={organizations}
-          previewAction={previewDonorCsv}
-          importAction={importDonorCsv}
-        />
-      </div>
+      <DonorCsvImportClient
+        organizations={organizations}
+        previewAction={previewDonorCsv}
+        importAction={importDonorCsv}
+      />
     </div>
   );
 }

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotForm.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotForm.tsx
@@ -3,6 +3,7 @@ import "client-only";
 
 import { useState, useId } from "react";
 import type { ChangeEvent, FormEvent } from "react";
+import { CircleNotch } from "@phosphor-icons/react/dist/ssr";
 import { Button, Input, Label } from "@/client/components/ui";
 
 interface BalanceSnapshotFormProps {
@@ -26,6 +27,7 @@ export default function BalanceSnapshotForm({
 
   const dateInputId = useId();
   const balanceInputId = useId();
+  const dateErrorId = useId();
 
   const validateDate = (dateValue: string) => {
     if (!dateValue) {
@@ -89,22 +91,32 @@ export default function BalanceSnapshotForm({
 
   return (
     <div>
-      <form onSubmit={handleSubmit} className="flex gap-4 items-start max-w-2xl">
-        <div className="w-48">
-          <Label htmlFor={dateInputId}>残高日付:</Label>
+      <form onSubmit={handleSubmit} className="flex flex-wrap items-start gap-4">
+        <div className="flex w-48 flex-col gap-1.5">
+          <Label htmlFor={dateInputId} className="text-xs font-bold">
+            残高日付 <span className="text-destructive">*</span>
+          </Label>
           <Input
             id={dateInputId}
             type="date"
             value={snapshotDate}
             onChange={handleDateChange}
-            className={`[color-scheme:dark] ${dateError ? "border-red-500 focus:ring-red-500" : ""}`}
+            className="font-latin text-[13px]"
+            aria-invalid={dateError ? true : undefined}
+            aria-describedby={dateError ? dateErrorId : undefined}
             required
           />
-          {dateError && <p className="text-destructive text-sm mt-1">{dateError}</p>}
+          {dateError && (
+            <p id={dateErrorId} className="text-xs text-destructive">
+              {dateError}
+            </p>
+          )}
         </div>
 
-        <div className="w-48">
-          <Label htmlFor={balanceInputId}>残高 (円):</Label>
+        <div className="flex w-48 flex-col gap-1.5">
+          <Label htmlFor={balanceInputId} className="text-xs font-bold">
+            残高 (円) <span className="text-destructive">*</span>
+          </Label>
           <Input
             id={balanceInputId}
             type="number"
@@ -112,18 +124,33 @@ export default function BalanceSnapshotForm({
             value={balance}
             onChange={(e) => setBalance(e.target.value)}
             placeholder="0"
+            className="font-latin text-[13px]"
             required
           />
         </div>
 
-        <div className="mt-7">
+        <div className="self-end">
           <Button type="submit" disabled={!snapshotDate || !balance || isSubmitting || !!dateError}>
-            {isSubmitting ? "登録中..." : "残高を登録"}
+            {isSubmitting ? (
+              <>
+                <CircleNotch aria-hidden className="animate-spin" />
+                登録中...
+              </>
+            ) : (
+              "残高を登録"
+            )}
           </Button>
         </div>
       </form>
 
-      {successMessage && <div className="mt-4 text-primary-hover text-sm">{successMessage}</div>}
+      {successMessage && (
+        <div
+          role="status"
+          className="mt-4 rounded-lg border border-primary-active bg-accent p-3 text-sm text-primary-active"
+        >
+          {successMessage}
+        </div>
+      )}
     </div>
   );
 }

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotList.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotList.tsx
@@ -3,12 +3,22 @@ import "client-only";
 
 import { useState } from "react";
 import type { BalanceSnapshot } from "@/server/contexts/shared/domain/models/balance-snapshot";
-import { Button } from "@/client/components/ui";
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/client/components/ui";
+import { formatAmount, formatDate, formatDateTime } from "@/client/lib";
 
 interface BalanceSnapshotListProps {
   snapshots: BalanceSnapshot[];
 }
 
+/** 残高スナップショットの履歴一覧（テーブル罫線ルールは取引一覧と同一、日付は YYYY.MM.DD、金額は Poppins 右寄せ） */
 export default function BalanceSnapshotList({ snapshots }: BalanceSnapshotListProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
@@ -36,53 +46,49 @@ export default function BalanceSnapshotList({ snapshots }: BalanceSnapshotListPr
 
   if (snapshots.length === 0) {
     return (
-      <div className="text-center py-10">
-        <p className="text-muted-foreground">残高スナップショットはありません</p>
-      </div>
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        残高スナップショットはありません
+      </p>
     );
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse">
-        <thead>
-          <tr className="border-b border-border">
-            <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">残高日付</th>
-            <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">残高</th>
-            <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">登録日時</th>
-            <th className="px-2 py-3 text-center text-sm font-semibold text-foreground w-20">
-              操作
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {snapshots.map((snapshot) => (
-            <tr key={snapshot.id} className="border-b border-border">
-              <td className="px-2 py-3 text-sm text-foreground">
-                {new Date(snapshot.snapshot_date).toLocaleDateString("ja-JP")}
-              </td>
-              <td className="px-2 py-3 text-sm text-right text-foreground">
-                ¥{snapshot.balance.toLocaleString()}
-              </td>
-              <td className="px-2 py-3 text-sm text-muted-foreground">
-                {new Date(snapshot.created_at).toLocaleString("ja-JP")}
-              </td>
-              <td className="px-2 py-3 text-center">
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  onClick={() => handleDelete(snapshot.id)}
-                  disabled={deletingId === snapshot.id}
-                  title="削除"
-                >
-                  {deletingId === snapshot.id ? "削除中..." : "削除"}
-                </Button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <Table>
+      <TableHeader>
+        <TableRow className="hover:bg-transparent">
+          <TableHead>残高日付</TableHead>
+          <TableHead className="text-right">残高</TableHead>
+          <TableHead>登録日時</TableHead>
+          <TableHead className="w-20 text-center">操作</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {snapshots.map((snapshot) => (
+          <TableRow key={snapshot.id}>
+            <TableCell className="font-latin text-[13px]">
+              {formatDate(snapshot.snapshot_date)}
+            </TableCell>
+            <TableCell className="font-latin text-right text-[13px] font-semibold">
+              {formatAmount(snapshot.balance)}
+            </TableCell>
+            <TableCell className="font-latin text-xs text-muted-foreground">
+              {formatDateTime(snapshot.created_at)}
+            </TableCell>
+            <TableCell className="text-center">
+              <Button
+                type="button"
+                variant="destructive"
+                size="xs"
+                onClick={() => handleDelete(snapshot.id)}
+                disabled={deletingId === snapshot.id}
+                title="削除"
+              >
+                {deletingId === snapshot.id ? "削除中..." : "削除"}
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 }

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotsClient.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotsClient.tsx
@@ -2,12 +2,14 @@
 import "client-only";
 
 import { useState, useEffect, useCallback } from "react";
+import { CircleNotch } from "@phosphor-icons/react/dist/ssr";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { BalanceSnapshot } from "@/server/contexts/shared/domain/models/balance-snapshot";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
-import BalanceSnapshotForm from "./BalanceSnapshotForm";
-import BalanceSnapshotList from "./BalanceSnapshotList";
-import CurrentBalance from "./CurrentBalance";
+import BalanceSnapshotForm from "@/client/components/balance-snapshots/BalanceSnapshotForm";
+import BalanceSnapshotList from "@/client/components/balance-snapshots/BalanceSnapshotList";
+import CurrentBalance from "@/client/components/balance-snapshots/CurrentBalance";
+import { Label } from "@/client/components/ui";
 import { apiClient } from "@/client/lib/api-client";
 
 interface BalanceSnapshotsClientProps {
@@ -78,32 +80,45 @@ export default function BalanceSnapshotsClient({ organizations }: BalanceSnapsho
 
   return (
     <div className="space-y-6">
-      <PoliticalOrganizationSelect
-        organizations={organizations}
-        value={selectedOrgId}
-        onValueChange={handleOrgChange}
-        required
-      />
-
-      {selectedOrgId && (
-        <div className="space-y-8">
-          <CurrentBalance snapshot={currentBalance} />
-
-          <hr className="border-border" />
-
-          <div>
-            <h3 className="text-lg font-medium text-foreground mb-4">残高を登録</h3>
-            <BalanceSnapshotForm
-              politicalOrganizationId={selectedOrgId}
-              onSubmit={handleFormSubmit}
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-6">
+        <div className="rounded-lg border border-border bg-card p-6">
+          <div className="flex max-w-[360px] flex-col gap-1.5">
+            <Label className="text-xs font-bold">
+              政治団体 <span className="text-destructive">*</span>
+            </Label>
+            <PoliticalOrganizationSelect
+              organizations={organizations}
+              value={selectedOrgId}
+              onValueChange={handleOrgChange}
+              required
+              hideLabel
+              className="w-full"
             />
           </div>
+          {selectedOrgId && (
+            <div className="mt-6">
+              <h2 className="text-[13px] font-bold text-foreground">残高を登録</h2>
+              <div className="mt-3">
+                <BalanceSnapshotForm
+                  politicalOrganizationId={selectedOrgId}
+                  onSubmit={handleFormSubmit}
+                />
+              </div>
+            </div>
+          )}
+        </div>
 
-          <div>
-            <h3 className="text-lg font-medium mb-4">残高スナップショット一覧</h3>
+        {selectedOrgId && <CurrentBalance snapshot={currentBalance} />}
+      </div>
+
+      {selectedOrgId && (
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h2 className="text-base font-bold text-foreground">残高スナップショット一覧</h2>
+          <div className="mt-4">
             {loading ? (
-              <div className="text-center py-4">
-                <p className="text-muted-foreground">読み込み中...</p>
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                <CircleNotch aria-hidden className="size-4 animate-spin text-primary" />
+                読み込み中...
               </div>
             ) : (
               <BalanceSnapshotList snapshots={snapshots} />

--- a/admin/src/client/components/balance-snapshots/CurrentBalance.tsx
+++ b/admin/src/client/components/balance-snapshots/CurrentBalance.tsx
@@ -1,42 +1,39 @@
 import type { BalanceSnapshot } from "@/server/contexts/shared/domain/models/balance-snapshot";
+import { formatAmount, formatDate, formatDateTime } from "@/client/lib";
 
 interface CurrentBalanceProps {
   snapshot: BalanceSnapshot | null;
 }
 
+/** 現在有効な残高（最新スナップショット）を示す白カード。金額は Poppins、日付は YYYY.MM.DD。 */
 export default function CurrentBalance({ snapshot }: CurrentBalanceProps) {
-  if (!snapshot) {
-    return (
-      <div className="bg-card rounded-lg p-6 border border-border max-w-md">
-        <h3 className="text-lg font-medium text-foreground mb-4">現在有効な残高</h3>
-        <p className="text-muted-foreground">残高スナップショットがありません</p>
-      </div>
-    );
-  }
-
   return (
-    <div className="bg-primary-card rounded-lg p-6 border border-border max-w-md">
-      <h3 className="text-lg font-medium text-foreground mb-4">現在有効な残高</h3>
-      <div className="space-y-3">
-        <div className="flex justify-between items-center">
-          <span className="text-muted-foreground">残高</span>
-          <span className="text-2xl font-bold text-foreground">
-            ¥{snapshot.balance.toLocaleString()}
-          </span>
-        </div>
-        <div className="flex justify-between items-center">
-          <span className="text-muted-foreground">残高日付</span>
-          <span className="text-foreground">
-            {new Date(snapshot.snapshot_date).toLocaleDateString("ja-JP")}
-          </span>
-        </div>
-        <div className="flex justify-between items-center">
-          <span className="text-muted-foreground">登録日時</span>
-          <span className="text-muted-foreground text-sm">
-            {new Date(snapshot.created_at).toLocaleString("ja-JP")}
-          </span>
-        </div>
-      </div>
+    <div className="rounded-lg border border-border bg-card p-6">
+      <h2 className="text-[13px] font-bold text-foreground">現在有効な残高</h2>
+      {snapshot ? (
+        <dl className="mt-3 space-y-3">
+          <div className="flex items-baseline justify-between gap-4">
+            <dt className="text-[13px] text-muted-foreground">残高</dt>
+            <dd className="font-latin text-2xl font-semibold text-foreground">
+              {formatAmount(snapshot.balance)}
+            </dd>
+          </div>
+          <div className="flex items-baseline justify-between gap-4 border-t border-border-soft pt-3">
+            <dt className="text-[13px] text-muted-foreground">残高日付</dt>
+            <dd className="font-latin text-[13px] text-foreground">
+              {formatDate(snapshot.snapshot_date)}
+            </dd>
+          </div>
+          <div className="flex items-baseline justify-between gap-4">
+            <dt className="text-[13px] text-muted-foreground">登録日時</dt>
+            <dd className="font-latin text-xs text-muted-foreground">
+              {formatDateTime(snapshot.created_at)}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <p className="mt-3 text-sm text-muted-foreground">残高スナップショットがありません</p>
+      )}
     </div>
   );
 }

--- a/admin/src/client/components/csv-upload/CsvDropzone.tsx
+++ b/admin/src/client/components/csv-upload/CsvDropzone.tsx
@@ -1,7 +1,7 @@
 "use client";
 import "client-only";
 
-import { useId, useRef, useState, type DragEvent } from "react";
+import { useEffect, useId, useRef, useState, type DragEvent } from "react";
 import { UploadSimple } from "@phosphor-icons/react/dist/ssr";
 import { Button } from "@/client/components/ui";
 import { cn } from "@/client/lib";
@@ -28,6 +28,13 @@ export function CsvDropzone({ file, onFileChange, disabled = false, note }: CsvD
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
+
+  // 親がファイルを破棄（取り込み完了など）したら hidden input も空にし、同じファイルを再選択できるようにする
+  useEffect(() => {
+    if (!file && inputRef.current) {
+      inputRef.current.value = "";
+    }
+  }, [file]);
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();

--- a/admin/src/client/components/donor-csv-import/DonorCsvImportClient.tsx
+++ b/admin/src/client/components/donor-csv-import/DonorCsvImportClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 import "client-only";
 
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CircleNotch } from "@phosphor-icons/react/dist/ssr";
 import { toast } from "sonner";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { PreviewDonorCsvResult } from "@/server/contexts/report/presentation/types/preview-donor-csv-types";
@@ -10,9 +11,10 @@ import type {
   ImportDonorCsvRequest,
   ImportDonorCsvResult,
 } from "@/server/contexts/report/presentation/actions/import-donor-csv";
-import DonorCsvPreview from "./DonorCsvPreview";
-import { Input, Label } from "@/client/components/ui";
+import DonorCsvPreview from "@/client/components/donor-csv-import/DonorCsvPreview";
+import { Label } from "@/client/components/ui";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
+import { CsvDropzone } from "@/client/components/csv-upload/CsvDropzone";
 
 interface DonorCsvImportClientProps {
   organizations: PoliticalOrganization[];
@@ -20,13 +22,14 @@ interface DonorCsvImportClientProps {
   importAction: (data: ImportDonorCsvRequest) => Promise<ImportDonorCsvResult>;
 }
 
+/** 対応形式と上限サイズ（上限は next.config.ts の serverActions.bodySizeLimit に合わせる） */
+const FILE_NOTE = "UTF-8 ・ 最大 100MB";
+
 export default function DonorCsvImportClient({
   organizations,
   previewAction,
   importAction,
 }: DonorCsvImportClientProps) {
-  const csvFileInputId = useId();
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [politicalOrganizationId, setPoliticalOrganizationId] = useState<string>("");
   const [previewResult, setPreviewResult] = useState<PreviewDonorCsvResult | null>(null);
@@ -56,6 +59,7 @@ export default function DonorCsvImportClient({
     [],
   );
 
+  // ファイルと政治団体が揃ったら自動でプレビューを取得する
   useEffect(() => {
     if (!file || !politicalOrganizationId) {
       setPreviewResult(null);
@@ -89,9 +93,6 @@ export default function DonorCsvImportClient({
     setFile(null);
     setPreviewResult(null);
     setError(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
   }, []);
 
   const handleImport = useCallback(async () => {
@@ -123,37 +124,52 @@ export default function DonorCsvImportClient({
   }, [file, politicalOrganizationId, resetFileInput]);
 
   return (
-    <div className="space-y-3">
-      <PoliticalOrganizationSelect
-        organizations={organizations}
-        value={politicalOrganizationId}
-        onValueChange={setPoliticalOrganizationId}
-        required
-      />
-      <div>
-        <Label htmlFor={csvFileInputId}>CSV File:</Label>
-        <Input
-          ref={fileInputRef}
-          id={csvFileInputId}
-          className="h-10 border-0 bg-transparent shadow-none file:mr-4 file:h-full file:px-6 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 file:cursor-pointer"
-          type="file"
-          accept=".csv,text/csv"
-          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-          required
-        />
+    <div className="space-y-6">
+      <div className="max-w-[720px] rounded-lg border border-border bg-card p-7">
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs font-bold">
+              政治団体 <span className="text-destructive">*</span>
+            </Label>
+            <PoliticalOrganizationSelect
+              organizations={organizations}
+              value={politicalOrganizationId}
+              onValueChange={setPoliticalOrganizationId}
+              required
+              hideLabel
+              className="w-full"
+            />
+          </div>
+        </div>
+
+        <div className="mt-6">
+          <CsvDropzone
+            file={file}
+            onFileChange={setFile}
+            disabled={loading || isImporting}
+            note={FILE_NOTE}
+          />
+        </div>
+
+        {loading && (
+          <div
+            role="status"
+            className="mt-4 flex items-center gap-2 rounded-lg border border-primary-active bg-accent p-3 text-sm text-primary-active"
+          >
+            <CircleNotch aria-hidden className="size-4 animate-spin" />
+            ファイルを処理中...
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="mt-4 rounded-lg border border-destructive bg-destructive-hover p-3 text-sm text-destructive"
+          >
+            エラー: {error}
+          </div>
+        )}
       </div>
-
-      {loading && (
-        <div className="bg-card/50 rounded-lg p-4">
-          <p className="text-muted-foreground">ファイルを処理中...</p>
-        </div>
-      )}
-
-      {error && (
-        <div className="bg-red-500/20 rounded-lg p-4">
-          <p className="text-red-500">エラー: {error}</p>
-        </div>
-      )}
 
       {previewResult && !loading && (
         <DonorCsvPreview result={previewResult} onImport={handleImport} isImporting={isImporting} />

--- a/admin/src/client/components/donor-csv-import/DonorCsvPreview.tsx
+++ b/admin/src/client/components/donor-csv-import/DonorCsvPreview.tsx
@@ -8,9 +8,21 @@ import type {
   PreviewDonorCsvRow,
   PreviewDonorCsvRowStatus,
 } from "@/server/contexts/report/domain/models/preview-donor-csv-row";
-import DonorCsvRow from "./DonorCsvRow";
+import DonorCsvRow from "@/client/components/donor-csv-import/DonorCsvRow";
 import { ClientPagination } from "@/client/components/ui/ClientPagination";
-import { Button, Tooltip, TooltipTrigger, TooltipContent } from "@/client/components/ui";
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/client/components/ui";
+import { cn, resolveDonorCsvStatusBadge } from "@/client/lib";
 
 interface DonorCsvPreviewProps {
   result: PreviewDonorCsvResult;
@@ -23,44 +35,44 @@ type TabKey = "all" | "valid_new" | "valid_existing" | PreviewDonorCsvRowStatus;
 interface TabDefinition {
   key: TabKey;
   label: string;
-  color: string;
   tooltip?: string;
 }
 
 const TABS: TabDefinition[] = [
-  { key: "all", label: "全件", color: "text-foreground" },
+  { key: "all", label: "全件" },
   {
     key: "valid_new",
     label: "新規寄付者",
-    color: "text-green-500",
     tooltip: "寄付者マスタに未登録の寄付者です。インポート時に新規登録されます",
   },
   {
     key: "valid_existing",
     label: "既存寄付者",
-    color: "text-emerald-400",
     tooltip: "寄付者マスタに登録済みの寄付者です。既存データに紐付けられます",
   },
   {
     key: "invalid",
-    label: "エラー",
-    color: "text-red-500",
+    label: resolveDonorCsvStatusBadge("invalid").label,
     tooltip: "CSVの入力値に問題があります（必須項目の欠落、フォーマット不正など）",
   },
   {
     key: "transaction_not_found",
-    label: "取引なし",
-    color: "text-yellow-500",
+    label: resolveDonorCsvStatusBadge("transaction_not_found").label,
     tooltip: "指定された取引Noに対応する取引データが見つかりません",
   },
   {
     key: "type_mismatch",
-    label: "種別不整合",
-    color: "text-orange-500",
+    label: resolveDonorCsvStatusBadge("type_mismatch").label,
     tooltip: "CSVの寄付者種別と取引のカテゴリ種別が一致しません",
   },
 ];
 
+const PER_PAGE = 10;
+
+/**
+ * 寄付者 CSV のプレビュー（白カード・テーブル罫線ルールは取引一覧と同一）。
+ * プレビューの取得は親（DonorCsvImportClient）が行い、本コンポーネントは表示と実行ボタンを担う。
+ */
 export default function DonorCsvPreview({
   result,
   onImport,
@@ -68,7 +80,6 @@ export default function DonorCsvPreview({
 }: DonorCsvPreviewProps) {
   const [activeTab, setActiveTab] = useState<TabKey>("all");
   const [currentPage, setCurrentPage] = useState(1);
-  const perPage = 10;
 
   const validCount = result.summary.valid;
 
@@ -86,8 +97,9 @@ export default function DonorCsvPreview({
   };
 
   const getTabCount = (tab: TabKey): number => {
-    if (tab === "all") return result.summary.total;
     switch (tab) {
+      case "all":
+        return result.summary.total;
       case "valid_new":
         return result.summary.validNew;
       case "valid_existing":
@@ -109,34 +121,40 @@ export default function DonorCsvPreview({
   };
 
   const handlePageChange = (page: number) => {
-    const filteredRows = getFilteredRows();
-    const totalPages = Math.ceil(filteredRows.length / perPage);
+    const totalPages = Math.ceil(getFilteredRows().length / PER_PAGE);
     if (page >= 1 && page <= totalPages) {
       setCurrentPage(page);
     }
   };
 
   const filteredRows = getFilteredRows();
-  const totalPages = Math.ceil(filteredRows.length / perPage);
-  const startIndex = (currentPage - 1) * perPage;
-  const endIndex = startIndex + perPage;
+  const totalPages = Math.ceil(filteredRows.length / PER_PAGE);
+  const startIndex = (currentPage - 1) * PER_PAGE;
+  const endIndex = startIndex + PER_PAGE;
   const currentRows = filteredRows.slice(startIndex, endIndex);
 
   return (
-    <div>
-      <div className="mb-4">
-        <div className="flex gap-2 flex-wrap">
-          {TABS.map(({ key, label, color, tooltip }) => {
+    <div className="rounded-lg border border-border bg-card p-6">
+      <h2 className="text-base font-bold text-foreground">取り込みプレビュー</h2>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2">
+          {TABS.map(({ key, label, tooltip }) => {
             const isActive = activeTab === key;
             const button = (
               <Button
                 type="button"
+                aria-pressed={isActive}
                 variant="outline"
                 size="sm"
                 onClick={() => handleTabChange(key)}
-                className={isActive ? color : "text-muted-foreground"}
+                className={cn(
+                  "text-xs",
+                  isActive && "border-primary-active bg-accent text-primary-active hover:bg-accent",
+                )}
               >
-                {label} ({getTabCount(key)})
+                {label}
+                <span className="font-latin">({getTabCount(key)})</span>
               </Button>
             );
 
@@ -152,68 +170,55 @@ export default function DonorCsvPreview({
             return <span key={key}>{button}</span>;
           })}
         </div>
-      </div>
-
-      <div className="mb-4">
-        <p className="text-muted-foreground text-sm">
+        <p className="text-[13px] text-muted-foreground">
           {filteredRows.length} 件中 {filteredRows.length > 0 ? startIndex + 1 : 0} -{" "}
           {Math.min(endIndex, filteredRows.length)} 件を表示
         </p>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full border-collapse">
-          <thead>
-            <tr className="border-b border-border">
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">行番号</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                ステータス
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">取引No</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                寄付者名
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                寄付者種別
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">住所</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">職業</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">取引日</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">
-                カテゴリ
-              </th>
-              <th className="px-2 py-3 text-right text-sm font-semibold text-foreground">金額</th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-foreground">備考</th>
-            </tr>
-          </thead>
-          <tbody>
+      <div className="mt-4">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead>行番号</TableHead>
+              <TableHead>ステータス</TableHead>
+              <TableHead>取引No</TableHead>
+              <TableHead>寄付者名</TableHead>
+              <TableHead>寄付者種別</TableHead>
+              <TableHead>住所</TableHead>
+              <TableHead>職業</TableHead>
+              <TableHead>取引日</TableHead>
+              <TableHead>カテゴリ</TableHead>
+              <TableHead className="text-right">金額</TableHead>
+              <TableHead>備考</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {currentRows.length === 0 ? (
-              <tr>
-                <td colSpan={11} className="px-2 py-8 text-center text-muted-foreground">
+              <TableRow className="hover:bg-transparent">
+                <TableCell colSpan={11} className="py-8 text-center text-sm text-muted-foreground">
                   表示するデータがありません
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             ) : (
               currentRows.map((row) => <DonorCsvRow key={row.rowNumber} row={row} />)
             )}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
 
-      {totalPages > 1 && (
-        <ClientPagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={handlePageChange}
-        />
-      )}
+      <ClientPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+      />
 
       {onImport && (
         <div className="mt-6 flex justify-end">
           <Button type="button" onClick={onImport} disabled={validCount === 0 || isImporting}>
             {isImporting ? (
               <>
-                <CircleNotch className="mr-2 h-4 w-4 animate-spin" />
+                <CircleNotch aria-hidden className="animate-spin" />
                 インポート中...
               </>
             ) : (

--- a/admin/src/client/components/donor-csv-import/DonorCsvRow.tsx
+++ b/admin/src/client/components/donor-csv-import/DonorCsvRow.tsx
@@ -1,77 +1,73 @@
 import type { PreviewDonorCsvRow } from "@/server/contexts/report/domain/models/preview-donor-csv-row";
 import { DONOR_TYPE_LABELS } from "@/server/contexts/report/domain/models/donor";
+import { TableCell, TableRow } from "@/client/components/ui";
+import { cn, formatAmount, formatDate, resolveDonorCsvStatusBadge } from "@/client/lib";
+import { CategoryPill } from "@/client/components/transactions/CategoryPill";
 
 interface DonorCsvRowProps {
   row: PreviewDonorCsvRow;
 }
 
-const STATUS_STYLES: Record<
-  PreviewDonorCsvRow["status"],
-  { bg: string; text: string; label: string }
-> = {
-  valid: { bg: "bg-green-500/20", text: "text-green-500", label: "正常" },
-  invalid: { bg: "bg-red-500/20", text: "text-red-500", label: "エラー" },
-  transaction_not_found: { bg: "bg-yellow-500/20", text: "text-yellow-500", label: "取引なし" },
-  type_mismatch: { bg: "bg-orange-500/20", text: "text-orange-500", label: "種別不整合" },
-};
-
+/** 寄付者 CSV プレビューの 1 行。日付は YYYY.MM.DD、金額は Poppins 右寄せ、カテゴリは取引一覧と同じピル。 */
 export default function DonorCsvRow({ row }: DonorCsvRowProps) {
-  const statusStyle = STATUS_STYLES[row.status];
-
-  const formatDate = (date: Date | null | undefined) => {
-    if (!date) return "-";
-    return new Date(date).toLocaleDateString("ja-JP");
-  };
-
-  const formatAmount = (amount: number | null | undefined) => {
-    if (amount === null || amount === undefined) return "-";
-    return amount.toLocaleString("ja-JP");
-  };
+  const badge = resolveDonorCsvStatusBadge(row.status);
+  const transaction = row.transaction;
 
   return (
-    <tr className="border-b border-border hover:bg-white/5">
-      <td className="px-2 py-3 text-sm">{row.rowNumber}</td>
-      <td className="px-2 py-3">
+    <TableRow>
+      <TableCell className="font-latin text-xs text-muted-foreground">{row.rowNumber}</TableCell>
+      <TableCell>
         <span
-          className={`px-2 py-1 rounded text-xs font-medium ${statusStyle.bg} ${statusStyle.text}`}
+          className={cn(
+            "inline-block rounded-full border-[1.5px] px-3 py-[3px] text-[11px] font-bold leading-none tracking-[0.04em] whitespace-nowrap",
+            badge.className,
+          )}
         >
-          {statusStyle.label}
+          {badge.label}
         </span>
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">{row.transactionNo || "-"}</td>
-      <td className="px-2 py-3 text-sm text-foreground">{row.name || "-"}</td>
-      <td className="px-2 py-3 text-sm text-foreground">
+      </TableCell>
+      <TableCell className="font-latin text-xs text-muted-foreground">
+        {row.transactionNo || "-"}
+      </TableCell>
+      <TableCell className="text-[13px] font-medium">{row.name || "-"}</TableCell>
+      <TableCell className="text-[13px]">
         {row.donorType ? DONOR_TYPE_LABELS[row.donorType] : "-"}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">{row.address || "-"}</td>
-      <td className="px-2 py-3 text-sm text-foreground">{row.occupation || "-"}</td>
-      <td className="px-2 py-3 text-sm text-foreground">
-        {formatDate(row.transaction?.transactionDate)}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground">
-        {row.transaction?.friendlyCategory || row.transaction?.categoryKey || "-"}
-      </td>
-      <td className="px-2 py-3 text-sm text-foreground text-right">
-        {formatAmount(row.transaction?.creditAmount)}
-      </td>
-      <td className="px-2 py-3 text-sm">
+      </TableCell>
+      <TableCell className="max-w-[200px] truncate text-xs text-muted-foreground">
+        {row.address || "-"}
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">{row.occupation || "-"}</TableCell>
+      <TableCell className="font-latin text-[13px]">
+        {transaction ? formatDate(transaction.transactionDate) : "-"}
+      </TableCell>
+      <TableCell>
+        {transaction ? (
+          <CategoryPill categoryKey={transaction.categoryKey} />
+        ) : (
+          <span className="text-xs text-muted-foreground">-</span>
+        )}
+      </TableCell>
+      <TableCell className="font-latin text-right text-[13px] font-semibold">
+        {transaction ? formatAmount(transaction.creditAmount) : "-"}
+      </TableCell>
+      <TableCell className="whitespace-normal align-top text-xs">
         {row.errors.length > 0 && (
-          <ul className="text-destructive text-xs list-disc list-inside">
+          <ul className="list-inside list-disc text-destructive">
             {row.errors.map((error) => (
               <li key={error}>{error}</li>
             ))}
           </ul>
         )}
-        {row.transaction?.existingDonor && (
-          <div className="text-yellow-600 text-xs mt-1">
-            既存: {row.transaction.existingDonor.name} (
-            {DONOR_TYPE_LABELS[row.transaction.existingDonor.donorType]})
+        {transaction?.existingDonor && (
+          <div className="mt-1 text-muted-foreground">
+            既存: {transaction.existingDonor.name} (
+            {DONOR_TYPE_LABELS[transaction.existingDonor.donorType]})
           </div>
         )}
         {row.matchingDonor && (
-          <div className="text-muted-foreground text-xs mt-1">一致: {row.matchingDonor.name}</div>
+          <div className="mt-1 text-muted-foreground">一致: {row.matchingDonor.name}</div>
         )}
-      </td>
-    </tr>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
+++ b/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
@@ -1,16 +1,14 @@
 "use client";
+import "client-only";
 
-import { useState } from "react";
+import { useId, useState } from "react";
+import { CircleNotch, MagnifyingGlass, Trash } from "@phosphor-icons/react/dist/ssr";
 import { toast } from "sonner";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
 import { PageHeader } from "@/client/components/layout/PageHeader";
 import {
   Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
   Input,
   Label,
   Table,
@@ -26,6 +24,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/client/components/ui";
+import { formatAmount, formatDate } from "@/client/lib";
 import { bulkDeleteTransactionsAction } from "@/server/contexts/data-import/presentation/actions/bulk-delete-transactions";
 import type { BulkDeleteSearchResult } from "@/server/contexts/data-import/presentation/types";
 
@@ -34,6 +33,7 @@ export function BulkDeleteTransactionsClient({
 }: {
   organizations: PoliticalOrganization[];
 }) {
+  const transactionNosInputId = useId();
   const [selectedOrgId, setSelectedOrgId] = useState("");
   const [transactionNosInput, setTransactionNosInput] = useState("");
   const [searchResult, setSearchResult] = useState<BulkDeleteSearchResult | null>(null);
@@ -41,7 +41,8 @@ export function BulkDeleteTransactionsClient({
   const [isDeleting, setIsDeleting] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
 
-  const handleSearch = async () => {
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
     if (!selectedOrgId || !transactionNosInput.trim()) return;
 
     const nos = transactionNosInput
@@ -82,82 +83,115 @@ export function BulkDeleteTransactionsClient({
     }
   };
 
+  const foundTransactions = searchResult?.success ? (searchResult.foundTransactions ?? []) : [];
+  const notFoundNos = searchResult?.success ? (searchResult.notFoundNos ?? []) : [];
+
   return (
     <div>
       <PageHeader label="Bulk Delete" title="取引一括削除" />
 
       <div className="space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>検索条件</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <PoliticalOrganizationSelect
-              organizations={organizations}
-              value={selectedOrgId}
-              onValueChange={(value) => {
-                setSelectedOrgId(value);
-                setSearchResult(null);
-              }}
-              required
-            />
-
-            <div className="space-y-2">
-              <Label>取引番号（カンマ区切り）</Label>
+        <form
+          onSubmit={handleSearch}
+          className="max-w-[720px] rounded-lg border border-border bg-card p-7"
+        >
+          <h2 className="text-base font-bold text-foreground">検索条件</h2>
+          <div className="mt-4 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs font-bold">
+                政治団体 <span className="text-destructive">*</span>
+              </Label>
+              <PoliticalOrganizationSelect
+                organizations={organizations}
+                value={selectedOrgId}
+                onValueChange={(value) => {
+                  setSelectedOrgId(value);
+                  setSearchResult(null);
+                }}
+                required
+                hideLabel
+                className="w-full"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor={transactionNosInputId} className="text-xs font-bold">
+                取引番号（カンマ区切り） <span className="text-destructive">*</span>
+              </Label>
               <Input
+                id={transactionNosInputId}
                 placeholder="例: 1,5,8,20"
                 value={transactionNosInput}
                 onChange={(e) => setTransactionNosInput(e.target.value)}
+                className="border-[1.5px] font-latin text-[13px]"
               />
             </div>
+          </div>
 
+          <div className="mt-6 flex justify-end">
             <Button
-              onClick={handleSearch}
+              type="submit"
+              variant="outline"
+              className="text-[13px]"
               disabled={!selectedOrgId || !transactionNosInput.trim() || isSearching}
             >
-              {isSearching ? "検索中..." : "検索"}
+              {isSearching ? (
+                <>
+                  <CircleNotch aria-hidden className="animate-spin" />
+                  検索中...
+                </>
+              ) : (
+                <>
+                  <MagnifyingGlass aria-hidden />
+                  検索
+                </>
+              )}
             </Button>
-          </CardContent>
-        </Card>
+          </div>
+        </form>
 
         {searchResult && !searchResult.success && (
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-red-600 font-medium">エラー: {searchResult.error}</p>
-            </CardContent>
-          </Card>
+          <div
+            role="alert"
+            className="max-w-[720px] rounded-lg border border-destructive bg-destructive-hover p-4 text-sm text-destructive"
+          >
+            エラー: {searchResult.error}
+          </div>
         )}
 
         {searchResult?.success && (
           <>
-            {searchResult.notFoundNos && searchResult.notFoundNos.length > 0 && (
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-amber-600">
-                    該当なし ({searchResult.notFoundNos.length}件)
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-muted-foreground">
-                    以下の取引番号は見つかりませんでした:{" "}
-                    <span className="font-mono">{searchResult.notFoundNos.join(", ")}</span>
-                  </p>
-                </CardContent>
-              </Card>
+            {notFoundNos.length > 0 && (
+              <div className="max-w-[720px] rounded-lg border border-border bg-card p-6">
+                <h2 className="text-base font-bold text-foreground">
+                  該当なし <span className="font-latin">({notFoundNos.length}件)</span>
+                </h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  以下の取引番号は見つかりませんでした:{" "}
+                  <span className="font-latin text-foreground">{notFoundNos.join(", ")}</span>
+                </p>
+              </div>
             )}
 
-            {searchResult.foundTransactions && searchResult.foundTransactions.length > 0 && (
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between">
-                  <CardTitle>削除対象 ({searchResult.foundTransactions.length}件)</CardTitle>
-                  <Button variant="destructive" onClick={() => setShowConfirmDialog(true)}>
+            {foundTransactions.length > 0 && (
+              <div className="rounded-lg border border-border bg-card p-6">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <h2 className="text-base font-bold text-foreground">
+                    削除対象 <span className="font-latin">({foundTransactions.length}件)</span>
+                  </h2>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    className="text-[13px]"
+                    onClick={() => setShowConfirmDialog(true)}
+                  >
+                    <Trash aria-hidden />
                     削除
                   </Button>
-                </CardHeader>
-                <CardContent>
+                </div>
+                <div className="mt-4">
                   <Table>
                     <TableHeader>
-                      <TableRow>
+                      <TableRow className="hover:bg-transparent">
                         <TableHead>取引番号</TableHead>
                         <TableHead>取引日</TableHead>
                         <TableHead>摘要</TableHead>
@@ -166,51 +200,73 @@ export function BulkDeleteTransactionsClient({
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {searchResult.foundTransactions.map((t) => (
+                      {foundTransactions.map((t) => (
                         <TableRow key={t.id}>
-                          <TableCell className="font-mono">{t.transactionNo}</TableCell>
-                          <TableCell>{t.transactionDate}</TableCell>
-                          <TableCell>{t.description}</TableCell>
-                          <TableCell className="text-right">
-                            {t.debitAmount.toLocaleString()}
+                          <TableCell className="font-latin text-xs text-muted-foreground">
+                            {t.transactionNo}
                           </TableCell>
-                          <TableCell className="text-right">
-                            {t.creditAmount.toLocaleString()}
+                          <TableCell className="font-latin text-[13px]">
+                            {formatDate(t.transactionDate)}
+                          </TableCell>
+                          <TableCell className="max-w-[200px] text-xs text-muted-foreground">
+                            <div className="truncate" title={t.description || undefined}>
+                              {t.description || "-"}
+                            </div>
+                          </TableCell>
+                          <TableCell className="font-latin text-right text-[13px] font-semibold">
+                            {formatAmount(t.debitAmount)}
+                          </TableCell>
+                          <TableCell className="font-latin text-right text-[13px] font-semibold">
+                            {formatAmount(t.creditAmount)}
                           </TableCell>
                         </TableRow>
                       ))}
                     </TableBody>
                   </Table>
-                </CardContent>
-              </Card>
+                </div>
+              </div>
             )}
 
-            {searchResult.foundTransactions?.length === 0 &&
-              searchResult.notFoundNos?.length === 0 && (
-                <Card>
-                  <CardContent className="pt-6">
-                    <p className="text-muted-foreground">該当する取引はありません。</p>
-                  </CardContent>
-                </Card>
-              )}
+            {foundTransactions.length === 0 && notFoundNos.length === 0 && (
+              <div className="max-w-[720px] rounded-lg border border-border bg-card px-6 py-8 text-center">
+                <p className="text-sm text-muted-foreground">該当する取引はありません。</p>
+              </div>
+            )}
           </>
         )}
 
         <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
-          <DialogContent>
+          <DialogContent className="max-w-md">
             <DialogHeader>
               <DialogTitle>取引の一括削除</DialogTitle>
               <DialogDescription>
-                {searchResult?.foundTransactions?.length}
+                <span className="font-latin">{foundTransactions.length}</span>
                 件の取引を削除します。この操作は取り消せません。
               </DialogDescription>
             </DialogHeader>
             <DialogFooter>
-              <Button variant="outline" onClick={() => setShowConfirmDialog(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setShowConfirmDialog(false)}
+                disabled={isDeleting}
+              >
                 キャンセル
               </Button>
-              <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
-                {isDeleting ? "削除中..." : "削除する"}
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={isDeleting}
+              >
+                {isDeleting ? (
+                  <>
+                    <CircleNotch aria-hidden className="animate-spin" />
+                    削除中...
+                  </>
+                ) : (
+                  "削除する"
+                )}
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/admin/src/client/lib/donor-csv-status-badge.ts
+++ b/admin/src/client/lib/donor-csv-status-badge.ts
@@ -1,0 +1,35 @@
+import type { PreviewDonorCsvRowStatus } from "@/server/contexts/report/domain/models/preview-donor-csv-row";
+
+interface DonorCsvStatusBadge {
+  label: string;
+  /** ピルバッジの色クラス。正常 = teal 系、取引なし = グレー系、エラー・種別不整合 = 赤系（ブランド外の色は使わない） */
+  className: string;
+}
+
+const DONOR_CSV_STATUS_BADGES: Record<PreviewDonorCsvRowStatus, DonorCsvStatusBadge> = {
+  valid: {
+    label: "正常",
+    className: "border-primary-active text-primary-active bg-accent",
+  },
+  transaction_not_found: {
+    label: "取引なし",
+    className: "border-subtle-foreground text-muted-foreground bg-secondary",
+  },
+  invalid: {
+    label: "エラー",
+    className: "border-destructive text-destructive bg-card",
+  },
+  type_mismatch: {
+    label: "種別不整合",
+    className: "border-destructive text-destructive bg-card",
+  },
+};
+
+/**
+ * 寄付者 CSV プレビューの行状態（正常 / 取引なし / エラー / 種別不整合）を
+ * バッジ表示用のラベルと色クラスに解決する。
+ * 語彙は teal（取り込まれる）/ グレー（紐付け先が無く取り込まれない）/ 赤（入力に問題がある）の 3 系統に限定する。
+ */
+export function resolveDonorCsvStatusBadge(status: PreviewDonorCsvRowStatus): DonorCsvStatusBadge {
+  return DONOR_CSV_STATUS_BADGES[status];
+}

--- a/admin/src/client/lib/format.ts
+++ b/admin/src/client/lib/format.ts
@@ -27,3 +27,15 @@ export function formatAmount(amount: number): string {
 export function formatCurrency(amount: number): string {
   return `¥${amount.toLocaleString("ja-JP")}`;
 }
+
+/**
+ * 日時を YYYY.MM.DD HH:mm 形式でフォーマットする（登録日時など、時刻まで示す場合）
+ * @param date - フォーマットする日時
+ * @returns フォーマットされた日時文字列（例: 2025.01.31 09:05）
+ */
+export function formatDateTime(date: Date | string): string {
+  const d = new Date(date);
+  const hours = String(d.getHours()).padStart(2, "0");
+  const minutes = String(d.getMinutes()).padStart(2, "0");
+  return `${formatDate(d)} ${hours}:${minutes}`;
+}

--- a/admin/src/client/lib/index.ts
+++ b/admin/src/client/lib/index.ts
@@ -1,8 +1,9 @@
 export { cn } from "./utils";
-export { formatDate, formatAmount, formatCurrency } from "./format";
+export { formatDate, formatDateTime, formatAmount, formatCurrency } from "./format";
 export { resolveCategoryPill, resolveCategoryPillByKey } from "./category-pill";
 export type { CategoryPillSource } from "./category-pill";
 export { resolveUserRoleBadge } from "./user-role-badge";
 export { resolveDonorTypeBadge } from "./donor-type-badge";
 export { resolveAssignmentStatusBadge } from "./assignment-status-badge";
 export { resolvePreviewStatusBadge } from "./preview-status-badge";
+export { resolveDonorCsvStatusBadge } from "./donor-csv-status-badge";

--- a/admin/src/server/contexts/data-import/presentation/loaders/load-transactions-by-nos.ts
+++ b/admin/src/server/contexts/data-import/presentation/loaders/load-transactions-by-nos.ts
@@ -11,6 +11,8 @@ export type BulkDeleteSearchResult = {
     description: string;
     debitAmount: number;
     creditAmount: number;
+    /** ISO 8601 文字列。表示側で YYYY.MM.DD に整形する */
+    /** ISO 8601 文字列。表示側で YYYY.MM.DD に整形する */
     transactionDate: string;
   }>;
   notFoundNos?: string[];
@@ -36,7 +38,7 @@ export async function loadTransactionsByNos(
         description: t.description || "",
         debitAmount: t.debit_amount,
         creditAmount: t.credit_amount,
-        transactionDate: new Date(t.transaction_date).toLocaleDateString("ja-JP"),
+        transactionDate: new Date(t.transaction_date).toISOString(),
       })),
       notFoundNos,
     };

--- a/admin/tests/client/lib/donor-csv-status-badge.test.ts
+++ b/admin/tests/client/lib/donor-csv-status-badge.test.ts
@@ -1,0 +1,36 @@
+import { resolveDonorCsvStatusBadge } from "@/client/lib/donor-csv-status-badge";
+
+describe("resolveDonorCsvStatusBadge", () => {
+  it("正常は teal 塗り（accent 背景・teal-deep 文字）になる", () => {
+    const badge = resolveDonorCsvStatusBadge("valid");
+    expect(badge.label).toBe("正常");
+    expect(badge.className).toContain("bg-accent");
+    expect(badge.className).toContain("text-primary-active");
+  });
+
+  it("取引なしはグレー系（secondary 背景・muted 文字）になる", () => {
+    const badge = resolveDonorCsvStatusBadge("transaction_not_found");
+    expect(badge.label).toBe("取引なし");
+    expect(badge.className).toContain("bg-secondary");
+    expect(badge.className).toContain("text-muted-foreground");
+  });
+
+  it("エラーと種別不整合は赤枠・赤文字の白地になる", () => {
+    for (const status of ["invalid", "type_mismatch"] as const) {
+      const badge = resolveDonorCsvStatusBadge(status);
+      expect(badge.className).toContain("border-destructive");
+      expect(badge.className).toContain("text-destructive");
+      expect(badge.className).toContain("bg-card");
+    }
+    expect(resolveDonorCsvStatusBadge("invalid").label).toBe("エラー");
+    expect(resolveDonorCsvStatusBadge("type_mismatch").label).toBe("種別不整合");
+  });
+
+  it("旧テーマの Tailwind パレット直書きを含まない", () => {
+    for (const status of ["valid", "invalid", "transaction_not_found", "type_mismatch"] as const) {
+      expect(resolveDonorCsvStatusBadge(status).className).not.toMatch(
+        /(red|green|blue|yellow|purple|orange|gray|slate|amber|emerald)-\d{3}/,
+      );
+    }
+  });
+});

--- a/admin/tests/client/lib/format.test.ts
+++ b/admin/tests/client/lib/format.test.ts
@@ -1,5 +1,6 @@
 import {
   formatDate,
+  formatDateTime,
   formatAmount,
   formatCurrency,
 } from "@/client/lib/format";
@@ -116,5 +117,16 @@ describe("formatAmount vs formatCurrency", () => {
     // For basic integer amounts, both should produce similar results
     expect(formatAmount(1000)).toBe(formatCurrency(1000));
     expect(formatAmount(0)).toBe(formatCurrency(0));
+  });
+});
+
+describe("formatDateTime", () => {
+  it("formats to YYYY.MM.DD HH:mm with zero-padding", () => {
+    expect(formatDateTime(new Date(2025, 0, 5, 9, 7))).toBe("2025.01.05 09:07");
+    expect(formatDateTime(new Date(2025, 11, 31, 23, 59))).toBe("2025.12.31 23:59");
+  });
+
+  it("accepts date strings", () => {
+    expect(formatDateTime("2025-06-15T14:30:00")).toBe("2025.06.15 14:30");
   });
 });


### PR DESCRIPTION
## 目的（Why）

admin リデザイン（土台 #1289、ページヘッダー #1291、CSV アップロード #1298）の一環として、サイドバー「データ取り込み」配下で旧テーマのままだった 3 画面（寄付者一括インポート・残高登録・取引一括削除）を、管理者がほかの画面と同じ Team Mirai の語彙（白カード・黒枠・ピル・teal / グレー / 赤）で迷わず操作できる状態にするため。

## 変更内容

### 寄付者一括インポート
- CSV アップロード画面と同じ max-width 720px の白カードに、政治団体のピル select（12px/700 ラベル + 赤 `*`）と `CsvDropzone`（1.5px dashed teal・teal-100 背景）を配置
- プレビューを白カード + `ui/table` の罫線ルールに置き換え。行状態バッジは新設の `resolveDonorCsvStatusBadge`（正常 = teal、取引なし = グレー、エラー / 種別不整合 = 赤）
- 日付は `YYYY.MM.DD`、金額は Poppins 右寄せ、カテゴリは取引一覧と同じ `CategoryPill`
- 処理中 / エラー表示を teal / 赤の語彙に統一。実行ボタンは teal 塗りピル

### 残高登録
- 政治団体 select + 登録フォーム、現在有効な残高、履歴一覧をそれぞれ白カードに分割
- フォームはピル入力・12px/700 ラベル・teal 実行ボタン。日付エラーは `aria-invalid` で赤枠
- 履歴は `ui/table`、削除は destructive の小ピル。日付 `YYYY.MM.DD`、登録日時は新設の `formatDateTime`（`YYYY.MM.DD HH:mm`）、金額は Poppins 右寄せ

### 取引一括削除
- 検索条件を白カード + ピル入力 + 黒枠「検索」ピル（`MagnifyingGlass`）に、削除対象を白カード + `ui/table` に置き換え
- 実行ボタンと確認ダイアログの実行ボタンは赤枠白地赤文字（`variant="destructive"`）。ダイアログは既存の `ui/dialog`（白・黒1px枠・角丸8px）
- 取引日は loader が ISO 文字列を返し、表示側で `formatDate` により `YYYY.MM.DD` に整形（ロジック変更なし）

### 共通
- `CsvDropzone`: 親がファイルを破棄したら hidden input も空にし、同じファイルを再選択できるようにする
- 旧テーマ前提の Tailwind パレット直書き（`red-500` / `green-500` / `yellow-500` / `orange-500` / `amber-600` / `emerald-400` / `[color-scheme:dark]` 等）をこれらの画面から除去
- E2E: 寄付者一括インポートのファイル入力ラベルを `CSV File:` から `CSVファイル` に更新

Closes #1299

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅
- `pnpm supabase:start && pnpm db:reset && pnpm test:e2e`: ✅ webapp 15 passed / admin 42 passed

## スコープアウトして起票した Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - CSV寄付者インポートで、ドラッグ＆ドロップ対応のファイル選択、状態バッジ、プレビュー表示を改善しました。
  - 同じCSVファイルを再選択できるようになりました。
  - 残高スナップショット画面をレスポンシブなカード構成に刷新しました。

- **改善**
  - 日付・金額表示を統一し、読み込み中のスピナーを追加しました。
  - 入力項目のラベルやエラー状態を改善し、アクセシビリティを向上しました。
  - 一括削除画面の検索・削除操作と確認ダイアログを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->