### PR TITLE
test(e2e): 価値の薄い E2E テストを統合・削除する

### DIFF
--- a/admin/e2e/tests/counterparts.spec.ts
+++ b/admin/e2e/tests/counterparts.spec.ts
@@ -2,42 +2,15 @@ import { test, expect } from "@playwright/test";
 
 test.describe("取引先マスタ管理", () => {
 	test.describe("読み込み", () => {
-		test("取引先マスタページが正常に表示される", async ({ page }) => {
+		test("取引先マスタページにシードデータと検索フォームが表示される", async ({ page }) => {
 			await page.goto("/counterparts");
 
 			await expect(page.getByRole("heading", { name: "取引先マスタ管理" })).toBeVisible();
 			await expect(page.getByRole("button", { name: "新規作成" })).toBeVisible();
-		});
-
-		test("シードデータの取引先が一覧に表示される", async ({ page }) => {
-			await page.goto("/counterparts");
+			await expect(page.getByLabel("取引先を名前または住所で検索")).toBeVisible();
 
 			await expect(page.getByRole("link", { name: "寄附　太郎" })).toBeVisible();
 			await expect(page.getByRole("link", { name: "東京電力株式会社" })).toBeVisible();
-		});
-
-		test("検索フォームが表示される", async ({ page }) => {
-			await page.goto("/counterparts");
-
-			await expect(
-				page.getByLabel("取引先を名前または住所で検索")
-			).toBeVisible();
-			await expect(page.getByRole("button", { name: "検索" })).toBeVisible();
-		});
-
-		test("テーブルヘッダーが正しく表示される", async ({ page }) => {
-			await page.goto("/counterparts");
-
-			await expect(page.getByRole("columnheader", { name: "名前" })).toBeVisible();
-			await expect(page.getByRole("columnheader", { name: "住所" })).toBeVisible();
-			await expect(page.getByRole("columnheader", { name: "使用数" })).toBeVisible();
-			await expect(page.getByRole("columnheader", { name: "操作" })).toBeVisible();
-		});
-
-		test("取引先の件数が表示される", async ({ page }) => {
-			await page.goto("/counterparts");
-
-			await expect(page.getByText(/\d+件の取引先/)).toBeVisible();
 		});
 	});
 

--- a/admin/e2e/tests/dashboard.spec.ts
+++ b/admin/e2e/tests/dashboard.spec.ts
@@ -1,17 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("ダッシュボード", () => {
-	test.beforeEach(async ({ page }) => {
+	test("ログイン後にダッシュボードが表示される", async ({ page }) => {
 		await page.goto("/");
-	});
 
-	test.describe("読み込み", () => {
-		test("ログイン後にダッシュボードが正常に表示される", async ({ page }) => {
-			await expect(page.getByRole("heading", { name: "ダッシュボード" })).toBeVisible();
-		});
-
-		test("Welcomeメッセージが表示される", async ({ page }) => {
-			await expect(page.getByText("Use the left navigation to manage data.")).toBeVisible();
-		});
+		await expect(page.getByRole("heading", { name: "ダッシュボード" })).toBeVisible();
 	});
 });

--- a/admin/e2e/tests/import-donors.spec.ts
+++ b/admin/e2e/tests/import-donors.spec.ts
@@ -1,5 +1,21 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import path from "node:path";
+
+const SAMPLE_CSV_PATH = path.resolve(process.cwd(), "../data/sample_donor_import.csv");
+
+/**
+ * 寄付者一括インポートページを開き、サンプル CSV をアップロードしてプレビューが
+ * 表示される（「全件」タブが出る）まで待つ。
+ */
+async function uploadSampleCsv(page: Page) {
+	await page.goto("/import-donors");
+
+	await page.getByLabel("CSVファイル", { exact: true }).setInputFiles(SAMPLE_CSV_PATH);
+
+	await expect(page.getByRole("button", { name: /全件/ })).toBeVisible({
+		timeout: 10000,
+	});
+}
 
 test.describe("寄付者一括インポート", () => {
 	test.describe("読み込み", () => {
@@ -9,16 +25,10 @@ test.describe("寄付者一括インポート", () => {
 			await expect(
 				page.getByRole("heading", { name: "寄付者一括インポート" }),
 			).toBeVisible();
-			await expect(page.getByRole("combobox")).toBeVisible();
 			await expect(page.getByLabel("CSVファイル", { exact: true })).toBeVisible();
-		});
-
-		test("政治団体セレクターが表示される", async ({ page }) => {
-			await page.goto("/import-donors");
 
 			const selector = page.getByRole("combobox");
 			await expect(selector).toBeVisible();
-
 			await selector.click();
 			await expect(
 				page.getByRole("option", { name: "サンプル党" }),
@@ -27,23 +37,11 @@ test.describe("寄付者一括インポート", () => {
 	});
 
 	test.describe("CSVプレビュー", () => {
-		test("CSVファイルをアップロードするとプレビューが表示される", async ({
+		test("CSVファイルをアップロードするとタブ付きのプレビューテーブルが表示される", async ({
 			page,
 		}) => {
-			await page.goto("/import-donors");
+			await uploadSampleCsv(page);
 
-			const fileInput = page.getByLabel("CSVファイル", { exact: true });
-			const csvPath = path.resolve(
-				process.cwd(),
-				"../data/sample_donor_import.csv",
-			);
-			await fileInput.setInputFiles(csvPath);
-
-			await expect(page.getByText("ファイルを処理中...")).toBeVisible();
-
-			await expect(page.getByRole("button", { name: /全件/ })).toBeVisible({
-				timeout: 10000,
-			});
 			await expect(
 				page.getByRole("button", { name: /新規寄付者/ }),
 			).toBeVisible();
@@ -55,25 +53,9 @@ test.describe("寄付者一括インポート", () => {
 			await expect(
 				page.getByRole("button", { name: /種別不整合/ }),
 			).toBeVisible();
-		});
-
-		test("プレビューテーブルにデータが表示される", async ({ page }) => {
-			await page.goto("/import-donors");
-
-			const fileInput = page.getByLabel("CSVファイル", { exact: true });
-			const csvPath = path.resolve(
-				process.cwd(),
-				"../data/sample_donor_import.csv",
-			);
-			await fileInput.setInputFiles(csvPath);
-
-			await expect(page.getByRole("button", { name: /全件/ })).toBeVisible({
-				timeout: 10000,
-			});
 
 			const table = page.locator("table");
 			await expect(table).toBeVisible();
-
 			await expect(
 				table.getByRole("columnheader", { name: "行番号" }),
 			).toBeVisible();
@@ -89,24 +71,11 @@ test.describe("寄付者一括インポート", () => {
 			await expect(
 				table.getByRole("columnheader", { name: "寄付者種別" }),
 			).toBeVisible();
-
-			const rows = table.locator("tbody tr");
-			await expect(rows).not.toHaveCount(0);
+			await expect(table.locator("tbody tr")).not.toHaveCount(0);
 		});
 
 		test("タブをクリックするとフィルタリングされる", async ({ page }) => {
-			await page.goto("/import-donors");
-
-			const fileInput = page.getByLabel("CSVファイル", { exact: true });
-			const csvPath = path.resolve(
-				process.cwd(),
-				"../data/sample_donor_import.csv",
-			);
-			await fileInput.setInputFiles(csvPath);
-
-			await expect(page.getByRole("button", { name: /全件/ })).toBeVisible({
-				timeout: 10000,
-			});
+			await uploadSampleCsv(page);
 
 			const allTabButton = page.getByRole("button", { name: /全件/ });
 			const allTabText = await allTabButton.textContent();
@@ -126,18 +95,7 @@ test.describe("寄付者一括インポート", () => {
 		});
 
 		test("ツールチップが表示される", async ({ page }) => {
-			await page.goto("/import-donors");
-
-			const fileInput = page.getByLabel("CSVファイル", { exact: true });
-			const csvPath = path.resolve(
-				process.cwd(),
-				"../data/sample_donor_import.csv",
-			);
-			await fileInput.setInputFiles(csvPath);
-
-			await expect(page.getByRole("button", { name: /全件/ })).toBeVisible({
-				timeout: 10000,
-			});
+			await uploadSampleCsv(page);
 
 			const newDonorButton = page.getByRole("button", { name: /新規寄付者/ });
 			await newDonorButton.hover();
@@ -148,7 +106,7 @@ test.describe("寄付者一括インポート", () => {
 		});
 
 		test.describe("CSVインポート確定", () => {
-			// この describe 配下の 2 テストは同じ寄付者 CSV を実際に DB へ書き込む。
+			// この describe 配下のテストは同じ寄付者 CSV を実際に DB へ書き込む。
 			// fullyParallel のまま並列に走ると同じ寄付者を同時に createMany して
 			// 一意制約違反で失敗するため、describe 単位で fullyParallel を解除し
 			// 同一ワーカーで順番に実行する（serial と違い、1 件失敗しても以降は skip されない）。
@@ -157,18 +115,7 @@ test.describe("寄付者一括インポート", () => {
 			test("有効な行がある場合、インポートボタンが表示される", async ({
 				page,
 			}) => {
-				await page.goto("/import-donors");
-
-				const fileInput = page.getByLabel("CSVファイル", { exact: true });
-				const csvPath = path.resolve(
-					process.cwd(),
-					"../data/sample_donor_import.csv",
-				);
-				await fileInput.setInputFiles(csvPath);
-
-				await expect(page.getByRole("button", { name: /全件/ })).toBeVisible({
-					timeout: 10000,
-				});
+				await uploadSampleCsv(page);
 
 				const importButton = page.getByRole("button", { name: /件をインポート/ });
 				await expect(importButton).toBeVisible();
@@ -178,18 +125,7 @@ test.describe("寄付者一括インポート", () => {
 			test("インポートボタンをクリックするとインポートが実行される", async ({
 				page,
 			}) => {
-				await page.goto("/import-donors");
-
-				const fileInput = page.getByLabel("CSVファイル", { exact: true });
-				const csvPath = path.resolve(
-					process.cwd(),
-					"../data/sample_donor_import.csv",
-				);
-				await fileInput.setInputFiles(csvPath);
-
-				await expect(page.getByRole("button", { name: /全件/ })).toBeVisible({
-					timeout: 10000,
-				});
+				await uploadSampleCsv(page);
 
 				const importButton = page.getByRole("button", { name: /件をインポート/ });
 				await expect(importButton).toBeVisible();
@@ -212,18 +148,7 @@ test.describe("寄付者一括インポート", () => {
 			test("インポート成功後、ファイル入力がリセットされる", async ({
 				page,
 			}) => {
-				await page.goto("/import-donors");
-
-				const fileInput = page.getByLabel("CSVファイル", { exact: true });
-				const csvPath = path.resolve(
-					process.cwd(),
-					"../data/sample_donor_import.csv",
-				);
-				await fileInput.setInputFiles(csvPath);
-
-				await expect(page.getByRole("button", { name: /全件/ })).toBeVisible({
-					timeout: 10000,
-				});
+				await uploadSampleCsv(page);
 
 				const importButton = page.getByRole("button", { name: /件をインポート/ });
 				await importButton.click();

--- a/admin/e2e/tests/transactions.spec.ts
+++ b/admin/e2e/tests/transactions.spec.ts
@@ -2,62 +2,36 @@ import { test, expect } from "@playwright/test";
 
 test.describe("取引一覧", () => {
 	test.describe("読み込み", () => {
-		test("取引一覧ページが正常に表示される", async ({ page }) => {
+		test("取引一覧ページにシードデータの取引が表示される", async ({ page }) => {
 			await page.goto("/transactions");
 
 			await expect(page.getByRole("heading", { name: "取引一覧" })).toBeVisible();
-			await expect(page.getByRole("combobox")).toBeVisible();
-		});
-
-		test("政治団体セレクターが表示される", async ({ page }) => {
-			await page.goto("/transactions");
 
 			const selector = page.getByRole("combobox");
 			await expect(selector).toBeVisible();
-
 			await selector.click();
 			await expect(page.getByRole("option", { name: "サンプル党" })).toBeVisible();
-		});
-
-		test("シードデータの取引が一覧に表示される", async ({ page }) => {
-			await page.goto("/transactions");
-
-			await expect(page.getByRole("heading", { name: "取引一覧" })).toBeVisible();
-
-			await page.waitForSelector("table");
+			await page.keyboard.press("Escape");
 
 			const table = page.locator("table");
 			await expect(table).toBeVisible();
-
 			await expect(table.getByRole("columnheader", { name: "取引日" })).toBeVisible();
-			await expect(table.getByRole("columnheader", { name: "政治団体" })).toBeVisible();
 			await expect(table.getByRole("columnheader", { name: "借方勘定科目" })).toBeVisible();
-			await expect(table.getByRole("columnheader", { name: "借方金額" })).toBeVisible();
-			await expect(table.getByRole("columnheader", { name: "貸方勘定科目" })).toBeVisible();
-			await expect(table.getByRole("columnheader", { name: "貸方金額" })).toBeVisible();
-			await expect(table.getByRole("columnheader", { name: "種別" })).toBeVisible();
-			await expect(table.getByRole("columnheader", { name: "カテゴリ" })).toBeVisible();
-
-			const rows = table.locator("tbody tr");
-			await expect(rows).not.toHaveCount(0);
+			await expect(table.locator("tbody tr")).not.toHaveCount(0);
 		});
 
-		test("ページネーションが機能する", async ({ page }) => {
+		test("次のページに遷移できる", async ({ page }) => {
+			// シードの sample-party の取引は 1 ページ（50 件）を超えるため、
+			// 「次へ」が必ず表示される前提で決定的に検証する
 			await page.goto("/transactions");
 
-			await page.waitForSelector("table");
+			await expect(page.getByText(/^全 \d+ 件中 1 - 50 件を表示$/)).toBeVisible();
 
-			const paginationInfo = page.getByText(/全 \d+ 件中/);
-			await expect(paginationInfo).toBeVisible();
+			const pagination = page.getByRole("navigation", { name: "pagination" });
+			await pagination.getByRole("link", { name: "次へ" }).click();
 
-			const pagination = page.locator("nav[aria-label='pagination']");
-			if (await pagination.isVisible()) {
-				const nextButton = pagination.getByRole("link", { name: /次/ });
-				if (await nextButton.isVisible()) {
-					await nextButton.click();
-					await expect(page).toHaveURL(/page=2/);
-				}
-			}
+			await expect(page).toHaveURL(/page=2/);
+			await expect(page.getByText(/^全 \d+ 件中 51 - \d+ 件を表示$/)).toBeVisible();
 		});
 	});
 });

--- a/admin/e2e/tests/user-info.spec.ts
+++ b/admin/e2e/tests/user-info.spec.ts
@@ -1,30 +1,11 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("ユーザー情報", () => {
-	test.describe("読み込み", () => {
-		test("ユーザー情報ページが正常に表示される", async ({ page }) => {
-			await page.goto("/user-info");
+	test("ログイン中のユーザー情報が表示される", async ({ page }) => {
+		await page.goto("/user-info");
 
-			await expect(page.getByRole("heading", { name: "ユーザー情報" })).toBeVisible();
-		});
-
-		test("ログイン中のユーザーのメールアドレスが表示される", async ({ page }) => {
-			await page.goto("/user-info");
-
-			// サイドバーのフッターにもメールアドレスが表示されるため、本文領域にスコープする
-			await expect(page.getByRole("main").getByText("foo@example.com")).toBeVisible();
-		});
-
-		test("ロール情報が表示される", async ({ page }) => {
-			await page.goto("/user-info");
-
-			await expect(page.getByText("ロール:")).toBeVisible();
-		});
-
-		test("作成日が表示される", async ({ page }) => {
-			await page.goto("/user-info");
-
-			await expect(page.getByText("作成日:")).toBeVisible();
-		});
+		await expect(page.getByRole("heading", { name: "ユーザー情報" })).toBeVisible();
+		// サイドバーのフッターにもメールアドレスが表示されるため、本文領域にスコープする
+		await expect(page.getByRole("main").getByText("foo@example.com")).toBeVisible();
 	});
 });

--- a/webapp/e2e/tests/organization.spec.ts
+++ b/webapp/e2e/tests/organization.spec.ts
@@ -61,13 +61,6 @@ test.describe("政治団体ページ", () => {
 			await expect(page).toHaveURL(/\/o\/[\w-]+\/2026$/);
 			await expect(page).not.toHaveURL(/non-existent-org/);
 		});
-
-		test("収支の流れセクションが表示される", async ({ page }) => {
-			await page.goto("/o/sample-party/2026");
-
-			// 収支の流れセクションが存在することを確認（メインコンテンツ内のセクション）
-			await expect(page.locator("#cash-flow").getByText("収支の流れ")).toBeVisible();
-		});
 	});
 
 	test.describe("政治団体・年度セレクター", () => {
@@ -89,19 +82,9 @@ test.describe("政治団体ページ", () => {
 			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
 			await selectorButton.click();
 
-			// シート内の選択肢をクリック（E2Eテスト団体が存在する場合）
-			const options = page.locator(
-				'button:has-text("E2Eテスト団体")',
-			);
-			const optionCount = await options.count();
-
-			if (optionCount > 0) {
-				await options.first().click();
-				await expect(page).toHaveURL("/o/e2e-test-org/2026");
-			} else {
-				// E2Eテスト団体がない場合はスキップ
-				test.skip();
-			}
+			// シード済みの「E2Eテスト団体」（slug: e2e-test-org）を選択する
+			await page.getByRole("button", { name: "E2Eテスト団体" }).click();
+			await expect(page).toHaveURL("/o/e2e-test-org/2026");
 		});
 
 		test("年度を切り替えるとページが切り替わる", async ({ page }) => {
@@ -152,20 +135,9 @@ test.describe("政治団体ページ", () => {
 			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
 			await selectorButton.click();
 
-			// シート内の選択肢をクリック
-			const options = page.locator(
-				'button:has-text("E2Eテスト団体")',
-			);
-			const optionCount = await options.count();
-
-			if (optionCount > 0) {
-				await options.first().click();
-				// URLが変更されることを確認（transactionsパスは維持）
-				await expect(page).toHaveURL("/o/e2e-test-org/2026/transactions");
-			} else {
-				// E2Eテスト団体がない場合はスキップ
-				test.skip();
-			}
+			// シード済みの「E2Eテスト団体」を選択すると、transactions パスを維持したまま URL が変わる
+			await page.getByRole("button", { name: "E2Eテスト団体" }).click();
+			await expect(page).toHaveURL("/o/e2e-test-org/2026/transactions");
 		});
 	});
 });


### PR DESCRIPTION
## 目的（Why）

CI の E2E を保守するメンバーが、実行コストに対して検証価値の低い（静的テキスト確認だけ・常時スキップ・assert なしで成功しうる）テストによって CI 時間と保守コストを押し上げられている状態を解消するため。

## 変更内容

### admin（30 → 30 テスト中、読み込み系 15 件を 5 件に統合）
- `dashboard.spec.ts`: Welcome 文言のテストを削除し、見出し確認のスモーク 1 件に統合
- `user-info.spec.ts`: 「ロール:」「作成日:」ラベルのテストを削除し、見出し + ログインユーザーのメールアドレス確認のスモーク 1 件に統合
- `counterparts.spec.ts`: 読み込み系 5 件（テーブルヘッダー・件数表示など）をスモーク 1 件に統合。書き込み系は変更なし
- `transactions.spec.ts`: 読み込み系 3 件をスモーク 1 件に統合。「ページネーションが機能する」（`if` が二重で assert なしに成功しうる）を、シードの sample-party の取引が 50 件を超える前提で「次へ」→ `page=2` → 「全 N 件中 51 - N 件を表示」を検証する決定的なテストに書き換え
- `import-donors.spec.ts`: 7 箇所に重複していた CSV アップロード処理を `uploadSampleCsv` ヘルパーに共通化。読み込み系 2 件を 1 件に、プレビュー表示 2 件を 1 件に統合

### webapp
- `organization.spec.ts`: 団体切り替えの 2 テストから `if / test.skip()` 分岐を除去。「E2Eテスト団体」は `prisma/seeds/politicalOrganizations.ts` に 2026-01 から存在しており、ローカル実測ではスキップされず通過していたため、削除ではなくシード済み団体を直接クリックする決定的なテストに書き換えた。また、ルートリダイレクトのテストと同じ検証をしていた「収支の流れセクションが表示される」を削除

### Issue の完了条件との差分
- 「`import-donors.spec.ts` に `mode: "serial"` を明示する」について: #1334 でインポート確定テストに `mode: "default"`（同一ワーカーで順次実行、1 件失敗しても後続を skip しない）が既に明示されており、その判断理由がコメントで残されているため、`serial` には変更せずそのまま維持した。

Closes #1308

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ 通過
- `pnpm db:reset && pnpm test:e2e`: ✅ webapp 14 passed / admin 30 passed

## スコープアウトして起票した Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 取引先、ダッシュボード、ユーザー情報、取引一覧、CSVインポートのE2Eテストを整理・統合しました。
  * シードデータを前提とした検証に統一し、ページネーションや団体切り替えの確認を安定化しました。
  * CSVアップロード手順の重複を削減し、プレビュー表示の検証を簡素化しました。
  * 一部の個別表示項目やウェルカムメッセージ、収支フロー表示に関するテストを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->