### PR TITLE
test: ユニットテストは src/ ではなく tests/ に置く方針を明文化し、dependency-cruiser で src/ 配下のテストファイルを検出する

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -2,6 +2,32 @@
 module.exports = {
   forbidden: [
     // ===========================================
+    // テストファイルの配置ルール (admin / webapp 共通)
+    // ===========================================
+    {
+      name: "no-tests-in-src",
+      comment:
+        "ユニットテストは src/ ではなく tests/ に src/ と同じ階層で置く（#1315）。" +
+        "jest の roots は tests/ のみなので、src/ 配下に置いたテストは実行されず、" +
+        "落ちていても気づけない。",
+      severity: "error",
+      from: { path: "^(admin|webapp)/src/.*\\.(test|spec)\\.tsx?$" },
+      to: {},
+    },
+    {
+      name: "no-orphan-tests-in-src",
+      comment:
+        "no-tests-in-src の補完。import を1つも持たないテストファイルは依存が無く" +
+        "上のルールに引っかからないため、orphan として別途検出する。",
+      severity: "error",
+      from: {
+        orphan: true,
+        path: "^(admin|webapp)/src/.*\\.(test|spec)\\.tsx?$",
+      },
+      to: {},
+    },
+
+    // ===========================================
     // Client層からの依存ルール (admin)
     // ===========================================
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,13 @@ contexts/{コンテキスト名}/
 
 - TypeScript の import は `@/` から始まる絶対パスを使用する（相対パス禁止）
 
+### テストの配置
+
+- ユニットテストは `{webapp,admin}/tests/` に、`src/` と同じ階層構造で置く
+  （例: `src/client/lib/format.ts` → `tests/client/lib/format.test.ts`）
+- **`src/` 配下に `*.test.ts` / `*.test.tsx` を置かない**。jest の `roots` は `tests/` のみなので `src/` 配下のテストは実行されず、
+  落ちていても気づけない。dependency-cruiser（`pnpm depcruise`）が `src/` 配下のテストファイルを検出して CI を落とす
+
 ## バックエンドアーキテクチャガイド
 
 webapp / admin のバックエンド実装に関する詳細なルールは [docs/backend-architecture-guide.md](docs/backend-architecture-guide.md) を参照すること。

--- a/admin/jest.config.js
+++ b/admin/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  // テストは tests/ に src/ と同じ階層で置く方針（src/ 配下の *.test.ts は意図的に収集しない）。
+  // src/ 配下に置かれたテストは dependency-cruiser の no-tests-in-src ルールで検出される。
   roots: ["<rootDir>/tests"],
   testMatch: ["**/*.test.ts"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],

--- a/docs/backend-architecture-guide.md
+++ b/docs/backend-architecture-guide.md
@@ -309,6 +309,23 @@ Domain層でエラーを扱う場合は、拡張エラー型とエラーコー�
 - **actions**: 処理成功後に `revalidatePath`（キャッシュを残す場合はあわせて `revalidateTag`）で無効化
 - **外部キャッシュ**: インターフェース経由でベストエフォート無効化
 
+### 6.5 テストの配置
+
+- **原則**: ユニットテストは `{webapp,admin}/tests/` に、`src/` と同じ階層構造で置く。
+  クライアント側（`src/client/`）のロジックも同様に `tests/client/` へ置き、コンポーネントの隣には置かない
+
+  | 実装 | テスト |
+  |---|---|
+  | `src/client/lib/format.ts` | `tests/client/lib/format.test.ts` |
+  | `src/client/components/layout/sidebar-nav.ts` | `tests/client/components/layout/sidebar-nav.test.ts` |
+  | `src/server/contexts/report/domain/services/xxx.ts` | `tests/server/contexts/report/domain/services/xxx.test.ts` |
+
+- **`src/` 配下に `*.test.ts` / `*.test.tsx` を置かない**。jest の `roots` は `tests/` のみを対象にしているため、
+  `src/` 配下のテストは収集されず、落ちていても CI では気づけない
+- **自動検証**: dependency-cruiser の `no-tests-in-src` / `no-orphan-tests-in-src` ルールが `src/` 配下のテストファイルを検出し、
+  `pnpm depcruise`（`pnpm verify` および CI に含まれる）を失敗させる
+- テストが実際に収集されているかは `pnpm --filter admin test --listTests` で確認できる
+
 ---
 
 ## 7. チェックリスト
@@ -341,6 +358,7 @@ Domain層でエラーを扱う場合は、拡張エラー型とエラーコー�
 ### テスタビリティ
 - [ ] UsecaseはConstructor Injectionを使用している
 - [ ] インターフェースを通じて依存を注入できる
+- [ ] テストは `tests/` に `src/` と同じ階層で置かれている（`src/` 配下に `*.test.ts` を置いていない）
 
 ---
 
@@ -358,6 +376,7 @@ pnpm depcruise
 
 | ルール | 説明 |
 |--------|------|
+| no-tests-in-src / no-orphan-tests-in-src | `src/` 配下に `*.test.ts(x)` / `*.spec.ts(x)` を置くこと禁止（テストは `tests/` に置く。6.5 参照） |
 | no-client-to-infrastructure | Client → Infrastructure 禁止 |
 | no-client-to-application | Client → Application 禁止 |
 | no-presentation-to-client | Presentation → Client 禁止 |

--- a/webapp/jest.config.js
+++ b/webapp/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  // テストは tests/ に src/ と同じ階層で置く方針（src/ 配下の *.test.ts は意図的に収集しない）。
+  // src/ 配下に置かれたテストは dependency-cruiser の no-tests-in-src ルールで検出される。
   roots: ["<rootDir>/tests"],
   testMatch: ["**/*.test.ts", "**/*.test.tsx"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],


### PR DESCRIPTION
## 目的（Why）

`src/` 配下に置かれたユニットテストが jest に収集されず「落ちていても気づけない」状態を、実装者・AIエージェントが再発させないため。
オーナーの判断（#1315 コメント）に従い **B方針: `src/` にテストを置かない** で統一する。

## 変更内容

- **`.dependency-cruiser.cjs`**: `no-tests-in-src` / `no-orphan-tests-in-src` ルールを追加。admin / webapp の `src/` 配下に `*.test.ts(x)` / `*.spec.ts(x)` が置かれると `pnpm depcruise`（`pnpm verify` および CI の "Check dependency rules" ステップ）が失敗する。import を持たないテストファイルも orphan ルールで検出する
- **`CLAUDE.md`**: 実装ルールに「テストの配置」節を追加
- **`docs/backend-architecture-guide.md`**: 6.5「テストの配置」を新設（`src/` と `tests/` の対応表）、7章チェックリストと8章の検証ルール表に追記
- **`admin/jest.config.js` / `webapp/jest.config.js`**: `roots` が `tests/` のみである意図をコメントで明記（設定自体は変更なし）

Issue で言及されていた `sidebar-nav.test.ts` はすでに `admin/tests/client/components/layout/` に置かれており、`src/` 配下のテストファイルは現時点で存在しない（移動対象なし）。

## 動作確認

- ダミーの `admin/src/client/lib/dummy.test.ts` / `webapp/src/client/lib/dummy.test.tsx` を置くと `pnpm depcruise` が `no-tests-in-src` で失敗し、import を持たないダミーは `no-orphan-tests-in-src` で失敗することを確認（確認後に削除）
- `pnpm --filter admin exec jest --listTests --watchman=false` で 81 件が収集され、`tests/client/components/layout/sidebar-nav.test.ts` が含まれることを確認

## ローカルCI

- `pnpm verify`: exit 0（typecheck / lint / knip / depcruise すべて通過）
- ⚠️ ただしこのマシンでは Homebrew の watchman が壊れており、素の `jest` が **0件・無出力で exit 0** になることが判明（#1338 として起票）。そのため jest は `--watchman=false` を付けて別途実行した:
  - admin: Test Suites 80 passed / 1 skipped、Tests 919 passed / 1 skipped
  - webapp: Test Suites 16 passed、Tests 135 passed
- E2E: 画面・導線・認証に影響する変更ではないため未実施

## スコープアウトして起票した Issue

- #1338 `loop:ready` `loop:unblock`: watchman が壊れた環境で jest が 0 件のまま exit 0 になり `pnpm verify` がテストを素通りする（jest config で `watchman: false` にする）

Closes #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * ユニットテストを `tests/` に配置するルールを文書化しました。
  * `src/` 配下のテストが検出対象外となることや、配置ルールの検証方法を追記しました。
  * テスタビリティのチェック項目と検証ルール一覧を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->