### PR TITLE
test: jest config で watchman を無効化し、watchman が壊れた環境でもテストが収集されるようにする

### DIFF
--- a/admin/jest.config.js
+++ b/admin/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
   // テストは tests/ に src/ と同じ階層で置く方針（src/ 配下の *.test.ts は意図的に収集しない）。
   // src/ 配下に置かれたテストは dependency-cruiser の no-tests-in-src ルールで検出される。
   roots: ["<rootDir>/tests"],
+  // 単発実行（CI / pnpm verify）では watchman の恩恵が無く、watchman が壊れた環境では
+  // jest がテストを 1 件も収集せず exit 0 で素通りするため、常に node crawler で収集する。
+  watchman: false,
   testMatch: ["**/*.test.ts"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   transform: {

--- a/webapp/jest.config.js
+++ b/webapp/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
   // テストは tests/ に src/ と同じ階層で置く方針（src/ 配下の *.test.ts は意図的に収集しない）。
   // src/ 配下に置かれたテストは dependency-cruiser の no-tests-in-src ルールで検出される。
   roots: ["<rootDir>/tests"],
+  // 単発実行（CI / pnpm verify）では watchman の恩恵が無く、watchman が壊れた環境では
+  // jest がテストを 1 件も収集せず exit 0 で素通りするため、常に node crawler で収集する。
+  watchman: false,
   testMatch: ["**/*.test.ts", "**/*.test.tsx"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   transform: {


### PR DESCRIPTION
## 目的（Why）

ループランナーのマシンで Homebrew の watchman が壊れている（`libfmt.11.dylib` 欠落で dyld エラー）状態だと、jest が **テストを 1 件も収集せず何も出力せず exit 0** で終了し、`pnpm verify` が green のままユニットテストを素通りしていた。ループの「ローカルCI」が骨抜きになる状態を解消し、ランナー環境の watchman の有無・状態に左右されずテストが走るようにする。

## 変更内容

- `admin/jest.config.js` / `webapp/jest.config.js` に `watchman: false` を追加（意図をコメントで記載）
- 単発実行（CI / `pnpm verify`）では watchman の恩恵が無いため、常に jest の node crawler でテストを収集する

## 確認結果（watchman 破損環境）

| | 変更前 `jest --listTests` | 変更後 |
|---|---|---|
| admin | 0 件（dyld エラー出力のみ） | 81 件 |
| webapp | 0 件 | 16 件 |

`pnpm test` の出力:

```
Test Suites: 1 skipped, 80 passed, 80 of 81 total   (admin)
Tests:       1 skipped, 919 passed, 920 total
Test Suites: 16 passed, 16 total                    (webapp)
Tests:       135 passed, 135 total
```

Closes #1338

## ローカルCI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ すべて通過
- E2E: 対象外（画面・導線・認証に影響しない設定変更のため未実行）

## スコープアウトして起票した Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テスト実行時に Watchman を使用せず、Node クローラーを利用するよう設定を変更しました。
  * Watchman が利用できない環境でも、テストが正しく収集・実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->