### PR TITLE
refactor(admin): フォームラベル（ui/label）をハンドオフの 12px/700 に揃える

### DIFF
--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotForm.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotForm.tsx
@@ -93,7 +93,7 @@ export default function BalanceSnapshotForm({
     <div>
       <form onSubmit={handleSubmit} className="flex flex-wrap items-start gap-4">
         <div className="flex w-48 flex-col gap-1.5">
-          <Label htmlFor={dateInputId} className="text-xs font-bold">
+          <Label htmlFor={dateInputId}>
             残高日付 <span className="text-destructive">*</span>
           </Label>
           <Input
@@ -114,7 +114,7 @@ export default function BalanceSnapshotForm({
         </div>
 
         <div className="flex w-48 flex-col gap-1.5">
-          <Label htmlFor={balanceInputId} className="text-xs font-bold">
+          <Label htmlFor={balanceInputId}>
             残高 (円) <span className="text-destructive">*</span>
           </Label>
           <Input

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotsClient.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotsClient.tsx
@@ -83,7 +83,7 @@ export default function BalanceSnapshotsClient({ organizations }: BalanceSnapsho
       <div className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-6">
         <div className="rounded-lg border border-border bg-card p-6">
           <div className="flex max-w-[360px] flex-col gap-1.5">
-            <Label className="text-xs font-bold">
+            <Label>
               政治団体 <span className="text-destructive">*</span>
             </Label>
             <PoliticalOrganizationSelect

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
@@ -258,9 +258,7 @@ export function CounterpartAssignmentClient({
             hideLabel
           />
           <div className="flex items-center gap-2">
-            <Label htmlFor="financial-year" className="text-xs font-bold">
-              報告年
-            </Label>
+            <Label htmlFor="financial-year">報告年</Label>
             <Input
               id="financial-year"
               type="number"

--- a/admin/src/client/components/counterparts/AddressInput.tsx
+++ b/admin/src/client/components/counterparts/AddressInput.tsx
@@ -74,7 +74,7 @@ export function AddressInput({
         <p className="text-xs font-bold text-foreground">AI検索で入力を補助</p>
 
         <div className="space-y-1.5">
-          <Label htmlFor={searchQueryId} className="text-xs text-muted-foreground">
+          <Label htmlFor={searchQueryId} className="text-muted-foreground">
             会社名
           </Label>
           <Input
@@ -88,7 +88,7 @@ export function AddressInput({
         </div>
 
         <div className="space-y-1.5">
-          <Label htmlFor={hintId} className="text-xs text-muted-foreground">
+          <Label htmlFor={hintId} className="text-muted-foreground">
             検索ヒント（任意）
           </Label>
           <Input

--- a/admin/src/client/components/counterparts/CounterpartSelectorContent.tsx
+++ b/admin/src/client/components/counterparts/CounterpartSelectorContent.tsx
@@ -80,9 +80,7 @@ export function CounterpartSelectorContent({
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label htmlFor="counterpart-search" className="text-xs font-bold">
-          取引先を検索
-        </Label>
+        <Label htmlFor="counterpart-search">取引先を検索</Label>
         <Input
           id="counterpart-search"
           type="text"

--- a/admin/src/client/components/csv-upload/CsvUploadClient.tsx
+++ b/admin/src/client/components/csv-upload/CsvUploadClient.tsx
@@ -156,7 +156,7 @@ export default function CsvUploadClient({
       >
         <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-4">
           <div className="flex flex-col gap-1.5">
-            <Label className="text-xs font-bold">
+            <Label>
               政治団体 <span className="text-destructive">*</span>
             </Label>
             <PoliticalOrganizationSelect
@@ -169,7 +169,7 @@ export default function CsvUploadClient({
             />
           </div>
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor={dataSourceSelectId} className="text-xs font-bold">
+            <Label htmlFor={dataSourceSelectId}>
               データソース <span className="text-destructive">*</span>
             </Label>
             <NativeSelect

--- a/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
@@ -251,9 +251,7 @@ export function DonorAssignmentClient({
             hideLabel
           />
           <div className="flex items-center gap-2">
-            <Label htmlFor="financial-year" className="text-xs font-bold">
-              報告年
-            </Label>
+            <Label htmlFor="financial-year">報告年</Label>
             <Input
               id="financial-year"
               type="number"

--- a/admin/src/client/components/donor-assignment/DonorSelectorContent.tsx
+++ b/admin/src/client/components/donor-assignment/DonorSelectorContent.tsx
@@ -71,9 +71,7 @@ export function DonorSelectorContent({
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label htmlFor="donor-search" className="text-xs font-bold">
-          寄付者を検索
-        </Label>
+        <Label htmlFor="donor-search">寄付者を検索</Label>
         <Input
           id="donor-search"
           type="text"

--- a/admin/src/client/components/donor-csv-import/DonorCsvImportClient.tsx
+++ b/admin/src/client/components/donor-csv-import/DonorCsvImportClient.tsx
@@ -128,7 +128,7 @@ export default function DonorCsvImportClient({
       <div className="max-w-[720px] rounded-lg border border-border bg-card p-7">
         <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-4">
           <div className="flex flex-col gap-1.5">
-            <Label className="text-xs font-bold">
+            <Label>
               政治団体 <span className="text-destructive">*</span>
             </Label>
             <PoliticalOrganizationSelect

--- a/admin/src/client/components/report-profile/BasicInfoSection.tsx
+++ b/admin/src/client/components/report-profile/BasicInfoSection.tsx
@@ -19,7 +19,7 @@ export function BasicInfoSection({ formData, updateFormData }: BasicInfoSectionP
         <div className="space-y-2">
           <Label>
             団体名称
-            <span className="text-muted-foreground text-sm ml-2">
+            <span className="text-muted-foreground text-sm font-normal ml-2">
               ({formData.officialName?.length ?? 0}/120)
             </span>
           </Label>
@@ -36,7 +36,7 @@ export function BasicInfoSection({ formData, updateFormData }: BasicInfoSectionP
         <div className="space-y-2">
           <Label>
             団体名称（カナ）
-            <span className="text-muted-foreground text-sm ml-2">
+            <span className="text-muted-foreground text-sm font-normal ml-2">
               ({formData.officialNameKana?.length ?? 0}/120)
             </span>
           </Label>
@@ -53,7 +53,7 @@ export function BasicInfoSection({ formData, updateFormData }: BasicInfoSectionP
         <div className="space-y-2">
           <Label>
             事務所所在地
-            <span className="text-muted-foreground text-sm ml-2">
+            <span className="text-muted-foreground text-sm font-normal ml-2">
               ({formData.officeAddress?.length ?? 0}/80)
             </span>
           </Label>
@@ -70,7 +70,7 @@ export function BasicInfoSection({ formData, updateFormData }: BasicInfoSectionP
         <div className="space-y-2">
           <Label>
             建物名等
-            <span className="text-muted-foreground text-sm ml-2">
+            <span className="text-muted-foreground text-sm font-normal ml-2">
               ({formData.officeAddressBuilding?.length ?? 0}/60)
             </span>
           </Label>

--- a/admin/src/client/components/report-profile/YearSelector.tsx
+++ b/admin/src/client/components/report-profile/YearSelector.tsx
@@ -15,9 +15,7 @@ export function YearSelector({ orgId, financialYear, currentYear }: YearSelector
 
   return (
     <div className="flex items-center gap-3">
-      <Label htmlFor="financial-year" className="text-xs font-bold">
-        報告年
-      </Label>
+      <Label htmlFor="financial-year">報告年</Label>
       <NativeSelect
         id="financial-year"
         key={financialYear}

--- a/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
+++ b/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
@@ -98,7 +98,7 @@ export function BulkDeleteTransactionsClient({
           <h2 className="text-base font-bold text-foreground">検索条件</h2>
           <div className="mt-4 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-4">
             <div className="flex flex-col gap-1.5">
-              <Label className="text-xs font-bold">
+              <Label>
                 政治団体 <span className="text-destructive">*</span>
               </Label>
               <PoliticalOrganizationSelect
@@ -114,7 +114,7 @@ export function BulkDeleteTransactionsClient({
               />
             </div>
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor={transactionNosInputId} className="text-xs font-bold">
+              <Label htmlFor={transactionNosInputId}>
                 取引番号（カンマ区切り） <span className="text-destructive">*</span>
               </Label>
               <Input

--- a/admin/src/client/components/ui/label.tsx
+++ b/admin/src/client/components/ui/label.tsx
@@ -5,12 +5,16 @@ import * as LabelPrimitive from "@radix-ui/react-label";
 
 import { cn } from "@/client/lib/index";
 
+/**
+ * フォームラベル。ハンドオフ既定は 12px/700（text-xs font-bold）。
+ * 無効表現は opacity ではなく text-disabled-foreground で行う（admin-ui-guidelines 参照）。
+ */
 function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-xs leading-none font-bold select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:text-disabled-foreground peer-disabled:cursor-not-allowed peer-disabled:text-disabled-foreground",
         className,
       )}
       {...props}

--- a/docs/admin-ui-guidelines.md
+++ b/docs/admin-ui-guidelines.md
@@ -40,6 +40,7 @@ import { Button, Input, Label } from "@/client/components/ui";
 
 ### フォーム・フォーカスリング
 
+- フォームラベル（`Label`）は 12px/700（`text-xs font-bold`）が既定。必須は `<span className="text-destructive">*</span>` を付ける。使用側で `text-xs font-bold` を重ねて指定しない
 - input / select はピル形状・黒枠・白地。placeholder は `#B1B1B1`（`text-disabled-foreground`）
 - focus 時は枠が teal + `0 0 0 2px #E2F6F3` のリング（`focus-visible:border-ring focus-visible:ring-[2px] focus-visible:ring-ring-soft`）
 - ボタンの focus-visible は `ring-2 ring-ring ring-offset-2`


### PR DESCRIPTION
## 目的（Why）

admin の各画面をハンドオフどおりにリデザインしている開発者が、共通 `Label` の既定（shadcn 既定の 14px/500 と `opacity-50` による無効表現）とハンドオフ（12px/700、無効は opacity を使わない）の食い違いにより、画面ごとに `text-xs font-bold` を重ね書きせざるを得ない状態を解消するため。

## 変更内容

- `admin/src/client/components/ui/label.tsx`
  - 既定クラスを `text-sm font-medium` → `text-xs font-bold` に変更
  - `group-data-[disabled=true]:opacity-50` / `peer-disabled:opacity-50` → `text-disabled-foreground` に置き換え
- 使用側で重ねて指定していた `className="text-xs font-bold"` を削除（10 ファイル）
  - YearSelector / CsvUploadClient / DonorCsvImportClient / BalanceSnapshotForm / BalanceSnapshotsClient / BulkDeleteTransactionsClient / DonorAssignmentClient / CounterpartAssignmentClient / DonorSelectorContent / CounterpartSelectorContent
- `AddressInput` の `text-xs text-muted-foreground` から重複する `text-xs` を削除
- `BasicInfoSection` の文字数カウンタ `span` に `font-normal` を付け、ラベルの太字を継承しないようにする
- `docs/admin-ui-guidelines.md` にラベルの既定ルールを追記

ラベルのテキスト自体は変更していないため、E2E の `getByLabel` には影響しません。

Closes #1320

## ローカルCI

- `pnpm verify`: ✅ 通過（admin: 80 suites / 919 tests、webapp: 16 suites / 135 tests、lint / typecheck / knip / depcruise すべて OK）
- admin E2E（`pnpm supabase:start && pnpm db:reset && pnpm test:e2e:admin`）: ✅ 30 passed

## スコープアウトして起票した Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - フォームラベルの既定表示を、より小さく太い文字に統一しました。
  - 個別画面で設定されていた重複するラベル装飾を整理し、表示を統一しました。
  - 無効状態のラベル表示を変更しました。
  - 文字数カウンターを通常の太さで表示するよう調整しました。

- **ドキュメント**
  - ラベルの既定スタイルと必須項目の表示ルールを管理画面ガイドラインに追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->