### PR TITLE
refactor(admin): ClientPagination（クライアント側ページネーション）をハンドオフのピル仕様に揃える

### DIFF
--- a/admin/src/client/components/ui/ClientPagination.tsx
+++ b/admin/src/client/components/ui/ClientPagination.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { CaretLeft, CaretRight } from "@phosphor-icons/react/dist/ssr";
 import { Button } from "@/client/components/ui";
 
 interface ClientPaginationProps {
@@ -9,94 +9,46 @@ interface ClientPaginationProps {
   onPageChange: (page: number) => void;
 }
 
+/** 「前へ / 次へ」ピルを StaticPagination と同じ寸法（px-4 / py-7px / 12px 文字）に揃える */
+const pillButtonClass = "h-auto gap-1.5 px-4 py-[7px] text-xs has-[>svg]:px-4";
+
+/**
+ * クライアント側の状態でページを切り替えるページネーション。
+ * 見た目は `StaticPagination` に揃える（「前へ / 次へ」の黒枠白ピルと、中央に Poppins の「現在 / 総数」表示）。
+ */
 export function ClientPagination({ currentPage, totalPages, onPageChange }: ClientPaginationProps) {
-  const renderPageNumbers = () => {
-    if (totalPages <= 0) return null;
+  if (totalPages <= 0) return null;
 
-    const pages: ReactNode[] = [];
-    const windowSize = 5;
-
-    const addPageButton = (page: number) => {
-      pages.push(
-        <Button
-          type="button"
-          key={`page-${page}`}
-          variant={page === currentPage ? "default" : "ghost"}
-          size="sm"
-          onClick={() => onPageChange(page)}
-        >
-          {page}
-        </Button>,
-      );
-    };
-
-    const addEllipsis = (key: string) => {
-      pages.push(
-        <span key={`ellipsis-${key}`} className="px-2 text-muted-foreground select-none">
-          …
-        </span>,
-      );
-    };
-
-    if (totalPages <= windowSize + 2) {
-      for (let page = 1; page <= totalPages; page++) {
-        addPageButton(page);
-      }
-      return pages;
-    }
-
-    addPageButton(1);
-
-    let startPage = Math.max(2, currentPage - Math.floor(windowSize / 2));
-    let endPage = Math.min(totalPages - 1, startPage + windowSize - 1);
-
-    if (endPage >= totalPages) {
-      endPage = totalPages - 1;
-      startPage = endPage - windowSize + 1;
-    }
-
-    if (startPage > 2) {
-      addEllipsis("left");
-    }
-
-    for (let page = startPage; page <= endPage; page++) {
-      addPageButton(page);
-    }
-
-    if (endPage < totalPages - 1) {
-      addEllipsis("right");
-    }
-
-    addPageButton(totalPages);
-
-    return pages;
-  };
+  const hasPrev = currentPage > 1;
+  const hasNext = currentPage < totalPages;
 
   return (
-    <div className="flex justify-center items-center gap-2 mt-6">
-      {currentPage > 1 && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => onPageChange(currentPage - 1)}
-        >
-          ← 前
-        </Button>
-      )}
+    <nav aria-label="pagination" className="mt-6 flex items-center justify-center gap-2.5">
+      <Button
+        type="button"
+        variant="outline"
+        className={pillButtonClass}
+        disabled={!hasPrev}
+        onClick={() => onPageChange(currentPage - 1)}
+      >
+        <CaretLeft className="size-3" />
+        前へ
+      </Button>
 
-      {renderPageNumbers()}
+      <span className="font-latin text-[13px] font-semibold text-foreground">
+        {currentPage} / {totalPages}
+      </span>
 
-      {currentPage < totalPages && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => onPageChange(currentPage + 1)}
-        >
-          次 →
-        </Button>
-      )}
-    </div>
+      <Button
+        type="button"
+        variant="outline"
+        className={pillButtonClass}
+        disabled={!hasNext}
+        onClick={() => onPageChange(currentPage + 1)}
+      >
+        次へ
+        <CaretRight className="size-3" />
+      </Button>
+    </nav>
   );
 }


### PR DESCRIPTION
## 目的（Why）

admin リデザインで、CSV 取り込みプレビュー・寄付者インポートプレビュー・取引先/寄付者割当画面の下部に出る共通コンポーネント `ClientPagination` だけが `ghost` ボタン + 「← 前 / 次 →」の旧語彙のまま残り、サーバー側 `StaticPagination`（取引一覧）と見た目が食い違っていた状態を解消する。

## 変更内容

- `admin/src/client/components/ui/ClientPagination.tsx` を `StaticPagination` と同じ構成に書き換え
  - 「前へ / 次へ」は `Button variant="outline"` + Phosphor `CaretLeft` / `CaretRight`（黒1.5px枠白ピル、寸法は `StaticPagination` と同じ px-4 / py-7px / 12px）
  - 端のページでは `disabled`（Button 共通の disabled スタイル: `#CCC` 枠・`#B1B1B1` 文字・not-allowed）
  - 中央に Poppins（`font-latin`）の「現在 / 総数」
  - `nav aria-label="pagination"` で `StaticPagination` と同じアクセシビリティ構造
- 文字矢印（← →）と `ghost` バリアントを除去
- ページ番号ボタン（窓幅 5 のロジック）はハンドオフ仕様・`StaticPagination` に存在しないため撤去。ページ切り替えは前へ/次へで従来どおり `onPageChange` を呼ぶ
- 利用箇所（`CsvPreview` / `DonorCsvPreview` / `DonorAssignmentClient` / `CounterpartAssignmentClient`）の呼び出し側は変更なし

Closes #1328

## ローカルCI

`pnpm verify` 通過（test / typecheck / lint / knip / depcruise）

- admin: Test Suites 16 passed / Tests 135 passed
- webapp: Test Suites 81 passed, 1 skipped / Tests 931 passed, 1 skipped

E2E は `StaticPagination`（取引一覧）のみを参照しており、`ClientPagination` を触るテストは無いため未実行。

## スコープアウトした Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI改善**
  - ページネーション表示を「前へ」「次へ」ボタンと、現在ページ／総ページ数の表示に簡素化しました。
  - ページの先頭・末尾では、該当する移動ボタンが無効になります。
  - ページが存在しない場合も適切に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->