### PR TITLE
feat(loop): ループランナーにモデル切り替え（opus/fable/astra）を追加する

### DIFF
--- a/docs/loop-engineering.md
+++ b/docs/loop-engineering.md
@@ -117,11 +117,13 @@ Claude Code 内で `/loop-issue <やりたいことの概要>` を実行する�
 ## コマンド
 
 ```bash
-./scripts/loop-once.sh    # 1回だけループを実行
-./scripts/loop.sh 10      # 最大10回ループを実行（夜間バッチ向け）
+./scripts/loop-once.sh        # 1回だけループを実行
+./scripts/loop.sh 10          # 最大10回ループを実行（夜間バッチ向け）
+./scripts/loop.sh 10 astra    # モデルを指定して実行（opus / fable / astra、デフォルト: opus）
 ```
 
-各イテレーションは `claude -p "/loop-once"` で**毎回新規セッション**を起動する。
+各イテレーションは**毎回新規セッション**を起動する。opus / fable は Claude Code（`claude -p "/loop-once" --model <モデル>`）、
+astra は Codex CLI（`codex exec --model gpt-6-astra`。要 `npm install -g @openai/codex`）で実行する。
 対話セッション内で試したい場合は Claude Code 内で `/loop-once` を実行してもよい。
 ログは `.loop/logs/` に残る（gitignore済み）。
 

--- a/scripts/loop-once.sh
+++ b/scripts/loop-once.sh
@@ -2,11 +2,15 @@
 #
 # ループエンジニアリング: 1回だけループを実行する
 #
-# 毎回まっさらな Claude Code セッション（claude -p）で /loop-once を実行する。
-# 手順の実体は .claude/commands/loop-once.md にある。
+# 毎回まっさらなエージェントセッションで手順書（.claude/commands/loop-once.md）を実行する。
 #
 # 使い方:
-#   ./scripts/loop-once.sh
+#   ./scripts/loop-once.sh [モデル]
+#
+# モデル:
+#   opus   (デフォルト) Claude Code (claude -p /loop-once --model opus)
+#   fable  Claude Code (claude -p /loop-once --model fable)
+#   astra  Codex CLI (codex exec --model gpt-6-astra)
 #
 # 環境変数:
 #   LOOP_LOG_FILE  ログの出力先（未指定なら .loop/logs/single-<時刻>.log）
@@ -23,6 +27,22 @@ set -uo pipefail
 # 実行中にこのファイル自体が書き換わっても、読み込み済みの定義で最後まで走る。
 main() {
   cd "$(cd "$(dirname "$0")/.." && pwd)"
+
+  # --- 引数: モデルの検証 ---
+  model="${1:-opus}"
+  case "$model" in
+    opus|fable) ;;
+    astra)
+      if ! command -v codex >/dev/null 2>&1; then
+        echo "[loop-once] astra には Codex CLI が必要です (npm install -g @openai/codex)。中断します。" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "usage: $0 [opus|fable|astra]" >&2
+      exit 1
+      ;;
+  esac
 
   # --- 前処理: 作業ツリーの状態確認 ---
   if [[ -n "$(git status --porcelain)" ]]; then
@@ -48,8 +68,29 @@ main() {
   log_file="${LOOP_LOG_FILE:-.loop/logs/single-$(date +%Y%m%d-%H%M%S).log}"
   mkdir -p "$(dirname "$log_file")"
 
-  echo "[loop-once] 開始 (残タスク: $ready_count 件) → $log_file"
+  echo "[loop-once] 開始 (モデル: $model, 残タスク: $ready_count 件) → $log_file"
 
+  if [[ "$model" == "astra" ]]; then
+    run_astra
+  else
+    run_claude "$model"
+  fi
+
+  result="$(grep -Eo 'LOOP_RESULT: [A-Z_]+[^\r]*' "$log_file" | tail -1 || true)"
+  if [[ -z "$result" ]]; then
+    result="LOOP_RESULT: FAILED reason=no-result-line"
+  fi
+  echo "[loop-once] $result"
+
+  case "$result" in
+    "LOOP_RESULT: SUCCESS"*) exit 0 ;;
+    "LOOP_RESULT: NO_TASK"*) exit 2 ;;
+    "LOOP_RESULT: BLOCKED"*) exit 3 ;;
+    *) exit 1 ;;
+  esac
+}
+
+run_claude() { # $1: claudeのモデルエイリアス (opus / fable)
   # stream-json をjqで進捗行に整形して流す（そのままだと完了まで無出力で不安になる）。
   # 整形後のテキストをログに残すので、LOOP_RESULT のgrepは従来どおり効く。
   local jq_progress='
@@ -74,27 +115,29 @@ main() {
       end'
 
   if command -v jq >/dev/null 2>&1; then
-    claude -p "/loop-once" --dangerously-skip-permissions \
+    claude -p "/loop-once" --model "$1" --dangerously-skip-permissions \
       --verbose --output-format stream-json 2>&1 \
       | jq --unbuffered -Rr "$jq_progress" \
       | tee "$log_file"
   else
     echo "[loop-once] jq が見つからないため進捗表示なしで実行します" >&2
-    claude -p "/loop-once" --dangerously-skip-permissions 2>&1 | tee "$log_file"
+    claude -p "/loop-once" --model "$1" --dangerously-skip-permissions 2>&1 | tee "$log_file"
   fi
+}
 
-  result="$(grep -Eo 'LOOP_RESULT: [A-Z_]+[^\r]*' "$log_file" | tail -1 || true)"
-  if [[ -z "$result" ]]; then
-    result="LOOP_RESULT: FAILED reason=no-result-line"
-  fi
-  echo "[loop-once] $result"
+run_astra() {
+  # /loop-once は Claude Code のスラッシュコマンドなので、Codex には手順書を読んで従うよう指示する。
+  # 手順書中の frontmatter や !`コマンド` 展開は Claude Code 専用機能のため、扱い方を明示する。
+  local prompt='あなたはループエンジニアリングの1イテレーションを実行するエージェントです。
+.claude/commands/loop-once.md を読み、その手順に従って1イテレーションを実行してください。
 
-  case "$result" in
-    "LOOP_RESULT: SUCCESS"*) exit 0 ;;
-    "LOOP_RESULT: NO_TASK"*) exit 2 ;;
-    "LOOP_RESULT: BLOCKED"*) exit 3 ;;
-    *) exit 1 ;;
-  esac
+- ファイル冒頭の frontmatter（allowed-tools 等）は Claude Code 用の設定なので無視してよい
+- 「現在の状況」セクションの !`コマンド` は自動展開されないので、各コマンドを自分で実行して状況を把握すること
+- 最後に必ず LOOP_RESULT 行を出力すること'
+
+  # stdin を閉じて渡す: codex exec は stdin がTTYでないと追加入力として読み込もうとする
+  codex exec --model gpt-6-astra --dangerously-bypass-approvals-and-sandbox \
+    "$prompt" </dev/null 2>&1 | tee "$log_file"
 }
 
 main "$@"

--- a/scripts/loop.sh
+++ b/scripts/loop.sh
@@ -5,7 +5,8 @@
 # for文で scripts/loop-once.sh を繰り返し呼び、停止条件を管理する。
 #
 # 使い方:
-#   ./scripts/loop.sh 10     # 最大10回ループ（夜間バッチ向け）
+#   ./scripts/loop.sh 10        # 最大10回ループ（夜間バッチ向け）
+#   ./scripts/loop.sh 10 astra  # モデルを指定（opus / fable / astra、デフォルト: opus）
 #
 # 停止条件:
 #   - loop:ready のIssueがなくなった (NO_TASK)
@@ -20,8 +21,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
 COUNT="${1:-1}"
-if ! [[ "$COUNT" =~ ^[1-9][0-9]*$ ]]; then
-  echo "usage: $0 [回数(正の整数)]" >&2
+MODEL="${2:-opus}"
+if ! [[ "$COUNT" =~ ^[1-9][0-9]*$ ]] || ! [[ "$MODEL" =~ ^(opus|fable|astra)$ ]]; then
+  echo "usage: $0 [回数(正の整数)] [opus|fable|astra]" >&2
   exit 1
 fi
 
@@ -30,7 +32,7 @@ RUN_ID="$(date +%Y%m%d-%H%M%S)"
 LOG_DIR=".loop/logs/$RUN_ID"
 mkdir -p "$LOG_DIR"
 
-echo "== loop run $RUN_ID: 最大 $COUNT 回 (ログ: $LOG_DIR) =="
+echo "== loop run $RUN_ID: 最大 $COUNT 回, モデル: $MODEL (ログ: $LOG_DIR) =="
 
 consecutive_failures=0
 results=()
@@ -40,7 +42,7 @@ for ((i = 1; i <= COUNT; i++)); do
   echo ""
   echo "[loop $i/$COUNT] 開始"
 
-  LOOP_LOG_FILE="$log_file" "$SCRIPT_DIR/loop-once.sh"
+  LOOP_LOG_FILE="$log_file" "$SCRIPT_DIR/loop-once.sh" "$MODEL"
   status=$?
 
   result="$(grep -Eo 'LOOP_RESULT: [A-Z_]+[^\r]*' "$log_file" 2>/dev/null | tail -1 || true)"


### PR DESCRIPTION
## 概要

`scripts/loop.sh` / `scripts/loop-once.sh` が Claude 決め打ちだったのを、第2引数（loop-once.sh は第1引数）でモデルを切り替えられるようにする。

```bash
./scripts/loop.sh 10          # デフォルト: opus
./scripts/loop.sh 10 fable    # Claude Code (claude -p /loop-once --model fable)
./scripts/loop.sh 10 astra    # Codex CLI (codex exec --model gpt-6-astra)
```

## 設計

- **ランナーの契約（`LOOP_RESULT:` 行の grep + 終了コード 0/1/2/3）はエージェント非依存の共通処理として維持**。loop.sh 側の停止条件・サマリ・後処理は無変更
- opus / fable は従来の `claude -p "/loop-once"` に `--model` を追加しただけ（stream-json + jq の進捗整形もそのまま）
- astra は `/loop-once` スラッシュコマンドが使えないため、手順書 `.claude/commands/loop-once.md` を読んで従うようプロンプトで指示（frontmatter は無視、`` !`コマンド` `` は自分で実行）
- astra 指定時は起動前に `codex` コマンドの存在をチェックし、未導入なら副作用ゼロでエラー終了
- `codex exec` は stdin が TTY でないと追加入力を待つ挙動があるため `</dev/null` で閉じる（夜間バッチ対策）

## 確認

- `claude --help` で `opus` / `fable` エイリアスの有効性を確認
- codex-cli 0.154.0 で `--model` / `--dangerously-bypass-approvals-and-sandbox` フラグの実在と、`gpt-6-astra` でのスモークテスト（最小プロンプト実行）を確認
- ダーティツリー時に起動前チェックで中断されることを確認（実機で loop.sh 経由の起動 → 中断を確認）

## 補足

Claude Code の `allowed-tools` 制限は Codex には効かないため、astra での無人実行の初回は目視推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * ループ実行時にモデル（opus、fable、astra）を指定できるよう、コマンド例と手順を更新しました。
  * モデルごとの実行方法と、astra 利用時に必要な Codex CLI のセットアップ手順を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->