### PR TITLE
feat(research-fund): 複式仕訳ドメインを追加

### DIFF
--- a/admin/src/server/contexts/research-fund/domain/models/journal-entry-hash.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/journal-entry-hash.ts
@@ -1,0 +1,59 @@
+import "server-only";
+import { createHash } from "node:crypto";
+import {
+  invalidResearchFundResult,
+  RF_ERROR_CODES,
+  type ResearchFundResult,
+} from "@/server/contexts/research-fund/domain/types/validation";
+
+export interface JournalEntryHash {
+  /** 暦日を YYYY-MM-DD で指定する。タイムゾーンによる日付のずれを避ける。 */
+  entryDate: string;
+  amount: number;
+  description: string;
+  documentId?: string | null;
+}
+
+export const JournalEntryHash = {
+  generate(input: JournalEntryHash): ResearchFundResult<string> {
+    const { entryDate, amount, description } = input;
+    const date = new Date(`${entryDate}T00:00:00.000Z`);
+    if (
+      !/^\d{4}-\d{2}-\d{2}$/.test(entryDate) ||
+      Number.isNaN(date.getTime()) ||
+      date.toISOString().slice(0, 10) !== entryDate
+    ) {
+      return invalidResearchFundResult(
+        "entryDate",
+        RF_ERROR_CODES.INVALID_DATE,
+        "日付は実在する日をYYYY-MM-DD形式で指定してください",
+      );
+    }
+    if (!Number.isSafeInteger(amount) || amount <= 0 || amount > 999_999_999_999) {
+      return invalidResearchFundResult(
+        "amount",
+        RF_ERROR_CODES.INVALID_AMOUNT,
+        "金額は1円以上999999999999円以下の整数で指定してください",
+      );
+    }
+    if (!description.trim()) {
+      return invalidResearchFundResult(
+        "description",
+        RF_ERROR_CODES.INVALID_DESCRIPTION,
+        "項目名を指定してください",
+      );
+    }
+    const documentId = input.documentId ?? null;
+    if (documentId !== null && !documentId.trim()) {
+      return invalidResearchFundResult(
+        "documentId",
+        RF_ERROR_CODES.INVALID_DOCUMENT,
+        "書類IDを指定するか、書類がない場合はnullにしてください",
+      );
+    }
+    // 固定順のJSON配列により、キー順序や区切り文字を含む入力に左右されない。
+    // 科目やステータスの修正は同一取引の再取込判定に影響させない。
+    const content = JSON.stringify([entryDate, amount, description, documentId]);
+    return { status: "valid", value: createHash("sha256").update(content, "utf8").digest("hex") };
+  },
+};

--- a/admin/src/server/contexts/research-fund/domain/models/journal-entry.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/journal-entry.ts
@@ -1,0 +1,32 @@
+import {
+  invalidResearchFundResult,
+  RF_ERROR_CODES,
+  type ResearchFundResult,
+} from "@/server/contexts/research-fund/domain/types/validation";
+
+type JournalEntryStatus = "draft" | "approved" | "published";
+
+export interface JournalEntry {
+  readonly status: JournalEntryStatus;
+}
+
+export const JournalEntry = {
+  transition(
+    entry: JournalEntry,
+    nextStatus: JournalEntryStatus,
+  ): ResearchFundResult<JournalEntry> {
+    if (
+      !(
+        (entry.status === "draft" && nextStatus === "approved") ||
+        (entry.status === "approved" && nextStatus === "published")
+      )
+    ) {
+      return invalidResearchFundResult(
+        "status",
+        RF_ERROR_CODES.INVALID_STATUS_TRANSITION,
+        "仕訳は下書きから確認済み、確認済みから公開済みへのみ変更できます",
+      );
+    }
+    return { status: "valid", value: Object.freeze({ ...entry, status: nextStatus }) };
+  },
+};

--- a/admin/src/server/contexts/research-fund/domain/models/journal-posting.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/journal-posting.ts
@@ -1,0 +1,140 @@
+import {
+  invalidResearchFundResult,
+  RF_ERROR_CODES,
+  type ResearchFundResult,
+} from "@/server/contexts/research-fund/domain/types/validation";
+
+export interface ResearchFundAccount {
+  readonly key: string;
+  readonly type: "asset" | "income" | "expense";
+}
+
+export interface JournalLine {
+  readonly side: "debit" | "credit";
+  readonly accountKey: string;
+  readonly amount: number;
+}
+
+export interface JournalPosting {
+  readonly lines: readonly JournalLine[];
+}
+
+type PostingInput = {
+  amount: number;
+  account: ResearchFundAccount;
+  assetAccount: ResearchFundAccount;
+} & (
+  | { pattern: "expense"; source: "scan" | "manual" }
+  | { pattern: "grant"; source: "grant" }
+  | { pattern: "refund"; source: "manual" }
+);
+
+// 円の整数。永続化先の Decimal(12, 0) と同じ範囲に制限する。
+function isValidAmount(amount: number): boolean {
+  return Number.isSafeInteger(amount) && amount > 0 && amount <= 999_999_999_999;
+}
+
+export const JournalPosting = {
+  generate(input: PostingInput): ResearchFundResult<JournalPosting> {
+    const { pattern, source, amount, account, assetAccount } = input;
+    if (
+      !(
+        (pattern === "expense" && (source === "scan" || source === "manual")) ||
+        (pattern === "grant" && source === "grant") ||
+        (pattern === "refund" && source === "manual")
+      )
+    ) {
+      return invalidResearchFundResult(
+        "pattern",
+        RF_ERROR_CODES.INVALID_PATTERN,
+        "仕訳パターンと入力元の組み合わせが不正です",
+      );
+    }
+    if (!isValidAmount(amount)) {
+      return invalidResearchFundResult(
+        "amount",
+        RF_ERROR_CODES.INVALID_AMOUNT,
+        "金額は1円以上999999999999円以下の整数で指定してください",
+      );
+    }
+    if (
+      !account.key.trim() ||
+      (pattern === "expense"
+        ? account.type !== "expense" || ["bank", "cash", "grant-income"].includes(account.key)
+        : account.type !== "income" || account.key !== "grant-income")
+    ) {
+      return invalidResearchFundResult(
+        "account",
+        RF_ERROR_CODES.INVALID_ACCOUNT,
+        "支出には費用科目、支給・返還には調査研究費収入を指定してください",
+      );
+    }
+    if (
+      assetAccount.type !== "asset" ||
+      (assetAccount.key !== "bank" && !(pattern === "expense" && assetAccount.key === "cash"))
+    ) {
+      return invalidResearchFundResult(
+        "assetAccount",
+        RF_ERROR_CODES.INVALID_ACCOUNT,
+        "決済科目は普通預金（支出のみ現金も可）を指定してください",
+      );
+    }
+    const debitAccount = pattern === "grant" ? assetAccount : account;
+    const creditAccount = pattern === "grant" ? account : assetAccount;
+    const lines = Object.freeze([
+      Object.freeze({ side: "debit" as const, accountKey: debitAccount.key, amount }),
+      Object.freeze({ side: "credit" as const, accountKey: creditAccount.key, amount }),
+    ]);
+    return { status: "valid", value: Object.freeze({ lines }) };
+  },
+
+  validate(lines: readonly JournalLine[]): ResearchFundResult<JournalPosting> {
+    if (lines.length < 2) {
+      return invalidResearchFundResult(
+        "lines",
+        RF_ERROR_CODES.INVALID_LINES,
+        "仕訳には借方と貸方の行が必要です",
+      );
+    }
+    let debit = BigInt(0);
+    let credit = BigInt(0);
+    for (const [index, line] of lines.entries()) {
+      if (line.side !== "debit" && line.side !== "credit") {
+        return invalidResearchFundResult(
+          `lines.${index}.side`,
+          RF_ERROR_CODES.INVALID_LINES,
+          "借方または貸方を指定してください",
+        );
+      }
+      if (!line.accountKey.trim()) {
+        return invalidResearchFundResult(
+          `lines.${index}.accountKey`,
+          RF_ERROR_CODES.INVALID_ACCOUNT,
+          "科目を指定してください",
+        );
+      }
+      if (!isValidAmount(line.amount)) {
+        return invalidResearchFundResult(
+          `lines.${index}.amount`,
+          RF_ERROR_CODES.INVALID_AMOUNT,
+          "金額は1円以上999999999999円以下の整数で指定してください",
+        );
+      }
+      if (line.side === "debit") debit += BigInt(line.amount);
+      else credit += BigInt(line.amount);
+    }
+    if (debit !== credit) {
+      return invalidResearchFundResult(
+        "lines",
+        RF_ERROR_CODES.UNBALANCED_POSTING,
+        "借方合計と貸方合計が一致しません",
+      );
+    }
+    return {
+      status: "valid",
+      value: Object.freeze({
+        lines: Object.freeze(lines.map((line) => Object.freeze({ ...line }))),
+      }),
+    };
+  },
+};

--- a/admin/src/server/contexts/research-fund/domain/types/validation.ts
+++ b/admin/src/server/contexts/research-fund/domain/types/validation.ts
@@ -1,0 +1,30 @@
+export const RF_ERROR_CODES = {
+  INVALID_AMOUNT: "RF_INVALID_AMOUNT",
+  INVALID_ACCOUNT: "RF_INVALID_ACCOUNT",
+  INVALID_PATTERN: "RF_INVALID_PATTERN",
+  INVALID_LINES: "RF_INVALID_LINES",
+  UNBALANCED_POSTING: "RF_UNBALANCED_POSTING",
+  INVALID_STATUS_TRANSITION: "RF_INVALID_STATUS_TRANSITION",
+  INVALID_DATE: "RF_INVALID_DATE",
+  INVALID_DESCRIPTION: "RF_INVALID_DESCRIPTION",
+  INVALID_DOCUMENT: "RF_INVALID_DOCUMENT",
+} as const;
+
+export interface ResearchFundValidationError {
+  path: string;
+  code: (typeof RF_ERROR_CODES)[keyof typeof RF_ERROR_CODES];
+  message: string;
+  severity: "error" | "warning";
+}
+
+export type ResearchFundResult<T> =
+  | { status: "valid"; value: T }
+  | { status: "invalid"; errors: ResearchFundValidationError[] };
+
+export function invalidResearchFundResult(
+  path: string,
+  code: ResearchFundValidationError["code"],
+  message: string,
+): ResearchFundResult<never> {
+  return { status: "invalid", errors: [{ path, code, message, severity: "error" }] };
+}

--- a/admin/tests/server/contexts/research-fund/domain/models/journal-entry-hash.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/journal-entry-hash.test.ts
@@ -1,0 +1,90 @@
+import { JournalEntryHash } from "@/server/contexts/research-fund/domain/models/journal-entry-hash";
+
+const content: JournalEntryHash = {
+  entryDate: "2026-09-10",
+  amount: 1200,
+  description: "タクシー代",
+  documentId: "123",
+};
+
+describe("JournalEntryHash.generate", () => {
+  it("同じ内容をキー順に依存せず決定的なSHA-256にする", () => {
+    const result = JournalEntryHash.generate(content);
+    expect(result).toEqual({ status: "valid", value: expect.stringMatching(/^[a-f0-9]{64}$/) });
+    expect(
+      JournalEntryHash.generate({
+        documentId: "123",
+        description: "タクシー代",
+        amount: 1200,
+        entryDate: "2026-09-10",
+      }),
+    ).toEqual(result);
+    expect(JournalEntryHash.generate({ ...content })).toEqual(result);
+  });
+
+  it.each([
+    { entryDate: "2026-09-11" },
+    { amount: 1201 },
+    { description: "電車代" },
+    { documentId: "124" },
+    { documentId: null },
+  ])("同一性を構成する各項目の変更 %j でhashが変わる", (change) => {
+    expect(JournalEntryHash.generate({ ...content, ...change })).not.toEqual(
+      JournalEntryHash.generate(content),
+    );
+  });
+
+  it("書類なしは未指定とnullで同じhashになる", () => {
+    expect(JournalEntryHash.generate({ ...content, documentId: undefined })).toEqual(
+      JournalEntryHash.generate({ ...content, documentId: null }),
+    );
+  });
+
+  it("区切り文字を含む項目名と書類IDを混同しない", () => {
+    expect(
+      JournalEntryHash.generate({ ...content, description: "a|b", documentId: "c" }),
+    ).not.toEqual(JournalEntryHash.generate({ ...content, description: "a", documentId: "b|c" }));
+  });
+
+  it.each([
+    "2026-02-29",
+    "2026-04-31",
+    "2026-13-01",
+    "2026-00-01",
+    "2026-09-00",
+    "2026-9-1",
+    "invalid",
+    "",
+    "2026-09-10T00:00:00Z",
+  ])("不正な暦日 %s を拒否する", (entryDate) => {
+    expect(JournalEntryHash.generate({ ...content, entryDate })).toMatchObject({
+      status: "invalid",
+      errors: [{ code: "RF_INVALID_DATE" }],
+    });
+  });
+
+  it("うるう日を受け付ける", () => {
+    expect(JournalEntryHash.generate({ ...content, entryDate: "2024-02-29" }).status).toBe("valid");
+  });
+
+  it.each([0, -1, 0.5, NaN, Infinity, 1_000_000_000_000])(
+    "不正な金額 %s をhash化しない",
+    (amount) => {
+      expect(JournalEntryHash.generate({ ...content, amount })).toMatchObject({
+        status: "invalid",
+        errors: [{ code: "RF_INVALID_AMOUNT" }],
+      });
+    },
+  );
+
+  it("空の項目名や書類IDを拒否する", () => {
+    expect(JournalEntryHash.generate({ ...content, description: " " })).toMatchObject({
+      status: "invalid",
+      errors: [{ code: "RF_INVALID_DESCRIPTION" }],
+    });
+    expect(JournalEntryHash.generate({ ...content, documentId: " " })).toMatchObject({
+      status: "invalid",
+      errors: [{ code: "RF_INVALID_DOCUMENT" }],
+    });
+  });
+});

--- a/admin/tests/server/contexts/research-fund/domain/models/journal-entry.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/journal-entry.test.ts
@@ -1,0 +1,34 @@
+import { JournalEntry } from "@/server/contexts/research-fund/domain/models/journal-entry";
+
+describe("JournalEntry.transition", () => {
+  const statuses = ["draft", "approved", "published"] as const;
+  for (const status of statuses) {
+    for (const nextStatus of statuses) {
+      it(`${status} → ${nextStatus}`, () => {
+        const entry: JournalEntry = { status };
+        const result = JournalEntry.transition(entry, nextStatus);
+        if (
+          (status === "draft" && nextStatus === "approved") ||
+          (status === "approved" && nextStatus === "published")
+        ) {
+          expect(result).toEqual({ status: "valid", value: { status: nextStatus } });
+        } else {
+          expect(result).toMatchObject({
+            status: "invalid",
+            errors: [{ code: "RF_INVALID_STATUS_TRANSITION", path: "status", severity: "error" }],
+          });
+        }
+        expect(entry.status).toBe(status);
+      });
+    }
+  }
+
+  it("型の外から渡る不正な状態を拒否する", () => {
+    expect(
+      JournalEntry.transition({ status: "unknown" as JournalEntry["status"] }, "approved").status,
+    ).toBe("invalid");
+    expect(
+      JournalEntry.transition({ status: "draft" }, "unknown" as JournalEntry["status"]).status,
+    ).toBe("invalid");
+  });
+});

--- a/admin/tests/server/contexts/research-fund/domain/models/journal-posting.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/journal-posting.test.ts
@@ -1,0 +1,199 @@
+import {
+  JournalPosting,
+  type JournalLine,
+  type ResearchFundAccount,
+} from "@/server/contexts/research-fund/domain/models/journal-posting";
+
+const expense: ResearchFundAccount = { key: "taxi", type: "expense" };
+const bank: ResearchFundAccount = { key: "bank", type: "asset" };
+const cash: ResearchFundAccount = { key: "cash", type: "asset" };
+const income: ResearchFundAccount = { key: "grant-income", type: "income" };
+const expenseInput = {
+  pattern: "expense" as const,
+  source: "scan" as const,
+  amount: 1200,
+  account: expense,
+  assetAccount: bank,
+};
+
+function expectInvalid(result: ReturnType<typeof JournalPosting.generate>, code: string) {
+  expect(result).toEqual({
+    status: "invalid",
+    errors: [
+      expect.objectContaining({
+        code,
+        path: expect.any(String),
+        message: expect.any(String),
+        severity: "error",
+      }),
+    ],
+  });
+}
+
+describe("JournalPosting", () => {
+  it.each(["scan", "manual"] as const)("%s の支出は費用 / 資産を生成する", (source) => {
+    for (const assetAccount of [bank, cash]) {
+      const result = JournalPosting.generate({ ...expenseInput, source, assetAccount });
+      expect(result).toEqual({
+        status: "valid",
+        value: {
+          lines: [
+            { side: "debit", accountKey: "taxi", amount: 1200 },
+            { side: "credit", accountKey: assetAccount.key, amount: 1200 },
+          ],
+        },
+      });
+    }
+  });
+
+  it.each([
+    ["grant", "grant", "bank", "grant-income"],
+    ["refund", "manual", "grant-income", "bank"],
+  ] as const)("%s の借方と貸方を生成する", (pattern, source, debitKey, creditKey) => {
+    const input =
+      pattern === "grant"
+        ? {
+            pattern,
+            source: "grant" as const,
+            amount: 1_000_000,
+            account: income,
+            assetAccount: bank,
+          }
+        : {
+            pattern,
+            source: "manual" as const,
+            amount: 1_000_000,
+            account: income,
+            assetAccount: bank,
+          };
+    expect(input.source).toBe(source);
+    expect(JournalPosting.generate(input)).toEqual({
+      status: "valid",
+      value: {
+        lines: [
+          { side: "debit", accountKey: debitKey, amount: 1_000_000 },
+          { side: "credit", accountKey: creditKey, amount: 1_000_000 },
+        ],
+      },
+    });
+  });
+
+  it.each([1, 999_999_999_999])("境界金額 %s の生成結果は貸借一致する", (amount) => {
+    const result = JournalPosting.generate({ ...expenseInput, amount });
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") throw new Error("生成失敗");
+    expect(JournalPosting.validate(result.value.lines)).toEqual(result);
+    expect(Object.isFrozen(result.value)).toBe(true);
+    expect(Object.isFrozen(result.value.lines)).toBe(true);
+    expect(Object.isFrozen(result.value.lines[0])).toBe(true);
+  });
+
+  it.each([0, -1, 0.5, NaN, Infinity, -Infinity, 1_000_000_000_000, Number.MAX_SAFE_INTEGER + 1])(
+    "不正な金額 %s を拒否する",
+    (amount) => {
+      expectInvalid(JournalPosting.generate({ ...expenseInput, amount }), "RF_INVALID_AMOUNT");
+      expectInvalid(
+        JournalPosting.validate([
+          { side: "debit", accountKey: "taxi", amount },
+          { side: "credit", accountKey: "bank", amount },
+        ]),
+        "RF_INVALID_AMOUNT",
+      );
+    },
+  );
+
+  it.each([
+    bank,
+    income,
+    { key: " ", type: "expense" },
+    { key: "bank", type: "expense" },
+  ] satisfies ResearchFundAccount[])("不正な支出科目 %j を拒否する", (account) => {
+    expectInvalid(JournalPosting.generate({ ...expenseInput, account }), "RF_INVALID_ACCOUNT");
+  });
+
+  it.each([
+    expense,
+    { key: "bank", type: "income" },
+    { key: "other", type: "asset" },
+  ] satisfies ResearchFundAccount[])("不正な決済科目 %j を拒否する", (assetAccount) => {
+    expectInvalid(JournalPosting.generate({ ...expenseInput, assetAccount }), "RF_INVALID_ACCOUNT");
+  });
+
+  it("支給・返還では調査研究費収入と普通預金だけを許す", () => {
+    for (const pattern of ["grant", "refund"] as const) {
+      const input =
+        pattern === "grant"
+          ? { pattern, source: "grant" as const, amount: 1000, account: income, assetAccount: bank }
+          : {
+              pattern,
+              source: "manual" as const,
+              amount: 1000,
+              account: income,
+              assetAccount: bank,
+            };
+      expectInvalid(
+        JournalPosting.generate({ ...input, assetAccount: cash }),
+        "RF_INVALID_ACCOUNT",
+      );
+      for (const account of [expense, bank, { key: "other-income", type: "income" as const }]) {
+        expectInvalid(JournalPosting.generate({ ...input, account }), "RF_INVALID_ACCOUNT");
+      }
+    }
+  });
+
+  it.each([
+    { pattern: "unknown", source: "manual" },
+    { pattern: "expense", source: "grant" },
+    { pattern: "grant", source: "scan" },
+    { pattern: "refund", source: "grant" },
+  ])("型の外から渡る不正パターン %j を拒否する", (invalid) => {
+    const input = { ...expenseInput, ...invalid } as Parameters<typeof JournalPosting.generate>[0];
+    expectInvalid(JournalPosting.generate(input), "RF_INVALID_PATTERN");
+  });
+
+  it("複数行の貸借を検証し、入力の変更から検証済みの行を保護する", () => {
+    const lines: JournalLine[] = [
+      { side: "debit", accountKey: "taxi", amount: 100 },
+      { side: "debit", accountKey: "lodging", amount: 200 },
+      { side: "credit", accountKey: "bank", amount: 300 },
+    ];
+    const result = JournalPosting.validate(lines);
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") throw new Error("検証失敗");
+    lines[0] = { side: "debit", accountKey: "taxi", amount: 999 };
+    lines.pop();
+    expect(result.value.lines).toHaveLength(3);
+    expect(result.value.lines[0].amount).toBe(100);
+  });
+
+  it("貸借不一致と片側しかない仕訳を拒否する", () => {
+    expectInvalid(
+      JournalPosting.validate([
+        { side: "debit", accountKey: "taxi", amount: 100 },
+        { side: "credit", accountKey: "bank", amount: 99 },
+      ]),
+      "RF_UNBALANCED_POSTING",
+    );
+    expectInvalid(
+      JournalPosting.validate([
+        { side: "debit", accountKey: "taxi", amount: 100 },
+        { side: "debit", accountKey: "lodging", amount: 100 },
+      ]),
+      "RF_UNBALANCED_POSTING",
+    );
+  });
+
+  it("空・単一行・不正なside・科目なしを拒否する", () => {
+    const debit: JournalLine = { side: "debit", accountKey: "taxi", amount: 1 };
+    expectInvalid(JournalPosting.validate([]), "RF_INVALID_LINES");
+    expectInvalid(JournalPosting.validate([debit]), "RF_INVALID_LINES");
+    expectInvalid(
+      JournalPosting.validate([debit, { ...debit, side: "invalid" as JournalLine["side"] }]),
+      "RF_INVALID_LINES",
+    );
+    expectInvalid(
+      JournalPosting.validate([debit, { side: "credit", accountKey: " ", amount: 1 }]),
+      "RF_INVALID_ACCOUNT",
+    );
+  });
+});


### PR DESCRIPTION
調研費を管理する議員室スタッフが、支出・支給・年度末返還の入力時に貸借不一致の仕訳を作ってしまう状態を防ぐため、DBに依存しない仕訳ドメインを追加します。

- `JournalPosting` が科目の種別・入力元・円の整数金額を検証し、3パターンの借方と貸方を生成。既存行の貸借検証も提供し、検証済みの行はコピーして凍結します。
- `JournalEntry` が draft → approved → published の遷移を検証します。
- `JournalEntryHash` が暦日（YYYY-MM-DD）・金額・項目名・書類IDから決定的な SHA-256 を生成します。書類なしの未指定/nullは統一し、Node依存のhash生成はserver-onlyの別モデルに分離します。
- 不正入力はガイドに沿った path / RF_コード / 日本語message / severity を持つ検証結果で返します。

検証: `pnpm verify` 成功（admin 995件・webapp 135件成功、既存の1件skip）。追加分は3スイート・64件。画面・導線・認証の変更がないためE2Eは対象外です。

スコープアウト: #1375（CodeRabbit待機中にauto-mergeされたmain保護設定の確認。`loop:human`）。

Closes #1347
