### PR TITLE
docs(loop): CodeRabbit対応を次のループの修理モードに移す

### DIFF
--- a/.claude/commands/loop-once.md
+++ b/.claude/commands/loop-once.md
@@ -67,7 +67,8 @@ description: loop:ready のIssueを1つ選び、実装→ローカルCI→PR作�
    （「現在の状況」の reviewDecision が CHANGES_REQUESTED で、チェックは failure でもコンフリクトでもない）:
    - `gh api repos/{owner}/{repo}/pulls/<N>/reviews --jq '.[] | select(.state == "CHANGES_REQUESTED") | .user.login'` で誰の Request changes かを確認する。
      **人間のレビューが含まれていたら触らない**（人間の管轄。修理対象から除外して次の候補へ）。CodeRabbit だけなら番号最小の1件を修理する
-   - `gh pr checkout <N>` でブランチに乗り、後述の「CodeRabbit レビューの取り扱い」に従って指摘を処理する
+   - 新規PRを作ったループはレビューを待たずに終了するため、CodeRabbit の指摘はこの修理モードで処理するのが通常の経路となる。CodeRabbit がまだレビュー中（reviewDecision が空）のPRは、チェック失敗・コンフリクトがなければ健全として対象外にする
+   - `gh pr checkout <N>` でブランチに乗り、後述の「CodeRabbit レビューの取り扱い（修理モード専用）」に従って指摘を処理し、対応結果をPRにコメントする
    - 処理後、auto-merge 予約が生きているか `gh pr view <N> --json autoMergeRequest --jq '.autoMergeRequest != null'` で確認し、無ければ `gh pr merge --auto --squash` で予約する
    - 上限（後述）を超えても CodeRabbit の承認が得られなければ、PRは open のまま残し、Issueを `loop:wip` から `loop:human` に付け替えて状況をコメントし、`LOOP_RESULT: BLOCKED issue=#<N> reason=coderabbit-unresolved` で終了する
    - 修理が完了したら `LOOP_RESULT: SUCCESS issue=#<関連Issue番号> pr=<PR URL>` で終了する（このループでは新規Issueに進まない）
@@ -136,28 +137,13 @@ pnpm verify   # test / typecheck / lint / knip / depcruise
 - auto-mergeを予約する: `gh pr merge --auto --squash`。
   main の必須チェックは CI（`ci-complete`）と CodeRabbit のステータス（`CodeRabbit`）の両方なので、
   予約しておけば「全部 green で自動マージ」になり、CodeRabbit のレビュー完了前にマージされることはない。
-  ただし CodeRabbit の Request changes が付いたままだとマージされないので、次の手順で指摘を処理する
+  CodeRabbit の Request changes が付いた場合は、次のループが新規タスクより優先して修理モード（手順2-3）で指摘を処理する
 - Issueにコメント: `gh issue comment <N> --body "🤖 PR作成: <PR URL>"`
   - `loop:wip` ラベルはそのまま残す（PRマージでIssueが自動クローズされるまでの「in-flight」表示）
 
-### 8. CodeRabbit レビュー対応
+- ここで新規Issueの作業は完了。CodeRabbit のレビュー到着・指摘処理・承認を待たず、手順8の結果出力で終了する。
 
-後述の「CodeRabbit レビューの取り扱い」に従い、指摘を **修正する / 退ける / Issue化する** のいずれかに振り分けて処理する。
-CodeRabbit の全スレッドを resolve する（または待機の上限に達する）まで完了しない。
-承認とマージは auto-merge が待ってくれるので、承認そのものをこのループで待つ必要はない。
-
-### 9. 対応結果の記録
-
-- PRにコメントで CodeRabbit 対応の結果を残す（人間がマージ後に読む。退けた指摘の妥当性を人間が監査できるようにするため）:
-  ```
-  🤖 CodeRabbit レビュー対応: 修正 <a> 件 / 退け <b> 件 / Issue化 <c> 件
-  - 修正: <要約>（<commit>）
-  - 退け: <要約> — <理由>
-  - Issue化: #<M> <タイトル>
-  ```
-  指摘が1件もなかった場合や、CodeRabbit のレビューが上限時間内に届かなかった場合もその旨を書く
-
-### 10. 結果出力
+### 8. 結果出力
 
 ループの最後に、**必ず1行**、以下の形式で出力する:
 
@@ -166,7 +152,11 @@ CodeRabbit の全スレッドを resolve する（または待機の上限に達
 - エスカレーション: `LOOP_RESULT: BLOCKED issue=#<N> reason=<短い理由>`
 - その他失敗: `LOOP_RESULT: FAILED reason=<短い理由>`
 
-## CodeRabbit レビューの取り扱い
+## CodeRabbit レビューの取り扱い（修理モード専用）
+
+この節は手順2-3の修理モードでのみ実行する。新規PRを作成したループでは実行しない。
+別セッションでの対応となるため、開始時に `gh issue view <関連Issue番号> --json body,comments` と
+`gh pr diff <N>` で Issue 本文・コメント（Out of scope を含む）と PR 差分を読み直し、目的と変更範囲を把握する。
 
 CodeRabbit（`.coderabbit.yml` で `request_changes_workflow: true`）は指摘があると **Request changes** を出し、
 main のブランチ保護がレビューを要求しているため、これが auto-merge をブロックする。
@@ -244,11 +234,10 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thre
   退けた根拠がスレッドに残らず、人間が監査できなくなるため
 
 **(f) 承認を確認する。** 全スレッドが resolve され最新コミットがレビュー済みなら、CodeRabbit は数十秒で APPROVED に切り替え、
-auto-merge が CI green を待ってマージする。このループが承認を待ち続ける必要はない:
+auto-merge が CI green を待ってマージする。修理モードでは以下の上限内で承認を確認する:
 
-- **新規PRのループ（手順8）では**: (b) をもう一度実行して未解決スレッドが増えていないことを確認したら完了。
-  増えていれば (b) に戻る（ラウンド上限に注意）。CHANGES_REQUESTED が残ったとしても次のループの修理モードが拾う
-- **修理モード（手順2-3）では**: 直っているかを確認するため最大5分待つ:
+- (b) をもう一度実行して未解決スレッドが増えていないことを確認する。増えていれば (b) に戻る（ラウンド上限に注意）。
+- 修理が完了したかを確認するため最大5分待つ:
   ```bash
   for i in $(seq 1 5); do
     decision=$(gh pr view <N> --json reviewDecision --jq '.reviewDecision')
@@ -258,6 +247,20 @@ auto-merge が CI green を待ってマージする。このループが承認�
   ```
   未解決スレッドが無いのに CHANGES_REQUESTED のままなら、`gh pr comment <N> --body "@coderabbitai review"` で再レビューを促してもう一度だけ (a) から待つ。
   それでも解けなければエスカレーション（PRは open のまま残す）
+
+**(g) 対応結果を記録する。** 成功・エスカレーションのどちらの場合も、結果出力の前にPRへコメントする
+（人間がマージ後に読み、退けた指摘の妥当性を監査するため）:
+
+```text
+🤖 CodeRabbit レビュー対応: 修正 <a> 件 / 退け <b> 件 / Issue化 <c> 件
+- 修正: <要約>（<commit>）
+- 退け: <要約> — <理由>
+- Issue化: #<M> <タイトル>
+```
+
+指摘が1件もなかった場合や、CodeRabbit のレビューが上限時間内に届かなかった場合もその旨を書く。
+成功時は手順2-3に戻って auto-merge の予約を確認し、結果を出力する。
+エスカレーション時は後述のラベル変更・状況コメントを行い、BLOCKED の結果を出力する。
 
 ### 上限
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@
 |---------|------|---------|
 | [backend-architecture-guide.md](backend-architecture-guide.md) | webapp / admin のバックエンド実装ルール（Bounded Context・レイヤードアーキテクチャ） | 実装者・AIエージェント |
 | [admin-ui-guidelines.md](admin-ui-guidelines.md) | admin の UI コンポーネント利用ルール | 実装者・AIエージェント |
-| [loop-engineering.md](loop-engineering.md) | AIエージェントによる自律実装（ループエンジニアリング）の運用ルール | メンテナ・AIエージェント |
+| [loop-engineering.md](loop-engineering.md) | AIエージェントによる自律実装と、次のループでのPR修理・CodeRabbit対応の運用ルール | メンテナ・AIエージェント |
 | [getting-started.md](getting-started.md) | ローカル開発環境のセットアップ手順 | 新規参加者 |
 | [devin-feature-recording-guide.md](devin-feature-recording-guide.md) | 実装結果の動画撮影・報告手順 | Devin |
 

--- a/docs/loop-engineering.md
+++ b/docs/loop-engineering.md
@@ -11,11 +11,12 @@ AIエージェント（Claude Code）に実装を自律的に回してもらう�
 
 **1ループ = 1 Issue = 1 PR = 1セッション。**
 セッションを使い捨てることでコンテキスト膨張による品質劣化を防ぐ。
-1ループは「Issue選択 → 実装 → ローカルCI → PR（auto-merge予約）→ CodeRabbit の指摘処理」で完結し、
-CI と CodeRabbit が両方greenになれば自動マージされIssueが閉じる。
+新規Issueの1ループは「Issue選択 → 実装 → ローカルCI → PR作成 → auto-merge予約 → Issueにコメント → 結果出力」で完結する。
+PRを出したループは CodeRabbit のレビューを待たずに終了し、CI と CodeRabbit が両方greenになれば自動マージされIssueが閉じる。
+CodeRabbit の Request changes で止まったPRは、次のループが修理モードで処理する。
 
 **新規タスクより既存成果物の健全性が優先。**
-mainのCIが落ちている、あるいはloop PRがCI失敗・コンフリクトしているなら、
+mainのCIが落ちている、あるいはloop PRがCI失敗・コンフリクト・CodeRabbit の Request changes で止まっているなら、
 そのループは新規Issueではなく修理に充てる。壊れた土台の上に積み上げない。
 
 **詰まったら止まる。**
@@ -91,11 +92,14 @@ CodeRabbit のコミットステータス（`CodeRabbit`）も必須チェック
 
 - CI（`ci-complete`）と CodeRabbit のステータスの両方が必須チェックなので、ループは PR 作成直後に auto-merge を予約してよい
   （CodeRabbit のレビュー完了前にマージされることはない）。Request changes が付くとマージされないので、
-  ループはレビューが届くのを待って指摘を処理し、スレッドを閉じる。承認とマージは auto-merge に任せて終了できる
+  PRを作ったループは待たずに終了し、次のループが新規タスクより優先して修理モードで指摘を処理する。
+  CodeRabbit がまだレビュー中（reviewDecision が空）のPRは、CI失敗・コンフリクトがなければ健全として対象外にする
+- 修理モードでは別セッションでの対応となるため、Issue本文（Out of scope を含む）とPR差分を読み直してから指摘を判定する。
+  修正push後は最新コミットの再レビューを待ち、各スレッドへの返信・resolve、上限内での承認確認、対応結果のPRコメントを行う
 - 退ける場合は必ずスレッドに `🤖` で始まる理由を返信してから resolve する。黙って resolve すること、
   `@coderabbitai resolve` での一括 resolve、レビュー自体の dismiss は禁止（人間が後から監査できなくなる）
-- 修正の push は 2 ラウンドまで、全体で 30 分まで。超えたら PR を open のまま `loop:human` にエスカレーションする。
-  CodeRabbit のレビューが届かない場合（障害など）も同様にエスカレーションし、人間に知らせる
+- 修理モードでの修正の push は 2 ラウンドまで、全体で 30 分まで。超えたら PR を open のまま `loop:human` にエスカレーションする。
+  修理モードで CodeRabbit の再レビューが届かない場合（障害など）も同様にエスカレーションし、人間に知らせる
 - エスカレーション済みの PR（Issue が `loop:human` / `loop:blocked`）は、メンテナが `loop:ready` に戻すまで次のループも触らない
 - ループが自動処理するのは `coderabbitai[bot]` のスレッドだけ。人間のレビューは人間の管轄
 - 判定基準と手順の実体は [loop-once.md の「CodeRabbit レビューの取り扱い」](../.claude/commands/loop-once.md)


### PR DESCRIPTION
新規PRを作成したループが CodeRabbit のレビュー待機で長時間停止する状態を解消するため、PR作成・auto-merge予約・Issueへのコメント後に結果を出力して終了する手順へ変更します。Request changes が付いたPRは、次のループが新規タスクより優先して修理モードで処理します。

- レビュー中で reviewDecision が空のPRは、CI失敗・コンフリクトがなければ修理対象外と明記。
- CodeRabbit対応を修理モード専用とし、別セッションでIssue本文とPR差分を読み直す手順を追加。修正push後の再レビュー待機、承認確認、対応結果のPRコメントを維持。
- 運用ドキュメントとドキュメント一覧も更新。

検証: `pnpm verify` 成功（test / typecheck / lint / knip / depcruise）。ドキュメントのみの変更のためE2Eは対象外。`git diff --check` 成功。

Closes #1374


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - ループ運用の説明を更新し、PR作成後は次のループで修理モードを実行する手順を明確化しました。
  - 修理モードの対象に、CodeRabbitによる変更要求で停止したPRを追加しました。
  - CI失敗やコンフリクト、レビュー未着時のエスカレーション条件を整理しました。
  - 一覧説明に、PR修理とCodeRabbit対応を含む運用ルールを反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->