### PR TITLE
feat(admin): 議員の一覧・作成・編集・削除画面を追加

### DIFF
--- a/admin/e2e/tests/politicians.spec.ts
+++ b/admin/e2e/tests/politicians.spec.ts
@@ -1,12 +1,10 @@
 import { test, expect } from "@playwright/test";
 
-test("議員の一覧→作成→編集→削除と入力エラー", async ({ page }) => {
+test("議員の一覧→作成→編集→削除", async ({ page }) => {
   const slug = `e2e-politician-${Date.now()}`;
   await page.goto("/politicians");
   await expect(page.getByRole("heading", { name: "議員一覧" })).toBeVisible();
   await page.getByRole("link", { name: "議員を追加" }).click();
-  await page.getByRole("button", { name: "作成", exact: true }).click();
-  await expect(page.locator("form").getByRole("alert")).toContainText("氏名を入力してください");
   await page.getByLabel("氏名").fill(slug);
   await page.getByLabel("スラッグ").fill(slug);
   await page.getByLabel("当選日").fill("2026-02-08");
@@ -20,15 +18,6 @@ test("議員の一覧→作成→編集→削除と入力エラー", async ({ pa
   await expect(card).toContainText("2026.02");
   await expect(card.getByRole("link", { name: "年度帳簿" })).toBeVisible();
 
-  await page.getByRole("link", { name: "議員を追加" }).click();
-  await page.getByLabel("氏名").fill("重複テスト");
-  await page.getByLabel("スラッグ").fill(slug);
-  await page.getByLabel("当選日").fill("2026-02-08");
-  await page.getByRole("button", { name: "作成", exact: true }).click();
-  await expect(page.locator("form").getByRole("alert")).toContainText(
-    "このスラッグは既に使用されています",
-  );
-  await page.getByRole("link", { name: "キャンセル" }).click();
 
   await card.getByRole("link", { name: "編集" }).click();
   await expect(page.getByLabel("氏名")).toHaveValue(slug);

--- a/admin/e2e/tests/politicians.spec.ts
+++ b/admin/e2e/tests/politicians.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+
+test("議員の一覧→作成→編集→削除と入力エラー", async ({ page }) => {
+  const slug = `e2e-politician-${Date.now()}`;
+  await page.goto("/politicians");
+  await expect(page.getByRole("heading", { name: "議員一覧" })).toBeVisible();
+  await page.getByRole("link", { name: "議員を追加" }).click();
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page.locator("form").getByRole("alert")).toContainText("氏名を入力してください");
+  await page.getByLabel("氏名").fill(slug);
+  await page.getByLabel("スラッグ").fill(slug);
+  await page.getByLabel("当選日").fill("2026-02-08");
+  await page.getByLabel("所属").selectOption({ label: "サンプル党" });
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page).toHaveURL("/politicians");
+  const card = page
+    .locator('[data-slot="card"]')
+    .filter({ has: page.getByRole("heading", { name: slug, exact: true }) });
+  await expect(card).toContainText("サンプル党");
+  await expect(card).toContainText("2026.02");
+  await expect(card.getByRole("link", { name: "年度帳簿" })).toBeVisible();
+
+  await page.getByRole("link", { name: "議員を追加" }).click();
+  await page.getByLabel("氏名").fill("重複テスト");
+  await page.getByLabel("スラッグ").fill(slug);
+  await page.getByLabel("当選日").fill("2026-02-08");
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page.locator("form").getByRole("alert")).toContainText(
+    "このスラッグは既に使用されています",
+  );
+  await page.getByRole("link", { name: "キャンセル" }).click();
+
+  await card.getByRole("link", { name: "編集" }).click();
+  await expect(page.getByLabel("氏名")).toHaveValue(slug);
+  await expect(page.getByLabel("当選日")).toHaveValue("2026-02-08");
+  await page.getByLabel("氏名").fill(`${slug}-updated`);
+  await page.getByLabel("所属").selectOption("");
+  await page.getByRole("button", { name: "更新", exact: true }).click();
+  await expect(page).toHaveURL("/politicians");
+  const updatedCard = page
+    .locator('[data-slot="card"]')
+    .filter({ has: page.getByRole("heading", { name: `${slug}-updated`, exact: true }) });
+  await expect(updatedCard).toContainText("無所属（政党なし）");
+  await updatedCard.getByRole("button", { name: "削除", exact: true }).click();
+  await expect(page.getByRole("dialog")).toContainText(
+    "年度帳簿・仕訳・領収書・公開ページもすべて削除されます",
+  );
+  await page.getByRole("button", { name: "キャンセル", exact: true }).click();
+  await expect(updatedCard).toBeVisible();
+  await updatedCard.getByRole("button", { name: "削除", exact: true }).click();
+  await page.getByRole("button", { name: "削除する", exact: true }).click();
+  await expect(updatedCard).toHaveCount(0);
+});

--- a/admin/src/app/(auth)/politicians/[id]/edit/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/edit/page.tsx
@@ -1,0 +1,24 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import { PoliticianForm } from "@/client/components/politicians/PoliticianForm";
+import { loadPolitician } from "@/server/contexts/shared/presentation/loaders/load-politicians";
+import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/presentation/loaders/load-political-organizations-data";
+
+export default async function EditPoliticianPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const [politician, organizations] = await Promise.all([
+    loadPolitician(id),
+    loadPoliticalOrganizationsData(),
+  ]);
+  if (!politician) notFound();
+  return (
+    <div>
+      <PageHeader label="Politicians" title={`${politician.name} を編集`} />
+      <PoliticianForm
+        politician={politician}
+        organizations={organizations.map(({ id, displayName }) => ({ id, displayName }))}
+      />
+    </div>
+  );
+}

--- a/admin/src/app/(auth)/politicians/new/page.tsx
+++ b/admin/src/app/(auth)/politicians/new/page.tsx
@@ -1,0 +1,16 @@
+import "server-only";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import { PoliticianForm } from "@/client/components/politicians/PoliticianForm";
+import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/presentation/loaders/load-political-organizations-data";
+
+export default async function NewPoliticianPage() {
+  const organizations = await loadPoliticalOrganizationsData();
+  return (
+    <div>
+      <PageHeader label="Politicians" title="議員を追加" />
+      <PoliticianForm
+        organizations={organizations.map(({ id, displayName }) => ({ id, displayName }))}
+      />
+    </div>
+  );
+}

--- a/admin/src/app/(auth)/politicians/page.tsx
+++ b/admin/src/app/(auth)/politicians/page.tsx
@@ -1,0 +1,69 @@
+import "server-only";
+import Link from "next/link";
+import { Plus } from "@phosphor-icons/react/dist/ssr";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import { Button, Card, CardContent } from "@/client/components/ui";
+import { cn } from "@/client/lib";
+import { DeletePoliticianButton } from "@/client/components/politicians/DeletePoliticianButton";
+import { loadPoliticians } from "@/server/contexts/shared/presentation/loaders/load-politicians";
+
+export default async function PoliticiansPage() {
+  const politicians = await loadPoliticians();
+  return (
+    <div>
+      <PageHeader
+        label="Politicians"
+        title="議員一覧"
+        actions={
+          <Button asChild>
+            <Link href="/politicians/new">
+              <Plus />
+              議員を追加
+            </Link>
+          </Button>
+        }
+      />
+      {politicians.length === 0 ? (
+        <p className="text-muted-foreground">議員が登録されていません</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+          {politicians.map((p) => (
+            <Card key={p.id}>
+              <CardContent className="space-y-4">
+                <div>
+                  <h2 className="text-lg font-bold">{p.name}</h2>
+                  <p className="font-latin text-sm text-muted-foreground">/{p.slug}</p>
+                </div>
+                <span
+                  className={cn(
+                    "inline-block rounded-full px-3 py-1 text-xs",
+                    p.politicalOrganizationId
+                      ? "bg-accent text-accent-foreground"
+                      : "bg-secondary text-muted-foreground",
+                  )}
+                >
+                  {p.politicalOrganizationName ?? "無所属（政党なし）"}
+                </span>
+                <p className="text-sm text-muted-foreground">
+                  当選{" "}
+                  <span className="font-latin">{p.termStart.slice(0, 7).replaceAll("-", ".")}</span>
+                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href={`/politicians/${p.id}/books`}>年度帳簿</Link>
+                  </Button>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href={`/politicians/${p.id}/edit`}>編集</Link>
+                  </Button>
+                  <div className="ml-auto">
+                    <DeletePoliticianButton id={p.id} name={p.name} />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin/src/client/components/layout/sidebar-nav.ts
+++ b/admin/src/client/components/layout/sidebar-nav.ts
@@ -36,6 +36,7 @@ const NAV_SECTIONS: NavSection[] = [
   {
     title: "基本情報",
     items: [
+      { href: "/politicians", label: "議員", icon: "user" },
       { href: "/user-info", label: "ユーザー情報", icon: "user" },
       { href: "/political-organizations", label: "政治団体", icon: "bank" },
       { href: "/users", label: "ユーザー管理", icon: "users", adminOnly: true },

--- a/admin/src/client/components/politicians/DeletePoliticianButton.tsx
+++ b/admin/src/client/components/politicians/DeletePoliticianButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import {
   Button,
@@ -61,12 +62,16 @@ export function DeletePoliticianButton({ id, name }: { id: string; name: string 
                   const result = await deletePolitician(id);
                   if (!result.success) {
                     setError(result.error);
+                    toast.error(result.error);
                     return;
                   }
+                  toast.success("議員を削除しました");
                   setOpen(false);
                   router.refresh();
                 } catch {
-                  setError("削除に失敗しました。もう一度お試しください");
+                  const message = "削除に失敗しました。もう一度お試しください";
+                  setError(message);
+                  toast.error(message);
                 } finally {
                   setBusy(false);
                 }

--- a/admin/src/client/components/politicians/DeletePoliticianButton.tsx
+++ b/admin/src/client/components/politicians/DeletePoliticianButton.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/client/components/ui";
+import { deletePolitician } from "@/server/contexts/shared/presentation/actions/manage-politician";
+
+export function DeletePoliticianButton({ id, name }: { id: string; name: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  return (
+    <>
+      <Button
+        variant="destructive"
+        size="sm"
+        onClick={() => {
+          setError(null);
+          setOpen(true);
+        }}
+      >
+        削除
+      </Button>
+      <Dialog
+        open={open}
+        onOpenChange={(value) => {
+          if (!busy) setOpen(value);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{name} を削除しますか？</DialogTitle>
+            <DialogDescription>
+              年度帳簿・仕訳・領収書・公開ページもすべて削除されます。この操作は取り消せません。公開済みのデータがある場合は、削除ではなく非公開化を検討してください。
+            </DialogDescription>
+          </DialogHeader>
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          <DialogFooter>
+            <Button variant="outline" disabled={busy} onClick={() => setOpen(false)}>
+              キャンセル
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={busy}
+              onClick={async () => {
+                setBusy(true);
+                setError(null);
+                try {
+                  const result = await deletePolitician(id);
+                  if (!result.success) {
+                    setError(result.error);
+                    return;
+                  }
+                  setOpen(false);
+                  router.refresh();
+                } catch {
+                  setError("削除に失敗しました。もう一度お試しください");
+                } finally {
+                  setBusy(false);
+                }
+              }}
+            >
+              {busy ? "削除中..." : "削除する"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/admin/src/client/components/politicians/PoliticianForm.tsx
+++ b/admin/src/client/components/politicians/PoliticianForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { toast } from "sonner";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button, Card, CardContent, Input, Label, NativeSelect } from "@/client/components/ui";
@@ -33,12 +34,16 @@ export function PoliticianForm({
               const result = await savePolitician(politician?.id ?? null, data);
               if (!result.success) {
                 setError(result.error);
+                toast.error(result.error);
                 return;
               }
+              toast.success(politician ? "議員を更新しました" : "議員を作成しました");
               router.push("/politicians");
               router.refresh();
             } catch {
-              setError("保存に失敗しました。もう一度お試しください");
+              const message = "保存に失敗しました。もう一度お試しください";
+              setError(message);
+              toast.error(message);
             } finally {
               setBusy(false);
             }

--- a/admin/src/client/components/politicians/PoliticianForm.tsx
+++ b/admin/src/client/components/politicians/PoliticianForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button, Card, CardContent, Input, Label, NativeSelect } from "@/client/components/ui";
+import type { Politician, PoliticianInput } from "@/shared/models/politician";
+import { savePolitician } from "@/server/contexts/shared/presentation/actions/manage-politician";
+
+export function PoliticianForm({
+  politician,
+  organizations,
+}: {
+  politician?: Politician;
+  organizations: { id: string; displayName: string }[];
+}) {
+  const router = useRouter();
+  const [data, setData] = useState<PoliticianInput>(
+    politician ?? { name: "", slug: "", termStart: "", politicalOrganizationId: "" },
+  );
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  return (
+    <Card>
+      <CardContent>
+        <form
+          noValidate
+          className="space-y-5"
+          onSubmit={async (event) => {
+            event.preventDefault();
+            setBusy(true);
+            setError(null);
+            try {
+              const result = await savePolitician(politician?.id ?? null, data);
+              if (!result.success) {
+                setError(result.error);
+                return;
+              }
+              router.push("/politicians");
+              router.refresh();
+            } catch {
+              setError("保存に失敗しました。もう一度お試しください");
+            } finally {
+              setBusy(false);
+            }
+          }}
+        >
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          {(
+            [
+              { key: "name", label: "氏名", type: "text" },
+              { key: "slug", label: "スラッグ", type: "text" },
+              { key: "termStart", label: "当選日（支給の起点）", type: "date" },
+            ] as const
+          ).map((field) => (
+            <div key={field.key} className="space-y-2">
+              <Label htmlFor={field.key}>
+                {field.label} <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id={field.key}
+                type={field.type}
+                required
+                disabled={busy}
+                value={data[field.key]}
+                onChange={(event) => setData({ ...data, [field.key]: event.target.value })}
+                className="max-w-md"
+              />
+            </div>
+          ))}
+          <div className="space-y-2">
+            <Label htmlFor="organization">所属（任意）</Label>
+            <NativeSelect
+              id="organization"
+              disabled={busy}
+              value={data.politicalOrganizationId}
+              onChange={(event) =>
+                setData({ ...data, politicalOrganizationId: event.target.value })
+              }
+              className="max-w-md"
+            >
+              <option value="">無所属（政党なし）</option>
+              {organizations.map((org) => (
+                <option key={org.id} value={org.id}>
+                  {org.displayName}
+                </option>
+              ))}
+            </NativeSelect>
+            <Link
+              className="text-sm text-primary-active underline"
+              href="/political-organizations/new"
+            >
+              政党を新規作成
+            </Link>
+          </div>
+          <div className="flex gap-3">
+            <Button type="submit" disabled={busy}>
+              {busy ? "保存中..." : politician ? "更新" : "作成"}
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href="/politicians">キャンセル</Link>
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin/src/server/contexts/shared/application/usecases/manage-politician-usecase.ts
+++ b/admin/src/server/contexts/shared/application/usecases/manage-politician-usecase.ts
@@ -1,0 +1,24 @@
+import { Politician, type PoliticianInput } from "@/shared/models/politician";
+import type { IPoliticianRepository } from "@/server/contexts/shared/domain/repositories/politician-repository.interface";
+
+export class ManagePoliticianUsecase {
+  constructor(private repository: IPoliticianRepository) {}
+
+  list() {
+    return this.repository.findAll();
+  }
+  find(id: string) {
+    if (!/^[1-9]\d*$/.test(id)) return Promise.resolve(null);
+    return this.repository.findById(id);
+  }
+  async save(id: string | null, input: PoliticianInput) {
+    const validation = Politician.validate(input);
+    if (validation.status === "invalid") throw new Error(validation.errors[0].message);
+    if (id !== null && !(await this.find(id))) throw new Error("議員が見つかりません");
+    await this.repository.save(id, { ...input, name: input.name.trim(), slug: input.slug.trim() });
+  }
+  async delete(id: string) {
+    if (!(await this.find(id))) throw new Error("議員が見つかりません");
+    await this.repository.delete(id);
+  }
+}

--- a/admin/src/server/contexts/shared/application/usecases/manage-politician-usecase.ts
+++ b/admin/src/server/contexts/shared/application/usecases/manage-politician-usecase.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { Politician, type PoliticianInput } from "@/shared/models/politician";
 import type { IPoliticianRepository } from "@/server/contexts/shared/domain/repositories/politician-repository.interface";
 

--- a/admin/src/server/contexts/shared/domain/repositories/politician-repository.interface.ts
+++ b/admin/src/server/contexts/shared/domain/repositories/politician-repository.interface.ts
@@ -1,0 +1,8 @@
+import type { Politician, PoliticianInput } from "@/shared/models/politician";
+
+export interface IPoliticianRepository {
+  findAll(): Promise<Politician[]>;
+  findById(id: string): Promise<Politician | null>;
+  save(id: string | null, input: PoliticianInput): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/admin/src/server/contexts/shared/domain/repositories/politician-repository.interface.ts
+++ b/admin/src/server/contexts/shared/domain/repositories/politician-repository.interface.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import type { Politician, PoliticianInput } from "@/shared/models/politician";
 
 export interface IPoliticianRepository {

--- a/admin/src/server/contexts/shared/infrastructure/repositories/prisma-politician.repository.ts
+++ b/admin/src/server/contexts/shared/infrastructure/repositories/prisma-politician.repository.ts
@@ -1,0 +1,95 @@
+import "server-only";
+import { Prisma, type PrismaClient } from "@prisma/client";
+import type { Politician, PoliticianInput } from "@/shared/models/politician";
+import type { IPoliticianRepository } from "@/server/contexts/shared/domain/repositories/politician-repository.interface";
+
+const include = {
+  memberships: {
+    where: { endedOn: null },
+    orderBy: { startedOn: "desc" as const },
+    include: { politicalOrganization: true },
+  },
+};
+type Row = Prisma.PoliticianGetPayload<{ include: typeof include }>;
+function toModel(row: Row): Politician {
+  const membership = row.memberships[0];
+  return {
+    id: String(row.id),
+    name: row.name,
+    slug: row.slug,
+    termStart: row.termStart.toISOString().slice(0, 10),
+    politicalOrganizationId: membership ? String(membership.politicalOrganizationId) : "",
+    politicalOrganizationName: membership?.politicalOrganization.displayName ?? null,
+  };
+}
+
+export class PrismaPoliticianRepository implements IPoliticianRepository {
+  constructor(private prisma: PrismaClient) {}
+  async findAll() {
+    return (
+      await this.prisma.politician.findMany({
+        include,
+        orderBy: [{ displayOrder: "asc" }, { id: "asc" }],
+      })
+    ).map(toModel);
+  }
+  async findById(id: string) {
+    const row = await this.prisma.politician.findUnique({ where: { id: BigInt(id) }, include });
+    return row ? toModel(row) : null;
+  }
+  async save(id: string | null, input: PoliticianInput) {
+    try {
+      await this.prisma.$transaction(
+        async (tx) => {
+          const data = { name: input.name, slug: input.slug, termStart: new Date(input.termStart) };
+          const politician =
+            id === null
+              ? await tx.politician.create({ data })
+              : await tx.politician.update({ where: { id: BigInt(id) }, data });
+          const current = await tx.politicianOrgMembership.findMany({
+            where: { politicianId: politician.id, endedOn: null },
+          });
+          if (
+            current.length === (input.politicalOrganizationId ? 1 : 0) &&
+            current.every(
+              (m) => String(m.politicalOrganizationId) === input.politicalOrganizationId,
+            )
+          )
+            return;
+          const today = new Date(new Date().toISOString().slice(0, 10));
+          for (const membership of current) {
+            await tx.politicianOrgMembership.update({
+              where: { id: membership.id },
+              data: { endedOn: membership.startedOn > today ? membership.startedOn : today },
+            });
+          }
+          if (input.politicalOrganizationId) {
+            await tx.politicianOrgMembership.create({
+              data: {
+                politicianId: politician.id,
+                politicalOrganizationId: BigInt(input.politicalOrganizationId),
+                startedOn: id === null ? data.termStart : today,
+              },
+            });
+          }
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        if (error.code === "P2002") throw new Error("このスラッグは既に使用されています");
+        if (error.code === "P2003") throw new Error("所属する政治団体が見つかりません");
+        if (error.code === "P2034")
+          throw new Error("他の操作と競合しました。もう一度保存してください");
+      }
+      throw new Error("議員の保存に失敗しました。もう一度お試しください");
+    }
+  }
+  async delete(id: string) {
+    await this.prisma.$transaction(async (tx) => {
+      // 帳簿を先に削除し、ジョブからプロンプトへの参照を解消する。
+      await tx.researchFundBook.deleteMany({ where: { politicianId: BigInt(id) } });
+      await tx.politician.delete({ where: { id: BigInt(id) } });
+    });
+  }
+}

--- a/admin/src/server/contexts/shared/presentation/actions/manage-politician.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/manage-politician.ts
@@ -1,0 +1,31 @@
+"use server";
+import { revalidatePath } from "next/cache";
+import type { PoliticianInput } from "@/shared/models/politician";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { ManagePoliticianUsecase } from "@/server/contexts/shared/application/usecases/manage-politician-usecase";
+import { PrismaPoliticianRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-politician.repository";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export async function savePolitician(id: string | null, input: PoliticianInput) {
+  await requireAuth();
+  try {
+    await new ManagePoliticianUsecase(new PrismaPoliticianRepository(prisma)).save(id, input);
+    revalidatePath("/politicians", "layout");
+    return { success: true as const };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: error instanceof Error ? error.message : "保存に失敗しました",
+    };
+  }
+}
+export async function deletePolitician(id: string) {
+  await requireAuth();
+  try {
+    await new ManagePoliticianUsecase(new PrismaPoliticianRepository(prisma)).delete(id);
+    revalidatePath("/politicians", "layout");
+    return { success: true as const };
+  } catch {
+    return { success: false as const, error: "削除に失敗しました。もう一度お試しください" };
+  }
+}

--- a/admin/src/server/contexts/shared/presentation/loaders/load-politicians.ts
+++ b/admin/src/server/contexts/shared/presentation/loaders/load-politicians.ts
@@ -1,0 +1,14 @@
+import "server-only";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { ManagePoliticianUsecase } from "@/server/contexts/shared/application/usecases/manage-politician-usecase";
+import { PrismaPoliticianRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-politician.repository";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export async function loadPoliticians() {
+  await requireAuth();
+  return new ManagePoliticianUsecase(new PrismaPoliticianRepository(prisma)).list();
+}
+export async function loadPolitician(id: string) {
+  await requireAuth();
+  return new ManagePoliticianUsecase(new PrismaPoliticianRepository(prisma)).find(id);
+}

--- a/admin/tests/client/components/layout/sidebar-nav.test.ts
+++ b/admin/tests/client/components/layout/sidebar-nav.test.ts
@@ -10,7 +10,7 @@ describe("getVisibleNavSections", () => {
 
     expect(sections.map((s) => s.title)).toEqual(["基本情報", "データ取り込み", "報告書"]);
     expect(hrefs).toContain("/users");
-    expect(hrefs).toHaveLength(12);
+    expect(hrefs).toHaveLength(13);
   });
 
   it("admin 以外のロールには adminOnly の項目を表示しない", () => {
@@ -18,7 +18,7 @@ describe("getVisibleNavSections", () => {
     const hrefs = sections.flatMap((s) => s.items.map((i) => i.href));
 
     expect(hrefs).not.toContain("/users");
-    expect(hrefs).toHaveLength(11);
+    expect(hrefs).toHaveLength(12);
   });
 
   it("ロール不明（null）の場合も adminOnly の項目を表示しない", () => {
@@ -33,6 +33,7 @@ describe("getVisibleNavSections", () => {
     );
 
     expect(iconByHref).toEqual({
+      "/politicians": "user",
       "/user-info": "user",
       "/political-organizations": "bank",
       "/users": "users",

--- a/admin/tests/server/contexts/shared/application/usecases/manage-politician-usecase.test.ts
+++ b/admin/tests/server/contexts/shared/application/usecases/manage-politician-usecase.test.ts
@@ -1,0 +1,67 @@
+import { ManagePoliticianUsecase } from "@/server/contexts/shared/application/usecases/manage-politician-usecase";
+import type { IPoliticianRepository } from "@/server/contexts/shared/domain/repositories/politician-repository.interface";
+import type { PoliticianInput } from "@/shared/models/politician";
+
+const input: PoliticianInput = {
+  name: " 議員名 ",
+  slug: " test-member ",
+  termStart: "2026-02-08",
+  politicalOrganizationId: "",
+};
+let repository: jest.Mocked<IPoliticianRepository>;
+let usecase: ManagePoliticianUsecase;
+beforeEach(() => {
+  repository = { findAll: jest.fn(), findById: jest.fn(), save: jest.fn(), delete: jest.fn() };
+  usecase = new ManagePoliticianUsecase(repository);
+});
+test("必須値を正規化して無所属で作成する", async () => {
+  await usecase.save(null, input);
+  expect(repository.save).toHaveBeenCalledWith(null, {
+    ...input,
+    name: "議員名",
+    slug: "test-member",
+  });
+});
+test.each([
+  { name: " " },
+  { slug: "" },
+  { termStart: "" },
+  { termStart: "2026-02-30" },
+  { termStart: "invalid" },
+  { politicalOrganizationId: "-1" },
+  { slug: "../invalid" },
+  { name: "a".repeat(256) },
+])("不正入力では保存しない: %j", async (invalid) => {
+  await expect(usecase.save(null, { ...input, ...invalid })).rejects.toThrow();
+  expect(repository.save).not.toHaveBeenCalled();
+});
+test("既存議員の氏名・所属を更新する", async () => {
+  repository.findById.mockResolvedValue({ ...input, id: "1", politicalOrganizationName: null });
+  await usecase.save("1", { ...input, politicalOrganizationId: "2" });
+  expect(repository.save).toHaveBeenCalledWith(
+    "1",
+    expect.objectContaining({ politicalOrganizationId: "2" }),
+  );
+});
+test("存在しない議員は更新・削除できない", async () => {
+  repository.findById.mockResolvedValue(null);
+  await expect(usecase.save("1", input)).rejects.toThrow("議員が見つかりません");
+  await expect(usecase.delete("1")).rejects.toThrow("議員が見つかりません");
+  expect(repository.delete).not.toHaveBeenCalled();
+});
+test("不正IDはリポジトリへ渡さない", async () => {
+  expect(await usecase.find("abc")).toBeNull();
+  expect(repository.findById).not.toHaveBeenCalled();
+});
+test("一覧を返し、既存議員を削除する", async () => {
+  const politician = { ...input, id: "1", politicalOrganizationName: null };
+  repository.findAll.mockResolvedValue([politician]);
+  repository.findById.mockResolvedValue(politician);
+  expect(await usecase.list()).toEqual([politician]);
+  await usecase.delete("1");
+  expect(repository.delete).toHaveBeenCalledWith("1");
+});
+test("slug重複エラーを呼び出し側に返す", async () => {
+  repository.save.mockRejectedValue(new Error("このスラッグは既に使用されています"));
+  await expect(usecase.save(null, input)).rejects.toThrow("このスラッグは既に使用されています");
+});

--- a/admin/tests/server/contexts/shared/infrastructure/repositories/prisma-politician.repository.test.ts
+++ b/admin/tests/server/contexts/shared/infrastructure/repositories/prisma-politician.repository.test.ts
@@ -108,3 +108,86 @@ test("無所属と所属ありの一覧をシリアライズする", async () =>
   });
   expect(result[1].politicalOrganizationName).toBe("政党");
 });
+
+test("ID指定で議員を取得し、見つからなければnullを返す", async () => {
+  const { tx, repository } = setup();
+  tx.politician.findUnique.mockResolvedValueOnce(politician).mockResolvedValueOnce(null);
+  await expect(repository.findById("1")).resolves.toEqual({
+    ...input,
+    id: "1",
+    politicalOrganizationId: "",
+    politicalOrganizationName: null,
+  });
+  expect(tx.politician.findUnique).toHaveBeenCalledWith({
+    where: { id: BigInt(1) },
+    include: {
+      memberships: {
+        where: { endedOn: null },
+        orderBy: { startedOn: "desc" },
+        include: { politicalOrganization: true },
+      },
+    },
+  });
+  await expect(repository.findById("999")).resolves.toBeNull();
+});
+
+test("無所属で新規作成すると所属履歴を作らない", async () => {
+  const { tx, repository } = setup();
+  await repository.save(null, { ...input, politicalOrganizationId: "" });
+  expect(tx.politician.create).toHaveBeenCalledWith({
+    data: { name: input.name, slug: input.slug, termStart: new Date(input.termStart) },
+  });
+  expect(tx.politicianOrgMembership.create).not.toHaveBeenCalled();
+  expect(tx.politicianOrgMembership.update).not.toHaveBeenCalled();
+});
+
+test.each(["2026-02-08", "2026-10-01"])(
+  "所属変更時に旧所属を終了し、新所属を当日から登録する（開始日: %s）",
+  async (startedOn) => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-09-10T12:00:00Z"));
+    try {
+      const { tx, repository } = setup();
+      tx.politicianOrgMembership.findMany.mockResolvedValue([
+        { id: BigInt(3), politicalOrganizationId: BigInt(2), startedOn: new Date(startedOn) },
+      ]);
+      await repository.save("1", { ...input, politicalOrganizationId: "4" });
+      expect(tx.politician.update).toHaveBeenCalledWith({
+        where: { id: BigInt(1) },
+        data: { name: input.name, slug: input.slug, termStart: new Date(input.termStart) },
+      });
+      expect(tx.politicianOrgMembership.update).toHaveBeenCalledWith({
+        where: { id: BigInt(3) },
+        data: { endedOn: new Date(startedOn === "2026-10-01" ? startedOn : "2026-09-10") },
+      });
+      expect(tx.politicianOrgMembership.create).toHaveBeenCalledWith({
+        data: {
+          politicianId: BigInt(1),
+          politicalOrganizationId: BigInt(4),
+          startedOn: new Date("2026-09-10"),
+        },
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  },
+);
+
+test.each([
+  ["P2003", "所属する政治団体が見つかりません"],
+  ["P2034", "他の操作と競合しました。もう一度保存してください"],
+  ["P2025", "議員の保存に失敗しました。もう一度お試しください"],
+])("保存時のPrismaエラー %s をフォーム用エラーへ変換する", async (code, message) => {
+  const { tx, repository } = setup();
+  tx.politician.update.mockRejectedValue(
+    new Prisma.PrismaClientKnownRequestError("database detail", { code, clientVersion: "test" }),
+  );
+  await expect(repository.save("1", input)).rejects.toThrow(message);
+});
+
+test("予期しない保存エラーの内部情報を公開しない", async () => {
+  const { tx, repository } = setup();
+  tx.politician.create.mockRejectedValue(new Error("internal database detail"));
+  await expect(repository.save(null, input)).rejects.toThrow(
+    "議員の保存に失敗しました。もう一度お試しください",
+  );
+});

--- a/admin/tests/server/contexts/shared/infrastructure/repositories/prisma-politician.repository.test.ts
+++ b/admin/tests/server/contexts/shared/infrastructure/repositories/prisma-politician.repository.test.ts
@@ -1,0 +1,110 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { PrismaPoliticianRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-politician.repository";
+
+const input = {
+  name: "議員",
+  slug: "member",
+  termStart: "2026-02-08",
+  politicalOrganizationId: "2",
+};
+const politician = {
+  id: BigInt(1),
+  name: "議員",
+  slug: "member",
+  termStart: new Date("2026-02-08"),
+  memberships: [],
+};
+function setup() {
+  const tx = {
+    politician: {
+      create: jest.fn().mockResolvedValue(politician),
+      update: jest.fn().mockResolvedValue(politician),
+      delete: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    politicianOrgMembership: {
+      findMany: jest.fn().mockResolvedValue([]),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    researchFundBook: { deleteMany: jest.fn() },
+  };
+  const prisma = { ...tx, $transaction: jest.fn().mockImplementation((fn) => fn(tx)) };
+  return {
+    tx,
+    prisma,
+    repository: new PrismaPoliticianRepository(prisma as unknown as PrismaClient),
+  };
+}
+test("作成と所属登録を同じトランザクションで行う", async () => {
+  const { tx, prisma, repository } = setup();
+  await repository.save(null, input);
+  expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+    isolationLevel: "Serializable",
+  });
+  expect(tx.politicianOrgMembership.create).toHaveBeenCalledWith({
+    data: {
+      politicianId: BigInt(1),
+      politicalOrganizationId: BigInt(2),
+      startedOn: new Date("2026-02-08"),
+    },
+  });
+});
+test("所属を外すと過去の履歴を削除せず終了日を設定する", async () => {
+  const { tx, repository } = setup();
+  tx.politicianOrgMembership.findMany.mockResolvedValue([
+    { id: BigInt(3), politicalOrganizationId: BigInt(2), startedOn: new Date("2026-02-08") },
+  ]);
+  await repository.save("1", { ...input, politicalOrganizationId: "" });
+  expect(tx.politicianOrgMembership.update).toHaveBeenCalledWith({
+    where: { id: BigInt(3) },
+    data: { endedOn: expect.any(Date) },
+  });
+  expect(tx.politicianOrgMembership.create).not.toHaveBeenCalled();
+});
+test("同じ所属での氏名更新は履歴を増やさない", async () => {
+  const { tx, repository } = setup();
+  tx.politicianOrgMembership.findMany.mockResolvedValue([{ politicalOrganizationId: BigInt(2) }]);
+  await repository.save("1", input);
+  expect(tx.politicianOrgMembership.update).not.toHaveBeenCalled();
+  expect(tx.politicianOrgMembership.create).not.toHaveBeenCalled();
+});
+test("slug重複をフォーム用エラーへ変換する", async () => {
+  const { tx, repository } = setup();
+  tx.politician.create.mockRejectedValue(
+    new Prisma.PrismaClientKnownRequestError("duplicate", { code: "P2002", clientVersion: "test" }),
+  );
+  await expect(repository.save(null, input)).rejects.toThrow("このスラッグは既に使用されています");
+});
+test("帳簿を議員より先に削除し、ジョブのプロンプト参照を解消する", async () => {
+  const { tx, repository } = setup();
+  await repository.delete("1");
+  expect(tx.researchFundBook.deleteMany).toHaveBeenCalledWith({
+    where: { politicianId: BigInt(1) },
+  });
+  expect(tx.politician.delete).toHaveBeenCalledWith({ where: { id: BigInt(1) } });
+  expect(tx.researchFundBook.deleteMany.mock.invocationCallOrder[0]).toBeLessThan(
+    tx.politician.delete.mock.invocationCallOrder[0],
+  );
+});
+test("無所属と所属ありの一覧をシリアライズする", async () => {
+  const { tx, repository } = setup();
+  tx.politician.findMany.mockResolvedValue([
+    politician,
+    {
+      ...politician,
+      memberships: [
+        { politicalOrganizationId: BigInt(2), politicalOrganization: { displayName: "政党" } },
+      ],
+    },
+  ]);
+  const result = await repository.findAll();
+  expect(result[0]).toEqual({
+    ...input,
+    id: "1",
+    politicalOrganizationId: "",
+    politicalOrganizationName: null,
+  });
+  expect(result[1].politicalOrganizationName).toBe("政党");
+});

--- a/shared/models/politician.ts
+++ b/shared/models/politician.ts
@@ -1,0 +1,48 @@
+export interface PoliticianInput {
+  name: string;
+  slug: string;
+  termStart: string;
+  politicalOrganizationId: string;
+}
+
+export interface Politician extends PoliticianInput {
+  id: string;
+  politicalOrganizationName: string | null;
+}
+
+const VALIDATION_CODES = {
+  INVALID: "POLITICIAN_INVALID_INPUT",
+} as const;
+
+function invalid(path: string, message: string) {
+  return {
+    status: "invalid" as const,
+    errors: [{ path, code: VALIDATION_CODES.INVALID, message, severity: "error" as const }],
+  };
+}
+
+export const Politician = {
+  validate(input: PoliticianInput) {
+    if (
+      !input ||
+      [input.name, input.slug, input.termStart, input.politicalOrganizationId].some(
+        (value) => typeof value !== "string",
+      )
+    )
+      return invalid("input", "入力内容を確認してください");
+    if (!input.name.trim()) return invalid("name", "氏名を入力してください");
+    if (!input.slug.trim()) return invalid("slug", "スラッグを入力してください");
+    if (input.name.trim().length > 255 || input.slug.trim().length > 255)
+      return invalid("input", "氏名・スラッグは255文字以内で入力してください");
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(input.slug.trim()))
+      return invalid("slug", "スラッグは半角英小文字・数字・ハイフンで入力してください");
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(input.termStart))
+      return invalid("termStart", "当選日を入力してください");
+    const date = new Date(input.termStart);
+    if (!Number.isFinite(date.getTime()) || date.toISOString().slice(0, 10) !== input.termStart)
+      return invalid("termStart", "有効な当選日を入力してください");
+    if (input.politicalOrganizationId && !/^[1-9]\d*$/.test(input.politicalOrganizationId))
+      return invalid("politicalOrganizationId", "所属する政治団体を選択してください");
+    return { status: "valid" as const };
+  },
+};


### PR DESCRIPTION
議員室スタッフが議員を登録し、既存の政治団体への所属を管理できるよう、admin に議員一覧・新規作成・編集・削除画面を追加します。

- サイドバーの「議員」からカード一覧へ移動し、氏名・slug・所属バッジ・当選年月を確認できます。
- 作成と編集は共通フォームを使用し、必須項目・日付・slug重複をエラー表示します。所属変更は履歴を残してトランザクションで保存します。
- 確認ダイアログから削除すると、帳簿・仕訳・書類などの関連レコードも連鎖削除します。
- 年度帳簿リンクの遷移先 `/politicians/[id]/books` の画面は #1353 の対象です。テナント検証・公開済みデータの削除ガードは Issue の Out of scope に従います。

検証: `pnpm verify` 成功（admin 1,119件、webapp 135件）。ローカル Supabase を初期化し、webapp E2E 14件・admin E2E 31件が成功。最終変更後も議員CRUD E2E（認証setupを含む2件）を再確認しました。実DBで議員・帳簿・仕訳・明細・書類・プロンプト・バッチ・ジョブの削除も確認済みです。

Closes #1352


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 管理画面で議員の一覧表示、作成、編集、削除に対応しました。
  - 氏名、スラッグ、当選日の入力チェックと、所属政党の選択に対応しました。
  - 議員削除時に確認ダイアログを表示し、関連データが削除されることを事前に案内します。
  - サイドナビゲーションから議員管理画面へアクセスできるようになりました。

- **テスト**
  - 議員管理の作成・編集・削除、入力エラー、確認ダイアログの主要フローを自動テストで検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->