### PR TITLE
fix(ci): Supabase CLI の最新版取得を認証する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
         uses: supabase/setup-cli@v1
         with:
           version: latest
+          # 最新版取得時の未認証 GitHub API レート制限を避ける。
+          github-token: ${{ github.token }}
 
       # Supabase の起動（docker イメージの pull + コンテナ起動）はこのジョブで最も時間がかかる。
       # 依存インストール・Playwright ブラウザのインストール・Prisma Client 生成とは独立しているため、


### PR DESCRIPTION
main の CI で Supabase CLI の最新版取得が未認証 GitHub API のレート制限にかかり、E2E テスト開始前に失敗していました。開発者とループが CI を安定して実行できるよう、`supabase/setup-cli@v1` の `github-token` 入力に `${{ github.token }}` を渡します。

公式 Action の action.yml・src/utils.ts・配布済み dist/index.js で、入力が最新版取得の Authorization ヘッダーに使われることを確認しました。変更は CI 設定の2行です。

Closes #1387

検証:
- `pnpm verify`: 成功（admin 96 suites / 1,222 tests、webapp 17 suites / 139 tests、typecheck / lint / knip / depcruise）
- Workflow YAML のパース、`git diff --check`: 成功
- 初回 typecheck は前ブランチ由来の Git 管理外 `admin/.next/dev/types` が存在しないページを参照して失敗。生成キャッシュを退避後、全チェック成功
- アプリの画面・認証・フォーム・ルーティングの変更はないためローカル E2E は省略。GitHub CI の Supabase CLI セットアップ結果を確認する

スコープアウトして起票した Issue: なし

失敗した main CI: https://github.com/team-mirai/marumie/actions/runs/34490704870
Action の入力定義: https://github.com/supabase/setup-cli/blob/v1/action.yml
