### PR TITLE
feat(admin): グローバル対象セレクタと議員室サイドバーを追加

### DIFF
--- a/admin/e2e/tests/books.spec.ts
+++ b/admin/e2e/tests/books.spec.ts
@@ -29,7 +29,7 @@ test("年度帳簿の作成・帳簿情報の編集", async ({ page }) => {
   await expect(card.getByLabel("時点の日付")).toHaveValue("2026-08-20");
   await expect(card.getByLabel("次回更新の案内")).toHaveValue("次回は11月ごろ");
   await expect(card.getByLabel("活用方針")).toHaveValue("調査研究に活用します");
-  await page.getByRole("link", { name: "別の議員に切り替え" }).click();
+  await page.getByRole("link", { name: "議員一覧へ" }).click();
   await politicianCard.getByRole("button", { name: "削除", exact: true }).click();
   await page.getByRole("button", { name: "削除する", exact: true }).click();
   await expect(politicianCard).toHaveCount(0);

--- a/admin/e2e/tests/sidebar.spec.ts
+++ b/admin/e2e/tests/sidebar.spec.ts
@@ -34,3 +34,64 @@ test.describe("サイドバー", () => {
 		await expect(sidebar.getByText("ADMIN CONSOLE")).toBeVisible();
 	});
 });
+
+	test("対象の選択をリロードと別タブで保持し、明示切り替えで議員室メニューに変わる", async ({ page, context }) => {
+    await page.goto("/");
+    const selector = page.getByRole("button", { name: "現在の対象を切り替え" });
+    await selector.click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByRole("heading", { name: "政治資金（政治団体）" })).toBeVisible();
+    await expect(dialog.getByRole("heading", { name: "調査研究費（議員室）" })).toBeVisible();
+    const organization = dialog.getByRole("button", { name: /^サンプル党／/ }).first();
+    const orgName = await organization.innerText();
+    await organization.click();
+    await expect(page).toHaveURL("/political-organizations");
+    await expect(selector).toContainText(orgName.trim());
+    await page.reload();
+    await expect(selector).toContainText(orgName.trim());
+
+    const otherTab = await context.newPage();
+    await otherTab.goto("/politicians");
+    const otherSelector = otherTab.getByRole("button", { name: "現在の対象を切り替え" });
+    await expect(otherSelector).toContainText(orgName.trim());
+    await selector.click();
+    await expect(dialog.getByRole("button", { name: orgName.trim() })).toHaveAttribute("aria-pressed", "true");
+    const researchGroup = dialog.locator("section").filter({ has: page.getByRole("heading", { name: "調査研究費（議員室）" }) });
+    const bookOption = researchGroup.getByRole("button").first();
+    const bookName = (await bookOption.innerText()).trim();
+    await bookOption.click();
+    await expect(page).toHaveURL(/\/politicians\/\d+\/books$/);
+    await expect(selector).toContainText(bookName);
+    await expect(otherSelector).toContainText(bookName);
+    await expect(otherTab).toHaveURL(page.url());
+    const sidebar = page.getByRole("complementary");
+    await expect(sidebar.getByText("調査研究費", { exact: true })).toBeVisible();
+    await expect(sidebar.getByRole("link", { name: "取引一覧" })).toHaveCount(0);
+    for (const name of ["書類スキャン", "仕訳の確認・編集", "支給の登録", "公開", "支出群と成果", "読み取りプロンプト"]) {
+      await expect(sidebar.getByRole("link", { name })).toHaveAttribute("href", /\/politicians\/\d+\/books\/\d+\//);
+    }
+    await expect(page.getByRole("main").getByText("現在の対象", { exact: true })).toBeVisible();
+    await sidebar.getByRole("link", { name: "議員", exact: true }).click();
+    await expect(page.getByRole("main").getByText(/^現在の対象：/)).toBeVisible();
+    await page.reload();
+    await expect(selector).toContainText(bookName);
+    await selector.click();
+    await expect(dialog.getByRole("button", { name: bookName })).toHaveAttribute("aria-pressed", "true");
+    await dialog.getByRole("button", { name: orgName.trim() }).click();
+    await expect(page).toHaveURL("/political-organizations");
+    await expect(otherTab).toHaveURL("/political-organizations");
+    await expect(sidebar.getByRole("link", { name: "取引一覧" })).toBeVisible();
+    await otherTab.close();
+  });
+
+  test("未選択でも議員管理に進め、折りたたんだ状態でも対象を選択できる", async ({ page }) => {
+    await page.goto("/");
+    const sidebar = page.getByRole("complementary");
+    await sidebar.getByRole("link", { name: "議員", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "議員一覧" })).toBeVisible();
+    await sidebar.getByRole("button", { name: "サイドバーを折りたたむ" }).click();
+    await sidebar.getByRole("button", { name: "現在の対象を切り替え" }).click();
+    await page.getByRole("dialog").getByRole("link", { name: "議員一覧・年度帳簿の作成へ" }).click();
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "議員一覧" })).toBeVisible();
+  });

--- a/admin/src/app/(auth)/layout.tsx
+++ b/admin/src/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import "server-only";
 import { redirect } from "next/navigation";
+import { loadAdminTargets } from "@/server/contexts/shared/presentation/loaders/load-admin-targets";
 import AuthShell from "@/client/components/layout/AuthShell";
 import { logout } from "@/server/contexts/auth/presentation/actions/logout";
 import { getCurrentUser } from "@/server/contexts/auth/presentation/loaders/load-current-user";
@@ -14,8 +15,17 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
     redirect("/login");
   }
 
+  const { targets, currentTarget, cookieName } = await loadAdminTargets();
+
   return (
-    <AuthShell logoutAction={logout} userRole={user.role} userEmail={user.email}>
+    <AuthShell
+      logoutAction={logout}
+      userRole={user.role}
+      userEmail={user.email}
+      targets={targets}
+      currentTarget={currentTarget}
+      syncKey={cookieName}
+    >
       {children}
     </AuthShell>
   );

--- a/admin/src/app/(auth)/politicians/[id]/books/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/page.tsx
@@ -1,4 +1,7 @@
 import "server-only";
+import { loadAdminTargets } from "@/server/contexts/shared/presentation/loaders/load-admin-targets";
+import { ChangeTargetButton } from "@/client/components/layout/TargetSelector";
+import { cn } from "@/client/lib";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { PlusCircle } from "@phosphor-icons/react/dist/ssr";
@@ -12,14 +15,15 @@ export default async function BooksPage({ params }: { params: Promise<{ id: stri
   const { id } = await params;
   const politician = await loadPolitician(id);
   if (!politician) notFound();
-  const books = await loadBooks(id);
+  const [books, { currentTarget }] = await Promise.all([loadBooks(id), loadAdminTargets()]);
   return (
     <div>
       <PageHeader label="Books" title="年度帳簿" />
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <h2 className="font-bold">{politician.name}の帳簿一覧</h2>
+        <ChangeTargetButton />
         <Link href="/politicians" className="text-sm text-primary-active underline">
-          別の議員に切り替え
+          議員一覧へ
         </Link>
       </div>
       <p className="mb-4 text-sm text-muted-foreground">
@@ -27,10 +31,16 @@ export default async function BooksPage({ params }: { params: Promise<{ id: stri
       </p>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
         {books.map((book) => (
-          <Card key={book.id}>
+          <Card
+            key={book.id}
+            className={cn(currentTarget?.key === `book:${book.id}` && "border-ring bg-accent")}
+          >
             <CardContent className="space-y-4">
               <div className="flex items-center gap-3">
                 <h3 className="font-latin text-xl font-bold">{book.financialYear}年度</h3>
+                {currentTarget?.key === `book:${book.id}` && (
+                  <span className="text-xs font-bold text-primary-active">現在の対象</span>
+                )}
                 {book.publishedThrough && (
                   <span className="rounded-full bg-primary px-3 py-1 text-xs font-bold text-primary-foreground">
                     公開中

--- a/admin/src/app/(auth)/politicians/page.tsx
+++ b/admin/src/app/(auth)/politicians/page.tsx
@@ -1,4 +1,5 @@
 import "server-only";
+import { loadAdminTargets } from "@/server/contexts/shared/presentation/loaders/load-admin-targets";
 import Link from "next/link";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
 import { PageHeader } from "@/client/components/layout/PageHeader";
@@ -8,7 +9,10 @@ import { DeletePoliticianButton } from "@/client/components/politicians/DeletePo
 import { loadPoliticians } from "@/server/contexts/shared/presentation/loaders/load-politicians";
 
 export default async function PoliticiansPage() {
-  const politicians = await loadPoliticians();
+  const [politicians, { currentTarget }] = await Promise.all([
+    loadPoliticians(),
+    loadAdminTargets(),
+  ]);
   return (
     <div>
       <PageHeader
@@ -28,10 +32,23 @@ export default async function PoliticiansPage() {
       ) : (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
           {politicians.map((p) => (
-            <Card key={p.id}>
+            <Card
+              key={p.id}
+              className={cn(
+                currentTarget?.kind === "research-fund" &&
+                  currentTarget.politicianId === p.id &&
+                  "border-ring bg-accent",
+              )}
+            >
               <CardContent className="space-y-4">
                 <div>
                   <h2 className="text-lg font-bold">{p.name}</h2>
+                  {currentTarget?.kind === "research-fund" &&
+                    currentTarget.politicianId === p.id && (
+                      <p className="text-xs font-bold text-primary-active">
+                        現在の対象：{currentTarget.year}年度
+                      </p>
+                    )}
                   <p className="font-latin text-sm text-muted-foreground">/{p.slug}</p>
                 </div>
                 <span

--- a/admin/src/client/components/layout/AdminTargetProvider.tsx
+++ b/admin/src/client/components/layout/AdminTargetProvider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+
+type TargetContext = {
+  targets: AdminTarget[];
+  currentTarget: AdminTarget | null;
+  syncKey: string;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+const Context = createContext<TargetContext | null>(null);
+
+export function AdminTargetProvider({
+  targets,
+  currentTarget,
+  syncKey,
+  children,
+}: Omit<TargetContext, "open" | "setOpen"> & { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    // cookie は全タブで共有される。古い対象の画面・フォームも同時に更新する。
+    const sync = (event: StorageEvent) => {
+      if (event.key !== syncKey || !event.newValue) return;
+      try {
+        const { destination } = JSON.parse(event.newValue);
+        if (
+          typeof destination === "string" &&
+          /^(\/politicians\/[1-9]\d*\/books|\/political-organizations)$/.test(destination)
+        ) {
+          window.location.assign(destination);
+        }
+      } catch {
+        window.location.reload();
+      }
+    };
+    window.addEventListener("storage", sync);
+    return () => window.removeEventListener("storage", sync);
+  }, [syncKey]);
+  return (
+    <Context.Provider value={{ targets, currentTarget, syncKey, open, setOpen }}>
+      {children}
+    </Context.Provider>
+  );
+}
+
+export function useAdminTarget() {
+  const context = useContext(Context);
+  if (!context) throw new Error("AdminTargetProvider is required");
+  return context;
+}

--- a/admin/src/client/components/layout/AuthShell.tsx
+++ b/admin/src/client/components/layout/AuthShell.tsx
@@ -3,6 +3,8 @@ import "client-only";
 
 import { useState } from "react";
 import type { UserRole } from "@prisma/client";
+import { AdminTargetProvider } from "@/client/components/layout/AdminTargetProvider";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
 import Sidebar from "@/client/components/layout/Sidebar";
 import { cn } from "@/client/lib/index";
 
@@ -11,6 +13,9 @@ type AuthShellProps = {
   userRole: UserRole | null;
   userEmail: string;
   children: React.ReactNode;
+  targets: AdminTarget[];
+  currentTarget: AdminTarget | null;
+  syncKey: string;
 };
 
 /**
@@ -18,24 +23,34 @@ type AuthShellProps = {
  * サイドバーの折りたたみ状態をローカル state で持ち、grid の列幅を追従させる。
  * 本文領域は背景 #F8F8F8 でサイドバーとは独立してスクロールする。
  */
-export default function AuthShell({ logoutAction, userRole, userEmail, children }: AuthShellProps) {
+export default function AuthShell({
+  logoutAction,
+  userRole,
+  userEmail,
+  children,
+  targets,
+  currentTarget,
+  syncKey,
+}: AuthShellProps) {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <div
-      className={cn(
-        "grid h-screen bg-background",
-        collapsed ? "grid-cols-[72px_minmax(0,1fr)]" : "grid-cols-[236px_minmax(0,1fr)]",
-      )}
-    >
-      <Sidebar
-        logoutAction={logoutAction}
-        userRole={userRole}
-        userEmail={userEmail}
-        collapsed={collapsed}
-        onToggleCollapsed={() => setCollapsed((prev) => !prev)}
-      />
-      <main className="min-w-0 overflow-y-auto p-5 text-foreground">{children}</main>
-    </div>
+    <AdminTargetProvider targets={targets} currentTarget={currentTarget} syncKey={syncKey}>
+      <div
+        className={cn(
+          "grid h-screen bg-background",
+          collapsed ? "grid-cols-[72px_minmax(0,1fr)]" : "grid-cols-[236px_minmax(0,1fr)]",
+        )}
+      >
+        <Sidebar
+          logoutAction={logoutAction}
+          userRole={userRole}
+          userEmail={userEmail}
+          collapsed={collapsed}
+          onToggleCollapsed={() => setCollapsed((prev) => !prev)}
+        />
+        <main className="min-w-0 overflow-y-auto p-5 text-foreground">{children}</main>
+      </div>
+    </AdminTargetProvider>
   );
 }

--- a/admin/src/client/components/layout/Sidebar.tsx
+++ b/admin/src/client/components/layout/Sidebar.tsx
@@ -1,6 +1,8 @@
 "use client";
 import "client-only";
 
+import { TargetSelector } from "@/client/components/layout/TargetSelector";
+import { useAdminTarget } from "@/client/components/layout/AdminTargetProvider";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { UserRole } from "@prisma/client";
@@ -86,7 +88,8 @@ export default function Sidebar({
   onToggleCollapsed,
 }: SidebarProps) {
   const pathname = usePathname();
-  const navSections = getVisibleNavSections(userRole);
+  const { currentTarget } = useAdminTarget();
+  const navSections = getVisibleNavSections(userRole, currentTarget);
   const ToggleIcon = collapsed ? CaretDoubleRight : CaretDoubleLeft;
   const toggleLabel = collapsed ? "サイドバーを開く" : "サイドバーを折りたたむ";
 
@@ -113,6 +116,8 @@ export default function Sidebar({
           <ToggleIcon size={13} aria-hidden="true" />
         </button>
       </div>
+
+      <TargetSelector collapsed={collapsed} />
 
       <nav aria-label="メインナビゲーション" className="flex flex-1 flex-col gap-5">
         {navSections.map((section) => (
@@ -141,6 +146,18 @@ export default function Sidebar({
                     >
                       <ItemIcon size={16} className="shrink-0" aria-hidden="true" />
                       <span className={cn(collapsed && "sr-only")}>{item.label}</span>
+                      {item.badge !== undefined && item.badge > 0 && (
+                        <span
+                          className={cn(
+                            "ml-auto rounded-full bg-destructive px-1.5 py-0.5 font-latin text-[10px] font-bold text-white",
+                            collapsed && "sr-only",
+                          )}
+                        >
+                          <span className="sr-only">下書き</span>
+                          {item.badge}
+                          <span className="sr-only">件</span>
+                        </span>
+                      )}
                     </Link>
                   </CollapsibleTooltip>
                 );

--- a/admin/src/client/components/layout/TargetSelector.tsx
+++ b/admin/src/client/components/layout/TargetSelector.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { CaretDown, Check, ArrowsLeftRight } from "@phosphor-icons/react/dist/ssr";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/client/components/ui";
+import { cn } from "@/client/lib";
+import { useAdminTarget } from "@/client/components/layout/AdminTargetProvider";
+import { selectAdminTarget } from "@/server/contexts/shared/presentation/actions/select-admin-target";
+
+export function ChangeTargetButton() {
+  const { setOpen } = useAdminTarget();
+  return (
+    <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+      対象を切り替え
+    </Button>
+  );
+}
+
+export function TargetSelector({ collapsed }: { collapsed: boolean }) {
+  const { targets, currentTarget, syncKey, open, setOpen } = useAdminTarget();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  return (
+    <>
+      <Button
+        variant="outline"
+        aria-label="現在の対象を切り替え"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        className={cn(
+          "mb-5 h-auto w-full rounded-lg border-ring bg-accent p-3 text-left text-accent-foreground",
+          collapsed && "px-0",
+        )}
+      >
+        {collapsed ? (
+          <ArrowsLeftRight aria-hidden="true" />
+        ) : (
+          <>
+            <span className="min-w-0 flex-1 space-y-1 whitespace-normal">
+              <span className="block text-[10px]">現在の対象</span>
+              <span className="block text-[10px]">
+                {currentTarget?.kind === "research-fund"
+                  ? "調査研究費・議員室"
+                  : "政治資金・政治団体"}
+              </span>
+              <span className="block truncate text-xs">
+                {currentTarget
+                  ? `${currentTarget.name}／${currentTarget.year}年度`
+                  : "対象を選択してください"}
+              </span>
+            </span>
+            <CaretDown className="shrink-0" aria-hidden="true" />
+          </>
+        )}
+      </Button>
+      <Dialog
+        open={open}
+        onOpenChange={(value) => {
+          if (!busy) setOpen(value);
+        }}
+      >
+        <DialogContent className="max-h-[85vh] w-[calc(100%-2rem)] max-w-xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>帳簿を切り替え</DialogTitle>
+            <DialogDescription>
+              切り替えるまで、すべての画面はこの対象に対して操作されます。メニューも対象に合わせて変わります。
+            </DialogDescription>
+          </DialogHeader>
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          {(["political-organization", "research-fund"] as const).map((kind) => {
+            const options = targets.filter((target) => target.kind === kind);
+            return (
+              <section key={kind} className="space-y-2">
+                <h2 className="text-xs font-bold text-muted-foreground">
+                  {kind === "research-fund" ? "調査研究費（議員室）" : "政治資金（政治団体）"}
+                </h2>
+                {options.length === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    {kind === "research-fund"
+                      ? "議員・年度帳簿を作成すると選択できます。"
+                      : "政治団体が登録されていません。"}
+                  </p>
+                )}
+                {options.map((target) => (
+                  <Button
+                    key={target.key}
+                    variant="outline"
+                    disabled={busy}
+                    aria-pressed={target.key === currentTarget?.key}
+                    className={cn(
+                      "h-auto w-full justify-between rounded-lg py-3 text-left whitespace-normal",
+                      target.key === currentTarget?.key &&
+                        "border-ring bg-accent text-accent-foreground",
+                    )}
+                    onClick={async () => {
+                      setBusy(true);
+                      setError(null);
+                      try {
+                        const result = await selectAdminTarget(target.key);
+                        if (!result.success) {
+                          setError(result.error);
+                          setBusy(false);
+                          return;
+                        }
+                        try {
+                          localStorage.setItem(
+                            syncKey,
+                            JSON.stringify({ destination: result.destination, nonce: Date.now() }),
+                          );
+                        } catch {
+                          /* cookie による保持は継続する */
+                        }
+                        window.location.assign(result.destination);
+                      } catch {
+                        setError("切り替えに失敗しました。もう一度お試しください");
+                        setBusy(false);
+                      }
+                    }}
+                  >
+                    <span>
+                      {target.name}／<span className="font-latin">{target.year}</span>年度
+                    </span>
+                    {target.key === currentTarget?.key && (
+                      <Check className="shrink-0" aria-label="選択中" />
+                    )}
+                  </Button>
+                ))}
+              </section>
+            );
+          })}
+          <Button variant="outline" asChild>
+            <Link href="/politicians" onClick={() => setOpen(false)}>
+              議員一覧・年度帳簿の作成へ
+            </Link>
+          </Button>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/admin/src/client/components/layout/sidebar-nav.ts
+++ b/admin/src/client/components/layout/sidebar-nav.ts
@@ -1,3 +1,4 @@
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
 import type { UserRole } from "@prisma/client";
 
 /**
@@ -24,6 +25,7 @@ type NavItem = {
   label: string;
   icon: NavIconName;
   adminOnly?: boolean;
+  badge?: number;
 };
 
 type NavSection = {
@@ -34,7 +36,7 @@ type NavSection = {
 // アイコン対応表はデザインハンドオフ README「1. サイドバー」節が正
 const NAV_SECTIONS: NavSection[] = [
   {
-    title: "基本情報",
+    title: "政治団体",
     items: [
       { href: "/politicians", label: "議員", icon: "user" },
       { href: "/user-info", label: "ユーザー情報", icon: "user" },
@@ -67,11 +69,59 @@ const NAV_SECTIONS: NavSection[] = [
  * ユーザーのロールに応じて表示可能な nav セクションを返す。
  * adminOnly の項目は admin ロールにのみ表示し、項目が空になったセクションは除外する。
  */
-export function getVisibleNavSections(userRole: UserRole | null): NavSection[] {
-  return NAV_SECTIONS.map((section) => ({
-    ...section,
-    items: section.items.filter((item) => !item.adminOnly || userRole === "admin"),
-  })).filter((section) => section.items.length > 0);
+export function getVisibleNavSections(
+  userRole: UserRole | null,
+  target: AdminTarget | null = null,
+): NavSection[] {
+  const base = target?.kind === "research-fund" ? `/politicians/${target.politicianId}/books` : "";
+  const sections: NavSection[] =
+    target?.kind === "research-fund"
+      ? [
+          {
+            title: "議員室",
+            items: [
+              { href: "/politicians", label: "議員", icon: "user" },
+              { href: base, label: "年度帳簿", icon: "bank" },
+              { href: "/user-info", label: "ユーザー情報", icon: "user" },
+              { href: "/users", label: "ユーザー管理", icon: "users", adminOnly: true },
+            ],
+          },
+          {
+            title: "調査研究費",
+            items: [
+              {
+                href: `${base}/${target.bookId}/scan`,
+                label: "書類スキャン",
+                icon: "upload-simple",
+              },
+              {
+                href: `${base}/${target.bookId}/entries`,
+                label: "仕訳の確認・編集",
+                icon: "list-bullets",
+                badge: target.draftCount,
+              },
+              { href: `${base}/${target.bookId}/grants`, label: "支給の登録", icon: "coins" },
+              { href: `${base}/${target.bookId}/publish`, label: "公開", icon: "export" },
+              {
+                href: `${base}/${target.bookId}/expenditure-groups`,
+                label: "支出群と成果",
+                icon: "hand-heart",
+              },
+              {
+                href: `${base}/${target.bookId}/prompts`,
+                label: "読み取りプロンプト",
+                icon: "list-bullets",
+              },
+            ],
+          },
+        ]
+      : NAV_SECTIONS;
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => !item.adminOnly || userRole === "admin"),
+    }))
+    .filter((section) => section.items.length > 0);
 }
 
 /**
@@ -79,6 +129,13 @@ export function getVisibleNavSections(userRole: UserRole | null): NavSection[] {
  * ルート以外は前方一致（配下の詳細画面でも親項目をアクティブにする）。
  */
 export function isNavItemActive(pathname: string, href: string): boolean {
+  if (href === "/politicians")
+    return (
+      pathname === href ||
+      pathname === `${href}/new` ||
+      /^\/politicians\/[^/]+\/edit$/.test(pathname)
+    );
+  if (/^\/politicians\/[^/]+\/books$/.test(href)) return pathname === href;
   if (href === "/") {
     return pathname === "/";
   }

--- a/admin/src/server/contexts/research-fund/presentation/actions/manage-book.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/manage-book.ts
@@ -28,7 +28,7 @@ export async function createBook(politicianId: string, year: number) {
   await requireAuth();
   try {
     await new ManageBookUsecase(new PrismaBookRepository(prisma)).create(politicianId, year);
-    revalidatePath(`/politicians/${politicianId}/books`);
+    revalidatePath("/(auth)", "layout");
     return { success: true as const };
   } catch (error) {
     return {
@@ -45,7 +45,7 @@ export async function updateBook(politicianId: string, bookId: string, input: Bo
       bookId,
       input,
     );
-    revalidatePath(`/politicians/${politicianId}/books`);
+    revalidatePath("/(auth)", "layout");
     return { success: true as const };
   } catch (error) {
     return {

--- a/admin/src/server/contexts/shared/application/usecases/get-admin-targets-usecase.ts
+++ b/admin/src/server/contexts/shared/application/usecases/get-admin-targets-usecase.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import type { IAdminTargetRepository } from "@/server/contexts/shared/domain/repositories/admin-target-repository.interface";
+
+export class GetAdminTargetsUsecase {
+  constructor(private repository: IAdminTargetRepository) {}
+  async execute(key: string | undefined, currentYear: number) {
+    const targets = await this.repository.list(currentYear);
+    // 年が変わって候補の当年・前年から外れても、明示選択した年度を保持する。
+    const savedOrganization = /^org:([1-9]\d*):(\d{4})$/.exec(key ?? "");
+    if (
+      savedOrganization &&
+      Number(savedOrganization[2]) >= 1900 &&
+      !targets.some((t) => t.key === key)
+    ) {
+      const organization = targets.find(
+        (t) => t.kind === "political-organization" && t.organizationId === savedOrganization[1],
+      );
+      if (organization)
+        targets.push({ ...organization, key: key as string, year: Number(savedOrganization[2]) });
+    }
+    // 未選択・削除済み対象を別の対象に自動でフォールバックさせない。
+    return { targets, currentTarget: targets.find((target) => target.key === key) ?? null };
+  }
+}

--- a/admin/src/server/contexts/shared/domain/models/admin-target.ts
+++ b/admin/src/server/contexts/shared/domain/models/admin-target.ts
@@ -1,0 +1,14 @@
+export type AdminTarget = {
+  key: string;
+  name: string;
+  year: number;
+} & (
+  | { kind: "political-organization"; organizationId: string }
+  | { kind: "research-fund"; politicianId: string; bookId: string; draftCount: number }
+);
+
+export function targetDestination(target: AdminTarget): string {
+  return target.kind === "research-fund"
+    ? `/politicians/${target.politicianId}/books`
+    : "/political-organizations";
+}

--- a/admin/src/server/contexts/shared/domain/repositories/admin-target-repository.interface.ts
+++ b/admin/src/server/contexts/shared/domain/repositories/admin-target-repository.interface.ts
@@ -1,0 +1,4 @@
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+export interface IAdminTargetRepository {
+  list(currentYear: number): Promise<AdminTarget[]>;
+}

--- a/admin/src/server/contexts/shared/infrastructure/repositories/prisma-admin-target.repository.ts
+++ b/admin/src/server/contexts/shared/infrastructure/repositories/prisma-admin-target.repository.ts
@@ -1,0 +1,63 @@
+import "server-only";
+import type { PrismaClient } from "@prisma/client";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+import type { IAdminTargetRepository } from "@/server/contexts/shared/domain/repositories/admin-target-repository.interface";
+
+export class PrismaAdminTargetRepository implements IAdminTargetRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async list(currentYear: number): Promise<AdminTarget[]> {
+    const [organizations, books] = await Promise.all([
+      this.prisma.politicalOrganization.findMany({
+        orderBy: { id: "asc" },
+        select: {
+          id: true,
+          displayName: true,
+          transactions: { distinct: ["financialYear"], select: { financialYear: true } },
+          reportProfiles: { select: { financialYear: true } },
+        },
+      }),
+      this.prisma.researchFundBook.findMany({
+        orderBy: [{ politicianId: "asc" }, { financialYear: "desc" }],
+        select: {
+          id: true,
+          politicianId: true,
+          financialYear: true,
+          politician: { select: { name: true } },
+          _count: { select: { journalEntries: { where: { status: "draft" } } } },
+        },
+      }),
+    ]);
+    return [
+      ...organizations.flatMap((org): AdminTarget[] => {
+        // データのない団体でも当年・前年を選べ、既存データの年度も失わない。
+        const years = new Set([
+          currentYear,
+          currentYear - 1,
+          ...org.transactions.map((t) => t.financialYear),
+          ...org.reportProfiles.map((p) => p.financialYear),
+        ]);
+        return [...years]
+          .sort((a, b) => b - a)
+          .map((year) => ({
+            kind: "political-organization",
+            key: `org:${org.id}:${year}`,
+            organizationId: String(org.id),
+            name: org.displayName,
+            year,
+          }));
+      }),
+      ...books.map(
+        (book): AdminTarget => ({
+          kind: "research-fund",
+          key: `book:${book.id}`,
+          bookId: String(book.id),
+          politicianId: String(book.politicianId),
+          name: book.politician.name,
+          year: book.financialYear,
+          draftCount: book._count.journalEntries,
+        }),
+      ),
+    ];
+  }
+}

--- a/admin/src/server/contexts/shared/presentation/actions/manage-politician.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/manage-politician.ts
@@ -10,7 +10,7 @@ export async function savePolitician(id: string | null, input: PoliticianInput) 
   await requireAuth();
   try {
     await new ManagePoliticianUsecase(new PrismaPoliticianRepository(prisma)).save(id, input);
-    revalidatePath("/politicians", "layout");
+    revalidatePath("/(auth)", "layout");
     return { success: true as const };
   } catch (error) {
     return {
@@ -23,7 +23,7 @@ export async function deletePolitician(id: string) {
   await requireAuth();
   try {
     await new ManagePoliticianUsecase(new PrismaPoliticianRepository(prisma)).delete(id);
-    revalidatePath("/politicians", "layout");
+    revalidatePath("/(auth)", "layout");
     return { success: true as const };
   } catch {
     return { success: false as const, error: "削除に失敗しました。もう一度お試しください" };

--- a/admin/src/server/contexts/shared/presentation/actions/select-admin-target.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/select-admin-target.ts
@@ -1,0 +1,22 @@
+"use server";
+import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
+import { targetDestination } from "@/server/contexts/shared/domain/models/admin-target";
+import { loadAdminTargets } from "@/server/contexts/shared/presentation/loaders/load-admin-targets";
+
+export async function selectAdminTarget(key: string) {
+  // loader 内で認証を確認し、最新の選択肢から ID を検証する。
+  const { targets, cookieName } = await loadAdminTargets();
+  const target = targets.find((item) => item.key === key);
+  if (!target)
+    return { success: false as const, error: "対象が見つかりません。再読み込みしてください" };
+  (await cookies()).set(cookieName, key, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+  });
+  revalidatePath("/(auth)", "layout");
+  return { success: true as const, destination: targetDestination(target) };
+}

--- a/admin/src/server/contexts/shared/presentation/loaders/load-admin-targets.ts
+++ b/admin/src/server/contexts/shared/presentation/loaders/load-admin-targets.ts
@@ -1,0 +1,18 @@
+import "server-only";
+import { cache } from "react";
+import { cookies } from "next/headers";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { GetAdminTargetsUsecase } from "@/server/contexts/shared/application/usecases/get-admin-targets-usecase";
+import { PrismaAdminTargetRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-admin-target.repository";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export const loadAdminTargets = cache(async () => {
+  const user = await requireAuth();
+  const cookieName = `admin-target-${user.id}`;
+  const key = (await cookies()).get(cookieName)?.value;
+  const data = await new GetAdminTargetsUsecase(new PrismaAdminTargetRepository(prisma)).execute(
+    key,
+    new Date().getFullYear(),
+  );
+  return { ...data, cookieName };
+});

--- a/admin/tests/client/components/layout/sidebar-nav.test.ts
+++ b/admin/tests/client/components/layout/sidebar-nav.test.ts
@@ -8,7 +8,7 @@ describe("getVisibleNavSections", () => {
     const sections = getVisibleNavSections("admin");
     const hrefs = sections.flatMap((s) => s.items.map((i) => i.href));
 
-    expect(sections.map((s) => s.title)).toEqual(["基本情報", "データ取り込み", "報告書"]);
+    expect(sections.map((s) => s.title)).toEqual(["政治団体", "データ取り込み", "報告書"]);
     expect(hrefs).toContain("/users");
     expect(hrefs).toHaveLength(13);
   });
@@ -74,5 +74,31 @@ describe("isNavItemActive", () => {
   it("ルート（/）は完全一致のみでアクティブになる", () => {
     expect(isNavItemActive("/", "/")).toBe(true);
     expect(isNavItemActive("/transactions", "/")).toBe(false);
+  });
+});
+
+
+describe("議員室モード", () => {
+  const target = { kind: "research-fund" as const, key: "book:7", name: "議員A", year: 2026, politicianId: "3", bookId: "7", draftCount: 4 };
+  it("選択した議員・帳簿のリンクと下書き件数を使う", () => {
+    const sections = getVisibleNavSections("user", target);
+    expect(sections.map((s) => s.title)).toEqual(["議員室", "調査研究費"]);
+    expect(sections[0].items.map((i) => i.href)).toEqual(["/politicians", "/politicians/3/books", "/user-info"]);
+    expect(sections[1].items).toHaveLength(6);
+    expect(sections[1].items.every((i) => i.href.startsWith("/politicians/3/books/7/"))).toBe(true);
+    expect(sections[1].items.find((i) => i.label === "仕訳の確認・編集")?.badge).toBe(4);
+  });
+  it("議員室モードでもユーザー管理は admin のみ表示する", () => {
+    expect(getVisibleNavSections("admin", target)[0].items.map((i) => i.href)).toContain("/users");
+    expect(getVisibleNavSections(null, target)[0].items.map((i) => i.href)).not.toContain("/users");
+  });
+  it("下書きが0件の場合も0を返し、他の帳簿の件数と混ざらない", () => {
+    expect(getVisibleNavSections("user", { ...target, bookId: "8", draftCount: 0 })[1].items[1]).toMatchObject({ href: "/politicians/3/books/8/entries", badge: 0 });
+  });
+  it("帳簿や仕訳画面で議員リンクを二重にアクティブにしない", () => {
+    expect(isNavItemActive("/politicians/3/books", "/politicians")).toBe(false);
+    expect(isNavItemActive("/politicians/3/edit", "/politicians")).toBe(true);
+    expect(isNavItemActive("/politicians/3/books/7/entries", "/politicians/3/books")).toBe(false);
+    expect(isNavItemActive("/politicians/3/books/7/entries", "/politicians/3/books/7/entries")).toBe(true);
   });
 });

--- a/admin/tests/server/contexts/research-fund/presentation/actions/manage-book.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/actions/manage-book.test.ts
@@ -21,7 +21,7 @@ describe.each([
     await expect(run()).resolves.toEqual({ success: true });
     expect(requireAuth).toHaveBeenCalledTimes(1);
     expect(execute).toHaveBeenCalledTimes(1);
-    expect(revalidatePath).toHaveBeenCalledWith("/politicians/1/books");
+    expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
   });
 
   test.each([

--- a/admin/tests/server/contexts/shared/application/usecases/get-admin-targets-usecase.test.ts
+++ b/admin/tests/server/contexts/shared/application/usecases/get-admin-targets-usecase.test.ts
@@ -1,0 +1,24 @@
+import { GetAdminTargetsUsecase } from "@/server/contexts/shared/application/usecases/get-admin-targets-usecase";
+import { targetDestination, type AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+const org: AdminTarget = { kind: "political-organization", key: "org:1:2026", name: "団体A", year: 2026, organizationId: "1" };
+const book: AdminTarget = { kind: "research-fund", key: "book:7", name: "議員A", year: 2026, politicianId: "3", bookId: "7", draftCount: 2 };
+function setup() {
+  const list = jest.fn().mockImplementation(async () => [org, book]);
+  return new GetAdminTargetsUsecase({ list });
+}
+test.each([undefined, "invalid", "book:99", "org:99:2026"])("未選択・無効・削除済みの %s は他の対象に切り替えない", async (key) => {
+  expect((await setup().execute(key, 2026)).currentTarget).toBeNull();
+});
+test("明示選択した帳簿をそのまま返し、一覧の先頭を選ばない", async () => {
+  expect((await setup().execute(book.key, 2026)).currentTarget).toEqual(book);
+  expect(targetDestination(book)).toBe("/politicians/3/books");
+  expect(targetDestination(org)).toBe("/political-organizations");
+});
+test("年をまたいでも選択した団体・年度は変わらない", async () => {
+  const result = await setup().execute("org:1:2024", 2026);
+  expect(result.currentTarget).toEqual({ ...org, key: "org:1:2024", year: 2024 });
+  expect(result.targets).toContainEqual(result.currentTarget);
+});
+test("対象が1つもなければ空リスト・未選択を返す", async () => {
+  expect(await new GetAdminTargetsUsecase({ list: async () => [] }).execute(undefined, 2026)).toEqual({ targets: [], currentTarget: null });
+});

--- a/admin/tests/server/contexts/shared/infrastructure/repositories/prisma-admin-target.repository.test.ts
+++ b/admin/tests/server/contexts/shared/infrastructure/repositories/prisma-admin-target.repository.test.ts
@@ -1,0 +1,21 @@
+import type { PrismaClient } from "@prisma/client";
+import { PrismaAdminTargetRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-admin-target.repository";
+test("団体×年度と議員×帳簿をシリアライズし、下書きのみを帳簿ごとに数える", async () => {
+  const politicalOrganization = { findMany: jest.fn().mockResolvedValue([
+    { id: BigInt(1), displayName: "団体", transactions: [{ financialYear: 2023 }, { financialYear: 2026 }], reportProfiles: [{ financialYear: 2024 }] },
+    { id: BigInt(2), displayName: "空の団体", transactions: [], reportProfiles: [] },
+  ]) };
+  const researchFundBook = { findMany: jest.fn().mockResolvedValue([
+    { id: BigInt(7), politicianId: BigInt(3), financialYear: 2026, politician: { name: "議員" }, _count: { journalEntries: 2 } },
+    { id: BigInt(8), politicianId: BigInt(3), financialYear: 2025, politician: { name: "議員" }, _count: { journalEntries: 0 } },
+  ]) };
+  const targets = await new PrismaAdminTargetRepository({ politicalOrganization, researchFundBook } as unknown as PrismaClient).list(2026);
+  expect(targets.filter((t) => t.kind === "political-organization" && t.organizationId === "1").map((t) => t.year)).toEqual([2026, 2025, 2024, 2023]);
+  expect(targets.filter((t) => t.kind === "political-organization" && t.organizationId === "2").map((t) => t.year)).toEqual([2026, 2025]);
+  expect(targets.filter((t) => t.kind === "research-fund")).toEqual([
+    { key: "book:7", kind: "research-fund", bookId: "7", politicianId: "3", name: "議員", year: 2026, draftCount: 2 },
+    { key: "book:8", kind: "research-fund", bookId: "8", politicianId: "3", name: "議員", year: 2025, draftCount: 0 },
+  ]);
+  expect(researchFundBook.findMany).toHaveBeenCalledWith(expect.objectContaining({ select: expect.objectContaining({ _count: { select: { journalEntries: { where: { status: "draft" } } } } }) }));
+  expect(() => JSON.stringify(targets)).not.toThrow();
+});

--- a/admin/tests/server/contexts/shared/presentation/actions/select-admin-target.test.ts
+++ b/admin/tests/server/contexts/shared/presentation/actions/select-admin-target.test.ts
@@ -1,0 +1,27 @@
+import { selectAdminTarget } from "@/server/contexts/shared/presentation/actions/select-admin-target";
+import { loadAdminTargets } from "@/server/contexts/shared/presentation/loaders/load-admin-targets";
+import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
+jest.mock("@/server/contexts/shared/presentation/loaders/load-admin-targets", () => ({ loadAdminTargets: jest.fn() }));
+jest.mock("next/headers", () => ({ cookies: jest.fn() }));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+const set = jest.fn();
+beforeEach(() => {
+  jest.clearAllMocks();
+  (cookies as jest.Mock).mockResolvedValue({ set });
+  (loadAdminTargets as jest.Mock).mockResolvedValue({ cookieName: "admin-target-user1", targets: [{ kind: "research-fund", key: "book:7", politicianId: "3" }] });
+});
+test("実在する選択肢だけユーザーごとのcookieに保存しシェルを再検証する", async () => {
+  expect(await selectAdminTarget("book:7")).toEqual({ success: true, destination: "/politicians/3/books" });
+  expect(set).toHaveBeenCalledWith("admin-target-user1", "book:7", expect.objectContaining({ httpOnly: true, path: "/", sameSite: "lax", maxAge: 31536000 }));
+  expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
+});
+test("削除された対象ではcookieを上書きしない", async () => {
+  expect(await selectAdminTarget("book:99")).toMatchObject({ success: false });
+  expect(set).not.toHaveBeenCalled();
+});
+test("認証失敗時は選択状態を更新しない", async () => {
+  (loadAdminTargets as jest.Mock).mockRejectedValue(new Error("認証が必要です"));
+  await expect(selectAdminTarget("book:7")).rejects.toThrow("認証が必要です");
+  expect(set).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## 目的

議員室スタッフが操作対象の議員・年度帳簿を見失わず、各調研費画面へ進めるようにする。

## 変更内容

- サイドバーのブランド直下に現在の対象と、政治団体×年度／議員×年度帳簿の2グループから選ぶダイアログを追加。
- 選択はユーザーごとの HttpOnly cookie に保存。リロード・新しいタブでも保持し、既存タブも明示切り替えの通知を受けて対象の一覧へ移動する。未選択・削除済みの対象は別の対象へ自動変更しない。
- 議員室モードのメニューと帳簿ごとの下書き件数バッジを追加。議員・年度帳簿一覧では現在の対象を強調し、年度帳簿画面からも対象を切り替えられる。
- 議員未登録でも議員一覧へ進める導線を維持。政治団体モードは3節へ再構成し、ユーザー情報・ユーザー管理と既存政治団体系ページのセレクタは維持する。
- 団体の年度候補は当年・前年と既存取引／報告書プロフィールの年度。年をまたいでも保存した年度は保持する。調研費の未実装画面は既存の帳簿URL構造に合わせたリンクのみ。

Closes #1354

## 検証

- `pnpm verify`: 成功（admin 1,280件、webapp 139件。既存の統合テスト1件はスキップ）
- `pnpm supabase:start`、`pnpm db:reset`: 成功
- E2E: webapp 14件、admin 34件すべて成功。追加テストの要素検索条件を修正後、admin全件を再実行して成功。
- 対象の保持・別タブ同期・選択状態・モード別リンク・折りたたみ時の導線を `sidebar.spec.ts` で検証。
