### PR TITLE
feat(admin): 調研費の仕訳確認・編集画面を追加

### DIFF
--- a/admin/.env.example
+++ b/admin/.env.example
@@ -15,6 +15,8 @@ WEBAPP_URL=http://localhost:3000
 SITE_URL=http://localhost:3001
 
 # === 任意 ===
+# 調研費の領収書プレビュー（既存の非公開 Storage バケット名を設定）
+# RESEARCH_FUND_DOCUMENT_BUCKET=private-receipts
 # 領収書抽出（調研費）。APIを使う環境で ANTHROPIC_API_KEY を設定する
 # ANTHROPIC_API_KEY=your-anthropic-api-key
 # RESEARCH_FUND_EXTRACTION_MODEL=claude-sonnet-5

--- a/admin/e2e/tests/journal-review.spec.ts
+++ b/admin/e2e/tests/journal-review.spec.ts
@@ -35,6 +35,12 @@ test("手動作成→一覧選択→編集→確認済、月絞り込みと破�
   await row.click();
   await expect(page.getByLabel("項目名", { exact: true })).toHaveValue("視察先への移動");
   await page.getByLabel("金額", { exact: true }).fill("1500");
+  const leaveDialog = page.waitForEvent("dialog");
+  await page.evaluate(() => { setTimeout(() => window.location.reload(), 0); });
+  const dialog = await leaveDialog;
+  expect(dialog.type()).toBe("beforeunload");
+  await dialog.dismiss();
+  await expect(page.getByLabel("金額", { exact: true })).toHaveValue("1500");
   await page.getByLabel("特記事項（公開される）").fill("視察のため");
   await page.getByLabel("備考", { exact: true }).fill("事務所内の確認メモ");
   await page.getByLabel("備考", { exact: true }).press("ArrowUp");

--- a/admin/e2e/tests/journal-review.spec.ts
+++ b/admin/e2e/tests/journal-review.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+
+test("手動作成→一覧選択→編集→確認済、月絞り込みと破棄", async ({ page }) => {
+  const name = `e2e-journal-${Date.now()}`;
+  await page.goto("/politicians/new");
+  await page.getByLabel("氏名").fill(name);
+  await page.getByLabel("スラッグ").fill(name);
+  await page.getByLabel("当選日").fill("2026-02-08");
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page).toHaveURL("/politicians");
+  const politicianCard = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name, exact: true }) });
+  await politicianCard.getByRole("link", { name: "年度帳簿" }).click();
+  await page.getByLabel(/^年度/).fill("2026");
+  await page.getByRole("button", { name: "帳簿を作成" }).click();
+  await expect(page.getByRole("heading", { name: "2026年度" })).toBeVisible();
+  await page.getByRole("button", { name: "現在の対象を切り替え" }).click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "load" }),
+    page.getByRole("button", { name: `${name}／2026年度` }).click(),
+  ]);
+  await page.getByRole("link", { name: "仕訳の確認・編集" }).click();
+  await expect(page.getByRole("heading", { name: "仕訳の確認・編集" })).toBeVisible();
+  for (const [description, date] of [["視察先への移動", "2026-08-01"], ["会議への移動", "2026-09-01"]]) {
+    await page.getByRole("button", { name: "手動で仕訳を作成" }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("日付", { exact: true }).fill(date);
+    await dialog.getByLabel("金額", { exact: true }).fill("1200");
+    await dialog.getByLabel("項目名", { exact: true }).fill(description);
+    await dialog.getByLabel("科目", { exact: true }).selectOption("taxi");
+    await dialog.getByRole("button", { name: "下書きを作成" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page.getByRole("row").filter({ hasText: description })).toBeVisible();
+  }
+  const row = page.getByRole("row").filter({ hasText: "視察先への移動" });
+  await row.click();
+  await expect(page.getByLabel("項目名", { exact: true })).toHaveValue("視察先への移動");
+  await page.getByLabel("金額", { exact: true }).fill("1500");
+  await page.getByLabel("特記事項（公開される）").fill("視察のため");
+  await page.getByLabel("備考", { exact: true }).fill("事務所内の確認メモ");
+  await page.getByLabel("備考", { exact: true }).press("ArrowUp");
+  await expect(page.getByLabel("項目名", { exact: true })).toHaveValue("視察先への移動");
+  await page.getByRole("button", { name: "確認済にする", exact: true }).click();
+  await expect(row).toContainText("確認済"); await expect(row).toContainText("1,500");
+  await page.reload();
+  await row.click();
+  await expect(page.getByLabel("備考", { exact: true })).toHaveValue("事務所内の確認メモ");
+  await row.focus(); await page.keyboard.press("ArrowUp");
+  await expect(page.getByLabel("項目名", { exact: true })).toHaveValue("会議への移動");
+  await page.getByLabel("月", { exact: true }).selectOption("08");
+  await expect(page.getByRole("row").filter({ hasText: "会議への移動" })).toHaveCount(0);
+  await expect(page.getByRole("tab", { name: "確認済（1）" })).toBeVisible();
+  await page.getByRole("button", { name: "破棄", exact: true }).click();
+  await page.getByRole("button", { name: "破棄する", exact: true }).click();
+  await expect(row).toHaveCount(0);
+  await page.goto("/politicians");
+  await politicianCard.getByRole("button", { name: "削除", exact: true }).click();
+  await page.getByRole("button", { name: "削除する", exact: true }).click();
+  await expect(politicianCard).toHaveCount(0);
+});

--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/entries/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/entries/page.tsx
@@ -1,0 +1,11 @@
+import { loadJournalReview } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { JournalReview } from "@/client/components/research-fund/JournalReview";
+export default async function JournalReviewPage({
+  params,
+}: {
+  params: Promise<{ id: string; bookId: string }>;
+}) {
+  const { id, bookId } = await params;
+  const data = await loadJournalReview(id, bookId);
+  return <JournalReview key={bookId} {...data} />;
+}

--- a/admin/src/app/api/research-fund/documents/[documentId]/route.ts
+++ b/admin/src/app/api/research-fund/documents/[documentId]/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { loadJournalDocument } from "@/server/contexts/research-fund/presentation/loaders/load-journal-document";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ documentId: string }> },
+) {
+  await requireAuth();
+  const { documentId } = await params;
+  const bookId = request.nextUrl.searchParams.get("bookId") ?? "";
+  const politicianId = request.nextUrl.searchParams.get("politicianId") ?? "";
+  try {
+    const document = await loadJournalDocument(politicianId, bookId, documentId);
+    if (!document) return new NextResponse("領収書が見つかりません", { status: 404 });
+    return NextResponse.redirect(document.signedUrl, {
+      headers: { "Cache-Control": "private, no-store", "Referrer-Policy": "no-referrer" },
+    });
+  } catch {
+    return new NextResponse("領収書を表示できません。ストレージ設定を確認してください。", {
+      status: 503,
+    });
+  }
+}

--- a/admin/src/client/components/research-fund/JournalEditor.tsx
+++ b/admin/src/client/components/research-fund/JournalEditor.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Button, Input, Label, NativeSelect, Textarea } from "@/client/components/ui";
 import type {
   JournalEdit,
@@ -36,6 +36,15 @@ export function JournalEditor({
     },
   );
   const [dirty, setDirty] = useState(false);
+  useEffect(() => {
+    if (!dirty) return;
+    function onBeforeUnload(event: BeforeUnloadEvent) {
+      event.preventDefault();
+      event.returnValue = "";
+    }
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [dirty]);
   const published = entry?.status === "published";
   function change<K extends keyof JournalEdit>(key: K, value: JournalEdit[K]) {
     setDirty(true);

--- a/admin/src/client/components/research-fund/JournalEditor.tsx
+++ b/admin/src/client/components/research-fund/JournalEditor.tsx
@@ -1,0 +1,194 @@
+"use client";
+import { useId, useState } from "react";
+import { Button, Input, Label, NativeSelect, Textarea } from "@/client/components/ui";
+import type {
+  JournalEdit,
+  ReviewAccount,
+  ReviewEntry,
+} from "@/server/contexts/research-fund/domain/models/journal-review";
+
+export function JournalEditor({
+  entry,
+  accounts,
+  year,
+  documentUrl,
+  pending,
+  onSave,
+  onDiscard,
+}: {
+  entry: ReviewEntry | null;
+  accounts: ReviewAccount[];
+  year: number;
+  documentUrl?: string;
+  pending: boolean;
+  onSave: (input: JournalEdit, approve: boolean) => void;
+  onDiscard: () => void;
+}) {
+  const fieldId = useId();
+  const [input, setInput] = useState<JournalEdit>(
+    entry ?? {
+      entryDate: `${year}-01-01`,
+      amount: 1,
+      description: "",
+      accountKey: "",
+      note: "",
+      memo: "",
+    },
+  );
+  const [dirty, setDirty] = useState(false);
+  const published = entry?.status === "published";
+  function change<K extends keyof JournalEdit>(key: K, value: JournalEdit[K]) {
+    setDirty(true);
+    setInput((old) => ({ ...old, [key]: value }));
+  }
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSave(input, false);
+      }}
+      className="space-y-4"
+      data-journal-dirty={dirty}
+    >
+      {documentUrl ? (
+        <div className="space-y-2">
+          <iframe
+            key={documentUrl}
+            title="領収書プレビュー"
+            src={documentUrl}
+            className="h-72 w-full rounded-lg border bg-background"
+          />
+          <a
+            href={documentUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-primary-active underline"
+          >
+            原寸で開く
+          </a>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          領収書なし（手動作成）
+        </div>
+      )}
+      {published && (
+        <p className="text-sm font-bold text-primary-active">公開中の仕訳は編集・破棄できません</p>
+      )}
+      <fieldset disabled={pending || published} className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <Label htmlFor={`${fieldId}-date`}>日付</Label>
+            <Input
+              id={`${fieldId}-date`}
+              type="date"
+              required
+              min={`${year}-01-01`}
+              max={`${year}-12-31`}
+              value={input.entryDate}
+              onChange={(e) => change("entryDate", e.target.value)}
+            />
+          </div>
+          <div>
+            <Label htmlFor={`${fieldId}-amount`}>金額</Label>
+            <Input
+              id={`${fieldId}-amount`}
+              type="number"
+              min="1"
+              max="999999999999"
+              step="1"
+              required
+              value={input.amount || ""}
+              onChange={(e) => change("amount", Number(e.target.value))}
+            />
+          </div>
+        </div>
+        <div>
+          <Label htmlFor={`${fieldId}-description`}>項目名</Label>
+          <Input
+            id={`${fieldId}-description`}
+            required
+            maxLength={255}
+            value={input.description}
+            onChange={(e) => change("description", e.target.value)}
+          />
+        </div>
+        <div>
+          <Label htmlFor={`${fieldId}-account`}>科目</Label>
+          <NativeSelect
+            id={`${fieldId}-account`}
+            required
+            value={input.accountKey}
+            onChange={(e) => change("accountKey", e.target.value)}
+            wrapperClassName="w-full"
+          >
+            <option value="">科目を選択</option>
+            {accounts.map((a) => (
+              <option key={a.key} value={a.key}>
+                {a.label}
+              </option>
+            ))}
+          </NativeSelect>
+          {input.accountKey === "needs-review" && (
+            <p className="text-sm font-bold text-destructive">要確認：科目を確定してください</p>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          複式の仕訳（借方 {accounts.find((a) => a.key === input.accountKey)?.label ?? "科目"}／貸方
+          普通預金）は自動で作られます
+        </p>
+        <div>
+          <Label htmlFor={`${fieldId}-note`}>特記事項（公開される）</Label>
+          <Textarea
+            id={`${fieldId}-note`}
+            value={input.note}
+            onChange={(e) => change("note", e.target.value)}
+          />
+        </div>
+        <div className="rounded-lg bg-background p-3">
+          <div className="mb-2 flex items-center gap-2">
+            <Label htmlFor={`${fieldId}-memo`}>備考</Label>
+            <span className="rounded-full border px-2 text-xs text-muted-foreground">
+              公開されない
+            </span>
+          </div>
+          <Textarea
+            id={`${fieldId}-memo`}
+            value={input.memo}
+            onChange={(e) => change("memo", e.target.value)}
+          />
+        </div>
+        {!published && (
+          <div className="flex flex-wrap gap-2">
+            <Button type="submit" variant={entry ? "outline" : "default"}>
+              {entry ? "保存" : "下書きを作成"}
+            </Button>
+            {entry?.status === "draft" && (
+              <Button
+                type="submit"
+                disabled={input.accountKey === "needs-review"}
+                onClick={(e) => {
+                  if (e.currentTarget.form?.reportValidity()) {
+                    e.preventDefault();
+                    onSave(input, true);
+                  }
+                }}
+              >
+                確認済にする
+              </Button>
+            )}
+            {entry && (
+              <Button type="button" variant="destructive" onClick={onDiscard}>
+                破棄
+              </Button>
+            )}
+          </div>
+        )}
+      </fieldset>
+      <p className="border-t border-border-soft pt-3 text-xs text-muted-foreground">
+        source: {entry?.source ?? "manual"} ／ モデル: {entry?.model ?? "—"} ／ プロンプト版:{" "}
+        {entry?.promptVersion ?? "—"}
+      </p>
+    </form>
+  );
+}

--- a/admin/src/client/components/research-fund/JournalReview.tsx
+++ b/admin/src/client/components/research-fund/JournalReview.tsx
@@ -1,0 +1,390 @@
+"use client";
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  Label,
+  NativeSelect,
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@/client/components/ui";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import { JournalEditor } from "@/client/components/research-fund/JournalEditor";
+import { ResearchFundCategoryPill } from "@/client/components/research-fund/ResearchFundCategoryPill";
+import type {
+  JournalEdit,
+  ReviewAccount,
+  ReviewEntry,
+} from "@/server/contexts/research-fund/domain/models/journal-review";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+import { mutateJournalReview } from "@/server/contexts/research-fund/presentation/actions/manage-journal-review";
+import { cn } from "@/client/lib";
+
+const statuses = { all: "すべて", draft: "下書き", approved: "確認済", published: "公開中" };
+export function JournalReview({
+  entries,
+  accounts,
+  target,
+}: {
+  entries: ReviewEntry[];
+  accounts: ReviewAccount[];
+  target: Extract<AdminTarget, { kind: "research-fund" }>;
+}) {
+  const router = useRouter();
+  const [status, setStatus] = useState("all");
+  const [month, setMonth] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [discarding, setDiscarding] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const monthly = entries.filter((e) => !month || e.entryDate.slice(5, 7) === month);
+  const visible = monthly.filter((e) => status === "all" || e.status === status);
+  const selected = visible.find((e) => e.id === selectedId) ?? visible[0] ?? null;
+  const index = visible.findIndex((e) => e.id === selected?.id);
+  function allowLeave() {
+    return (
+      !document.querySelector('[data-journal-dirty="true"]') ||
+      window.confirm("未保存の変更を破棄して移動しますか？")
+    );
+  }
+  function select(id: string) {
+    if (id !== selected?.id && !pending && allowLeave()) setSelectedId(id);
+  }
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (
+        pending ||
+        creating ||
+        discarding ||
+        event.defaultPrevented ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        (event.key !== "ArrowUp" && event.key !== "ArrowDown")
+      )
+        return;
+      const element = event.target;
+      if (
+        element instanceof HTMLElement &&
+        element.closest(
+          'input, textarea, select, button, a, [role="combobox"], [role="tab"], [contenteditable="true"], [role="dialog"]',
+        )
+      )
+        return;
+      const next = visible[index + (event.key === "ArrowDown" ? 1 : -1)];
+      if (next) {
+        event.preventDefault();
+        select(next.id);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+  function save(input: JournalEdit, approve: boolean) {
+    startTransition(async () => {
+      try {
+        const result = await mutateJournalReview(
+          target.politicianId,
+          target.bookId,
+          creating
+            ? { type: "create", input }
+            : {
+                type: "save",
+                id: selected?.id ?? "",
+                updatedAt: selected?.updatedAt ?? "",
+                input,
+                approve,
+              },
+        );
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success(
+          creating ? "下書きを作成しました" : approve ? "確認済にしました" : "保存しました",
+        );
+        if (result.id) {
+          setStatus("all");
+          setMonth("");
+          setSelectedId(result.id);
+        }
+        setCreating(false);
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+  function discard() {
+    if (!selected) return;
+    startTransition(async () => {
+      try {
+        const result = await mutateJournalReview(target.politicianId, target.bookId, {
+          type: "discard",
+          id: selected.id,
+          updatedAt: selected.updatedAt,
+        });
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success("仕訳を破棄しました");
+        setDiscarding(false);
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+  const documentUrl = selected?.documentId
+    ? `/api/research-fund/documents/${selected.documentId}?bookId=${target.bookId}&politicianId=${target.politicianId}`
+    : undefined;
+  return (
+    <>
+      <PageHeader
+        label="Journal entries"
+        title="仕訳の確認・編集"
+        description={`${target.name}・${target.year}年 — 領収書と並べて支出を確認します。↑↓キーで移動できます。`}
+        actions={
+          <Button
+            disabled={pending}
+            onClick={() => {
+              if (allowLeave()) setCreating(true);
+            }}
+          >
+            手動で仕訳を作成
+          </Button>
+        }
+      />
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+        <Tabs
+          value={status}
+          onValueChange={(value) => {
+            if (!pending && allowLeave()) {
+              setStatus(value);
+              setSelectedId(null);
+            }
+          }}
+        >
+          <TabsList aria-label="仕訳の状態">
+            {Object.entries(statuses).map(([key, label]) => (
+              <TabsTrigger key={key} value={key}>
+                {label}（{monthly.filter((e) => key === "all" || e.status === key).length}）
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <div className="flex items-center gap-2">
+          <Label htmlFor="journal-month">月</Label>
+          <NativeSelect
+            id="journal-month"
+            value={month}
+            disabled={pending}
+            onChange={(e) => {
+              if (allowLeave()) {
+                setMonth(e.target.value);
+                setSelectedId(null);
+              }
+            }}
+          >
+            <option value="">すべての月</option>
+            {Array.from({ length: 12 }, (_, i) => (
+              <option key={i} value={String(i + 1).padStart(2, "0")}>
+                {i + 1}月
+              </option>
+            ))}
+          </NativeSelect>
+        </div>
+      </div>
+      <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,3fr)_minmax(360px,2fr)]">
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>日付</TableHead>
+                  <TableHead>カテゴリー</TableHead>
+                  <TableHead>項目</TableHead>
+                  <TableHead>金額</TableHead>
+                  <TableHead>状態</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {visible.map((entry) => {
+                  const splits = entry.splitGroup
+                    ? entries.filter(
+                        (e) =>
+                          e.splitGroup === entry.splitGroup && e.documentId === entry.documentId,
+                      )
+                    : [];
+                  return (
+                    <TableRow
+                      key={entry.id}
+                      tabIndex={0}
+                      aria-selected={entry.id === selected?.id}
+                      onClick={() => select(entry.id)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          select(entry.id);
+                        }
+                      }}
+                      className={cn(
+                        "cursor-pointer",
+                        entry.id === selected?.id && "bg-accent",
+                        entry.accountKey === "needs-review" && "border-l-4 border-l-destructive",
+                      )}
+                    >
+                      <TableCell className="font-latin whitespace-nowrap">
+                        {entry.entryDate.replaceAll("-", ".")}
+                      </TableCell>
+                      <TableCell>
+                        <ResearchFundCategoryPill accountKey={entry.accountKey} />
+                      </TableCell>
+                      <TableCell>
+                        <span>{entry.description}</span>
+                        <div className="mt-1 flex flex-wrap gap-1 text-xs text-muted-foreground">
+                          {splits.length > 1 && (
+                            <span className="rounded-full border px-2">
+                              分割 {splits.findIndex((e) => e.id === entry.id) + 1}/{splits.length}
+                            </span>
+                          )}
+                          {!entry.documentId && (
+                            <span className="rounded-full border px-2">領収書なし</span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right font-latin">
+                        ¥{entry.amount.toLocaleString("ja-JP")}
+                      </TableCell>
+                      <TableCell>
+                        <span
+                          className={cn(
+                            "whitespace-nowrap rounded-full border px-2 py-1 text-xs",
+                            entry.status === "draft"
+                              ? "bg-background text-muted-foreground"
+                              : "bg-accent text-accent-foreground",
+                          )}
+                        >
+                          {statuses[entry.status]}
+                        </span>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+                {visible.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5} className="p-8 text-center text-muted-foreground">
+                      該当する仕訳はありません
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+        <Card className="xl:sticky xl:top-6">
+          <CardContent className="p-5">
+            {selected ? (
+              <>
+                <div className="mb-4 flex items-center justify-between">
+                  <h2 className="font-bold">仕訳の詳細</h2>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      disabled={pending || index <= 0}
+                      onClick={() => select(visible[index - 1].id)}
+                    >
+                      前へ
+                    </Button>
+                    <Button
+                      variant="outline"
+                      disabled={pending || index >= visible.length - 1}
+                      onClick={() => select(visible[index + 1].id)}
+                    >
+                      次へ
+                    </Button>
+                  </div>
+                </div>
+                <JournalEditor
+                  key={`${selected.id}:${selected.updatedAt}`}
+                  entry={selected}
+                  accounts={accounts}
+                  year={target.year}
+                  documentUrl={documentUrl}
+                  pending={pending}
+                  onSave={save}
+                  onDiscard={() => setDiscarding(true)}
+                />
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                仕訳を作成すると、ここで確認できます。
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+      <Dialog
+        open={creating}
+        onOpenChange={(open) => {
+          if (!pending && (open || allowLeave())) setCreating(open);
+        }}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>手動で仕訳を作成</DialogTitle>
+            <DialogDescription>領収書なしの支出を下書きとして登録します。</DialogDescription>
+          </DialogHeader>
+          <JournalEditor
+            entry={null}
+            accounts={accounts.filter((a) => a.key !== "needs-review")}
+            year={target.year}
+            pending={pending}
+            onSave={save}
+            onDiscard={() => {}}
+          />
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={discarding}
+        onOpenChange={(open) => {
+          if (!pending) setDiscarding(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>仕訳を破棄しますか？</DialogTitle>
+            <DialogDescription>
+              「{selected?.description}」を削除します。この操作は取り消せません。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" disabled={pending} onClick={() => setDiscarding(false)}>
+              キャンセル
+            </Button>
+            <Button variant="destructive" disabled={pending} onClick={discard}>
+              破棄する
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/admin/src/client/components/research-fund/ResearchFundCategoryPill.tsx
+++ b/admin/src/client/components/research-fund/ResearchFundCategoryPill.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/client/lib";
+import { RECEIPT_CATEGORIES } from "@/server/contexts/research-fund/domain/models/receipt-categories";
+
+const colors: Record<keyof typeof RECEIPT_CATEGORIES, string> = {
+  "pc-electronics": "bg-accent text-accent-foreground",
+  "stationery-supplies": "bg-background text-foreground",
+  taxi: "bg-accent text-accent-foreground",
+  airfare: "bg-accent text-accent-foreground",
+  housing: "bg-background text-muted-foreground",
+  "public-transport": "bg-accent text-accent-foreground",
+  "telecom-it": "bg-background text-foreground",
+  lodging: "bg-accent text-accent-foreground",
+  "books-newspapers": "bg-accent text-accent-foreground",
+  "printing-pr": "bg-accent text-accent-foreground",
+  "trip-arrangement": "bg-accent text-accent-foreground",
+  utilities: "bg-background text-muted-foreground",
+  hospitality: "bg-background text-foreground",
+  "membership-fees": "bg-background text-foreground",
+  postage: "bg-background text-foreground",
+  "tolls-parking": "bg-accent text-accent-foreground",
+  meetings: "bg-accent text-accent-foreground",
+  "bank-fees": "bg-background text-muted-foreground",
+  misc: "bg-background text-muted-foreground",
+  personnel: "bg-background text-foreground",
+  donation: "bg-background text-foreground",
+};
+export function ResearchFundCategoryPill({ accountKey }: { accountKey: string }) {
+  const key = accountKey as keyof typeof RECEIPT_CATEGORIES;
+  return (
+    <span
+      className={cn(
+        "inline-block whitespace-nowrap rounded-full border px-3 py-0.5 text-xs font-medium",
+        colors[key] ?? "border-destructive bg-destructive-hover text-destructive",
+      )}
+    >
+      {RECEIPT_CATEGORIES[key]?.label ?? "要確認"}
+    </span>
+  );
+}

--- a/admin/src/server/contexts/research-fund/application/usecases/manage-journal-review-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/manage-journal-review-usecase.ts
@@ -1,0 +1,90 @@
+import "server-only";
+import { JournalEntry } from "@/server/contexts/research-fund/domain/models/journal-entry";
+import { JournalEntryHash } from "@/server/contexts/research-fund/domain/models/journal-entry-hash";
+import { JournalPosting } from "@/server/contexts/research-fund/domain/models/journal-posting";
+import {
+  JournalReviewError,
+  journalEditSchema,
+  type JournalEdit,
+  type JournalWrite,
+} from "@/server/contexts/research-fund/domain/models/journal-review";
+import type { JournalReviewRepository } from "@/server/contexts/research-fund/domain/repositories/journal-review-repository.interface";
+
+export class ManageJournalReviewUsecase {
+  constructor(private repository: JournalReviewRepository) {}
+  async list(bookId: string) {
+    return {
+      entries: await this.repository.list(bookId),
+      accounts: (await this.repository.accounts()).filter((a) => a.type === "expense"),
+    };
+  }
+  private async editable(bookId: string, id: string, updatedAt: string) {
+    const entry = await this.repository.find(bookId, id);
+    if (!entry) throw new JournalReviewError("仕訳が見つかりません");
+    if (entry.status === "published")
+      throw new JournalReviewError("公開中の仕訳は編集・破棄できません");
+    if (entry.source === "grant") throw new JournalReviewError("支給は支給の登録画面で扱います");
+    if (entry.updatedAt !== updatedAt)
+      throw new JournalReviewError("別の操作で更新されました。画面を再読み込みしてください");
+    return entry;
+  }
+  private async prepare(
+    bookId: string,
+    raw: JournalEdit,
+    source: "manual" | "scan",
+    documentId: string | null,
+    status: JournalWrite["status"],
+  ): Promise<JournalWrite> {
+    const parsed = journalEditSchema.safeParse(raw);
+    if (!parsed.success)
+      throw new JournalReviewError("日付・金額・項目名・科目を正しく入力してください");
+    const input = parsed.data;
+    const year = await this.repository.year(bookId);
+    if (!year || Number(input.entryDate.slice(0, 4)) !== year)
+      throw new JournalReviewError("帳簿の年度内の日付を指定してください");
+    if (status === "approved" && input.accountKey === "needs-review")
+      throw new JournalReviewError("科目を確定してから確認済にしてください");
+    const accounts = await this.repository.accounts();
+    const account = accounts.find((a) => a.key === input.accountKey);
+    const assetAccount = accounts.find((a) => a.key === "bank");
+    if (!account || !assetAccount) throw new JournalReviewError("科目が見つかりません");
+    const posting = JournalPosting.generate({
+      pattern: "expense",
+      source,
+      amount: input.amount,
+      account,
+      assetAccount,
+    });
+    if (posting.status === "invalid") throw new JournalReviewError(posting.errors[0].message);
+    const hash = JournalEntryHash.generate({ ...input, documentId });
+    if (hash.status === "invalid") throw new JournalReviewError(hash.errors[0].message);
+    return { ...input, status, hash: hash.value, lines: posting.value.lines };
+  }
+  async create(bookId: string, input: JournalEdit, userId: string) {
+    return this.repository.create(
+      bookId,
+      await this.prepare(bookId, input, "manual", null, "draft"),
+      userId,
+    );
+  }
+  async save(bookId: string, id: string, updatedAt: string, input: JournalEdit, approve: boolean) {
+    const entry = await this.editable(bookId, id, updatedAt);
+    let status = entry.status;
+    if (approve) {
+      const result = JournalEntry.transition(entry, "approved");
+      if (result.status === "invalid") throw new JournalReviewError(result.errors[0].message);
+      status = result.value.status;
+    }
+    const write = await this.prepare(
+      bookId,
+      input,
+      entry.source === "scan" ? "scan" : "manual",
+      entry.documentId,
+      status,
+    );
+    await this.repository.update(bookId, entry, write);
+  }
+  async discard(bookId: string, id: string, updatedAt: string) {
+    await this.repository.discard(bookId, await this.editable(bookId, id, updatedAt));
+  }
+}

--- a/admin/src/server/contexts/research-fund/domain/models/journal-review.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/journal-review.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import type { JournalEntry } from "@/server/contexts/research-fund/domain/models/journal-entry";
+import type {
+  JournalLine,
+  ResearchFundAccount,
+} from "@/server/contexts/research-fund/domain/models/journal-posting";
+
+export const journalEditSchema = z.object({
+  entryDate: z.iso.date(),
+  description: z.string().trim().min(1).max(255),
+  amount: z.number().int().positive().max(999_999_999_999),
+  accountKey: z.string().min(1).max(50),
+  note: z.string(),
+  memo: z.string(),
+});
+export type JournalEdit = z.infer<typeof journalEditSchema>;
+export interface ReviewAccount extends ResearchFundAccount {
+  label: string;
+}
+export interface ReviewEntry extends JournalEdit, JournalEntry {
+  id: string;
+  source: "scan" | "manual" | "grant";
+  documentId: string | null;
+  splitGroup: string | null;
+  updatedAt: string;
+  model: string | null;
+  promptVersion: number | null;
+}
+export interface JournalWrite extends JournalEdit {
+  hash: string;
+  lines: readonly JournalLine[];
+  status: ReviewEntry["status"];
+}
+export class JournalReviewError extends Error {}

--- a/admin/src/server/contexts/research-fund/domain/repositories/journal-review-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/journal-review-repository.interface.ts
@@ -1,0 +1,14 @@
+import type {
+  JournalWrite,
+  ReviewAccount,
+  ReviewEntry,
+} from "@/server/contexts/research-fund/domain/models/journal-review";
+export interface JournalReviewRepository {
+  list(bookId: string): Promise<ReviewEntry[]>;
+  accounts(): Promise<ReviewAccount[]>;
+  find(bookId: string, id: string): Promise<ReviewEntry | null>;
+  year(bookId: string): Promise<number | null>;
+  create(bookId: string, input: JournalWrite, userId: string): Promise<string>;
+  update(bookId: string, entry: ReviewEntry, input: JournalWrite): Promise<void>;
+  discard(bookId: string, entry: ReviewEntry): Promise<void>;
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.ts
@@ -24,16 +24,22 @@ const expenseWhere = {
   source: { in: ["manual", "scan"] },
   lines: { some: { side: "debit", account: { type: "expense" } } },
 } satisfies Prisma.ResearchFundJournalEntryWhereInput;
-function model(row: Row): ReviewEntry {
+function model(row: Row): ReviewEntry | null {
   const expense = row.lines.find((l) => l.side === "debit" && l.account.type === "expense");
+  const bank = row.lines.find(
+    (l) => l.side === "credit" && l.accountKey === "bank" && l.account.type === "asset",
+  );
+  // このフォームが損失なく再生成できる「費用1行／普通預金1行」だけを扱う。
+  if (row.lines.length !== 2 || !expense || !bank || !expense.amount.equals(bank.amount))
+    return null;
   // 書類の再スキャンで過去の仕訳に別のモデル・版を表示しない。
   const job = row.document?.scanJobs.find((j) => j.createdAt <= row.createdAt);
   return {
     id: String(row.id),
     entryDate: row.entryDate.toISOString().slice(0, 10),
     description: row.description,
-    amount: expense?.amount.toNumber() ?? 0,
-    accountKey: expense?.accountKey ?? "needs-review",
+    amount: expense.amount.toNumber(),
+    accountKey: expense.accountKey,
     note: row.note ?? "",
     memo: row.memo ?? "",
     status: row.status,
@@ -73,7 +79,9 @@ export class PrismaJournalReviewRepository implements JournalReviewRepository {
         include,
         orderBy: [{ entryDate: "desc" }, { id: "asc" }],
       })
-    ).map(model);
+    )
+      .map(model)
+      .filter((entry): entry is ReviewEntry => entry !== null);
   }
   async accounts() {
     return this.prisma.researchFundAccount.findMany({ orderBy: { displayOrder: "asc" } });
@@ -111,6 +119,11 @@ export class PrismaJournalReviewRepository implements JournalReviewRepository {
       });
       if (result.count !== 1)
         throw new JournalReviewError("仕訳が更新・公開されました。画面を再読み込みしてください");
+      const row = await tx.researchFundJournalEntry.findFirst({
+        where: { id: BigInt(entry.id), bookId: BigInt(bookId) },
+        include,
+      });
+      if (!row || !model(row)) throw new JournalReviewError("この形式の仕訳は編集できません");
       await tx.researchFundJournalLine.deleteMany({ where: { entryId: BigInt(entry.id) } });
       await tx.researchFundJournalLine.createMany({
         data: input.lines.map((l) => ({ ...l, entryId: BigInt(entry.id) })),

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.ts
@@ -1,0 +1,127 @@
+import "server-only";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import {
+  JournalReviewError,
+  type JournalWrite,
+  type ReviewEntry,
+} from "@/server/contexts/research-fund/domain/models/journal-review";
+import type { JournalReviewRepository } from "@/server/contexts/research-fund/domain/repositories/journal-review-repository.interface";
+
+const include = {
+  lines: { include: { account: true } },
+  document: {
+    include: {
+      scanJobs: {
+        where: { status: "succeeded" as const },
+        orderBy: { createdAt: "desc" as const },
+        include: { prompt: true },
+      },
+    },
+  },
+} satisfies Prisma.ResearchFundJournalEntryInclude;
+type Row = Prisma.ResearchFundJournalEntryGetPayload<{ include: typeof include }>;
+const expenseWhere = {
+  source: { in: ["manual", "scan"] },
+  lines: { some: { side: "debit", account: { type: "expense" } } },
+} satisfies Prisma.ResearchFundJournalEntryWhereInput;
+function model(row: Row): ReviewEntry {
+  const expense = row.lines.find((l) => l.side === "debit" && l.account.type === "expense");
+  // 書類の再スキャンで過去の仕訳に別のモデル・版を表示しない。
+  const job = row.document?.scanJobs.find((j) => j.createdAt <= row.createdAt);
+  return {
+    id: String(row.id),
+    entryDate: row.entryDate.toISOString().slice(0, 10),
+    description: row.description,
+    amount: expense?.amount.toNumber() ?? 0,
+    accountKey: expense?.accountKey ?? "needs-review",
+    note: row.note ?? "",
+    memo: row.memo ?? "",
+    status: row.status,
+    source: row.source,
+    documentId: row.documentId === null ? null : String(row.documentId),
+    splitGroup: row.splitGroup,
+    updatedAt: row.updatedAt.toISOString(),
+    model: job?.model ?? null,
+    promptVersion: job?.prompt.version ?? null,
+  };
+}
+function data(input: JournalWrite) {
+  return {
+    entryDate: new Date(input.entryDate),
+    description: input.description,
+    note: input.note || null,
+    memo: input.memo || null,
+    status: input.status,
+    hash: input.hash,
+  };
+}
+function guard(bookId: string, entry: ReviewEntry) {
+  return {
+    id: BigInt(entry.id),
+    bookId: BigInt(bookId),
+    status: { in: ["draft", "approved"] as ("draft" | "approved")[] },
+    updatedAt: new Date(entry.updatedAt),
+    ...expenseWhere,
+  };
+}
+export class PrismaJournalReviewRepository implements JournalReviewRepository {
+  constructor(private prisma: PrismaClient) {}
+  async list(bookId: string) {
+    return (
+      await this.prisma.researchFundJournalEntry.findMany({
+        where: { bookId: BigInt(bookId), ...expenseWhere },
+        include,
+        orderBy: [{ entryDate: "desc" }, { id: "asc" }],
+      })
+    ).map(model);
+  }
+  async accounts() {
+    return this.prisma.researchFundAccount.findMany({ orderBy: { displayOrder: "asc" } });
+  }
+  async find(bookId: string, id: string) {
+    const row = await this.prisma.researchFundJournalEntry.findFirst({
+      where: { bookId: BigInt(bookId), id: BigInt(id), ...expenseWhere },
+      include,
+    });
+    return row ? model(row) : null;
+  }
+  async year(bookId: string) {
+    return (
+      (await this.prisma.researchFundBook.findUnique({ where: { id: BigInt(bookId) } }))
+        ?.financialYear ?? null
+    );
+  }
+  async create(bookId: string, input: JournalWrite, userId: string) {
+    const row = await this.prisma.researchFundJournalEntry.create({
+      data: {
+        ...data(input),
+        bookId: BigInt(bookId),
+        source: "manual",
+        createdById: userId,
+        lines: { create: input.lines.map((l) => ({ ...l })) },
+      },
+    });
+    return String(row.id);
+  }
+  async update(bookId: string, entry: ReviewEntry, input: JournalWrite) {
+    await this.prisma.$transaction(async (tx) => {
+      const result = await tx.researchFundJournalEntry.updateMany({
+        where: guard(bookId, entry),
+        data: data(input),
+      });
+      if (result.count !== 1)
+        throw new JournalReviewError("仕訳が更新・公開されました。画面を再読み込みしてください");
+      await tx.researchFundJournalLine.deleteMany({ where: { entryId: BigInt(entry.id) } });
+      await tx.researchFundJournalLine.createMany({
+        data: input.lines.map((l) => ({ ...l, entryId: BigInt(entry.id) })),
+      });
+    });
+  }
+  async discard(bookId: string, entry: ReviewEntry) {
+    const result = await this.prisma.researchFundJournalEntry.deleteMany({
+      where: guard(bookId, entry),
+    });
+    if (result.count !== 1)
+      throw new JournalReviewError("仕訳が更新・公開されました。画面を再読み込みしてください");
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/actions/manage-journal-review.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/manage-journal-review.ts
@@ -1,4 +1,5 @@
 "use server";
+import "server-only";
 import { revalidatePath } from "next/cache";
 import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";

--- a/admin/src/server/contexts/research-fund/presentation/actions/manage-journal-review.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/manage-journal-review.ts
@@ -1,0 +1,42 @@
+"use server";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { ManageJournalReviewUsecase } from "@/server/contexts/research-fund/application/usecases/manage-journal-review-usecase";
+import { PrismaJournalReviewRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository";
+import {
+  JournalReviewError,
+  type JournalEdit,
+} from "@/server/contexts/research-fund/domain/models/journal-review";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+type Mutation =
+  | { type: "create"; input: JournalEdit }
+  | { type: "save"; id: string; updatedAt: string; input: JournalEdit; approve: boolean }
+  | { type: "discard"; id: string; updatedAt: string };
+export async function mutateJournalReview(
+  politicianId: string,
+  bookId: string,
+  mutation: Mutation,
+) {
+  const user = await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    const usecase = new ManageJournalReviewUsecase(new PrismaJournalReviewRepository(prisma));
+    let id: string | undefined;
+    if (mutation.type === "create") id = await usecase.create(bookId, mutation.input, user.id);
+    else if (mutation.type === "save")
+      await usecase.save(bookId, mutation.id, mutation.updatedAt, mutation.input, mutation.approve);
+    else if (mutation.type === "discard")
+      await usecase.discard(bookId, mutation.id, mutation.updatedAt);
+    else throw new JournalReviewError("操作が不正です");
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const, id };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: error instanceof JournalReviewError ? error.message : "仕訳の保存に失敗しました",
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-journal-document.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-journal-document.ts
@@ -1,0 +1,27 @@
+import "server-only";
+import { createClient } from "@supabase/supabase-js";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { GetDocumentUsecase } from "@/server/contexts/research-fund/application/usecases/get-document-usecase";
+import { PrismaDocumentRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository";
+import { SupabaseDocumentStorage } from "@/server/contexts/research-fund/infrastructure/storage/supabase-document-storage";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export async function loadJournalDocument(
+  politicianId: string,
+  bookId: string,
+  documentId: string,
+) {
+  if (!(await requireJournalTarget(politicianId, bookId))) return null;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const bucket = process.env.RESEARCH_FUND_DOCUMENT_BUCKET;
+  if (!url || !key || !bucket) throw new Error("領収書ストレージが未設定です");
+  const client = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const result = await new GetDocumentUsecase(
+    new PrismaDocumentRepository(prisma),
+    new SupabaseDocumentStorage(client, bucket),
+  ).execute({ bookId, documentId, expiresIn: 300 });
+  return result.status === "valid" ? { signedUrl: result.value.signedUrl } : null;
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-journal-review.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-journal-review.ts
@@ -1,0 +1,25 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { loadAdminTargets } from "@/server/contexts/shared/presentation/loaders/load-admin-targets";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+import { ManageJournalReviewUsecase } from "@/server/contexts/research-fund/application/usecases/manage-journal-review-usecase";
+import { PrismaJournalReviewRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository";
+
+export async function requireJournalTarget(politicianId: string, bookId: string) {
+  const { currentTarget } = await loadAdminTargets();
+  if (
+    currentTarget?.kind !== "research-fund" ||
+    currentTarget.bookId !== bookId ||
+    currentTarget.politicianId !== politicianId
+  )
+    return null;
+  return currentTarget;
+}
+export async function loadJournalReview(politicianId: string, bookId: string) {
+  const target = await requireJournalTarget(politicianId, bookId);
+  if (!target) notFound();
+  const data = await new ManageJournalReviewUsecase(new PrismaJournalReviewRepository(prisma)).list(
+    bookId,
+  );
+  return { ...data, target };
+}

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-journal-review-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-journal-review-usecase.test.ts
@@ -1,0 +1,53 @@
+import { ManageJournalReviewUsecase } from "@/server/contexts/research-fund/application/usecases/manage-journal-review-usecase";
+import type { JournalEdit, ReviewEntry } from "@/server/contexts/research-fund/domain/models/journal-review";
+const input: JournalEdit = { entryDate: "2026-08-01", description: "視察の移動", amount: 1200, accountKey: "taxi", note: "公開メモ", memo: "内部メモ" };
+const entry: ReviewEntry = { ...input, id: "2", source: "scan", documentId: "3", splitGroup: "group", status: "draft", updatedAt: "2026-08-01T12:00:00.000Z", model: "test-model", promptVersion: 1 };
+function setup(overrides: Partial<ReviewEntry> = {}) {
+  const repository = { list: jest.fn().mockResolvedValue([entry]), find: jest.fn().mockResolvedValue({ ...entry, ...overrides }), accounts: jest.fn().mockResolvedValue([{ key: "taxi", label: "タクシー代", type: "expense" }, { key: "needs-review", label: "要確認", type: "expense" }, { key: "bank", label: "普通預金", type: "asset" }]), year: jest.fn().mockResolvedValue(2026), create: jest.fn().mockResolvedValue("10"), update: jest.fn(), discard: jest.fn() };
+  return { repository, usecase: new ManageJournalReviewUsecase(repository) };
+}
+test("手動作成は下書き・複式の行・hashを保存する", async () => {
+  const { repository, usecase } = setup();
+  await expect(usecase.create("1", input, "user")).resolves.toBe("10");
+  expect(repository.create).toHaveBeenCalledWith("1", expect.objectContaining({ ...input, status: "draft", hash: expect.stringMatching(/^[a-f0-9]{64}$/), lines: [{ side: "debit", accountKey: "taxi", amount: 1200 }, { side: "credit", accountKey: "bank", amount: 1200 }] }), "user");
+});
+test("編集して確認済にする。公開・非公開メモと書類由来のhashを保存", async () => {
+  const { repository, usecase } = setup();
+  await usecase.save("1", "2", entry.updatedAt, { ...input, amount: 1500 }, true);
+  expect(repository.update).toHaveBeenCalledWith("1", entry, expect.objectContaining({ status: "approved", amount: 1500, note: "公開メモ", memo: "内部メモ", lines: [{ side: "debit", accountKey: "taxi", amount: 1500 }, { side: "credit", accountKey: "bank", amount: 1500 }] }));
+});
+test.each(["draft", "approved"] as const)("%s を保存・破棄できる", async status => {
+  const { repository, usecase } = setup({ status });
+  await usecase.save("1", "2", entry.updatedAt, input, false);
+  expect(repository.update.mock.calls[0][2].status).toBe(status);
+  await usecase.discard("1", "2", entry.updatedAt);
+  expect(repository.discard).toHaveBeenCalled();
+});
+test.each([{ status: "published" as const }, { source: "grant" as const }, { updatedAt: "new" }])("公開・支給・同時編集は保存と破棄を拒否 %j", async overrides => {
+  const { repository, usecase } = setup(overrides);
+  await expect(usecase.save("1", "2", entry.updatedAt, input, false)).rejects.toThrow();
+  await expect(usecase.discard("1", "2", entry.updatedAt)).rejects.toThrow();
+  expect(repository.update).not.toHaveBeenCalled(); expect(repository.discard).not.toHaveBeenCalled();
+});
+test.each([{ amount: 0 }, { amount: 1.5 }, { amount: 1e12 }, { entryDate: "2026-02-30" }, { entryDate: "2025-12-31" }, { description: " " }, { description: "a".repeat(256) }, { accountKey: "bank" }, { accountKey: "missing" }, { memo: null }])("不正な入力は保存しない %j", async override => {
+  const { repository, usecase } = setup();
+  await expect(usecase.create("1", { ...input, ...override } as JournalEdit, "user")).rejects.toThrow();
+  expect(repository.create).not.toHaveBeenCalled();
+});
+test("未確定の科目は下書きで保存し、確認済への遷移を拒否", async () => {
+  const { repository, usecase } = setup();
+  await usecase.save("1", "2", entry.updatedAt, { ...input, accountKey: "needs-review" }, false);
+  repository.update.mockClear();
+  await expect(usecase.save("1", "2", entry.updatedAt, { ...input, accountKey: "needs-review" }, true)).rejects.toThrow("科目を確定");
+  expect(repository.update).not.toHaveBeenCalled();
+});
+test("別帳簿の仕訳・存在しない仕訳は更新できない", async () => {
+  const { repository, usecase } = setup(); repository.find.mockResolvedValue(null);
+  await expect(usecase.save("9", "2", entry.updatedAt, input, true)).rejects.toThrow("見つかりません");
+  expect(repository.find).toHaveBeenCalledWith("9", "2"); expect(repository.update).not.toHaveBeenCalled();
+});
+test("一覧には費用科目だけを渡す", async () => {
+  const { usecase } = setup();
+  const data = await usecase.list("1");
+  expect(data.entries).toEqual([entry]); expect(data.accounts.map(a => a.key)).toEqual(["taxi", "needs-review"]);
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
@@ -3,8 +3,17 @@ import { PrismaJournalReviewRepository } from "@/server/contexts/research-fund/i
 import type { JournalWrite, ReviewEntry } from "@/server/contexts/research-fund/domain/models/journal-review";
 const entry = { id: "9007199254740993", updatedAt: "2026-08-01T00:00:00.000Z" } as ReviewEntry;
 const input: JournalWrite = { entryDate: "2026-08-01", description: "移動", amount: 1200, accountKey: "taxi", note: "公開", memo: "非公開", hash: "hash", status: "approved", lines: [{ side: "debit", accountKey: "taxi", amount: 1200 }, { side: "credit", accountKey: "bank", amount: 1200 }] };
+function rowWithLines(lines = input.lines) {
+  return {
+    id: BigInt(entry.id), entryDate: new Date(input.entryDate), createdAt: new Date(input.entryDate),
+    updatedAt: new Date(entry.updatedAt), description: input.description, note: null, memo: null,
+    status: "draft", source: "manual", documentId: null, splitGroup: null, document: null,
+    lines: lines.map(line => ({ ...line, amount: new Prisma.Decimal(line.amount),
+      account: { type: line.side === "debit" ? "expense" : "asset" } })),
+  };
+}
 function setup(count = 1) {
-  const tx = { researchFundJournalEntry: { updateMany: jest.fn().mockResolvedValue({ count }), deleteMany: jest.fn().mockResolvedValue({ count }), findMany: jest.fn(), findFirst: jest.fn(), create: jest.fn().mockResolvedValue({ id: BigInt(entry.id) }) }, researchFundJournalLine: { deleteMany: jest.fn(), createMany: jest.fn() }, researchFundAccount: { findMany: jest.fn() }, researchFundBook: { findUnique: jest.fn() } };
+  const tx = { researchFundJournalEntry: { updateMany: jest.fn().mockResolvedValue({ count }), deleteMany: jest.fn().mockResolvedValue({ count }), findMany: jest.fn(), findFirst: jest.fn().mockResolvedValue(rowWithLines()), create: jest.fn().mockResolvedValue({ id: BigInt(entry.id) }) }, researchFundJournalLine: { deleteMany: jest.fn(), createMany: jest.fn() }, researchFundAccount: { findMany: jest.fn() }, researchFundBook: { findUnique: jest.fn() } };
   const transaction = jest.fn(async fn => fn(tx));
   const repository = new PrismaJournalReviewRepository({ ...tx, $transaction: transaction } as unknown as PrismaClient);
   return { repository, tx, transaction };
@@ -28,7 +37,7 @@ test("手動作成の source と帳簿、作成者、行を保存する", async 
 });
 test("一覧は帳簿内の支出に限定し、BigInt/Decimal/Dateとスキャン情報を変換", async () => {
   const { repository, tx } = setup();
-  tx.researchFundJournalEntry.findMany.mockResolvedValue([{ id: BigInt(entry.id), entryDate: new Date(input.entryDate), createdAt: new Date("2026-08-02"), updatedAt: new Date(entry.updatedAt), description: "移動", note: "公開", memo: "非公開", source: "scan", status: "draft", splitGroup: "split", documentId: BigInt(3), lines: [{ side: "debit", accountKey: "taxi", account: { type: "expense" }, amount: new Prisma.Decimal(1200) }], document: { scanJobs: [{ createdAt: new Date("2026-08-03"), model: "later", prompt: { version: 2 } }, { createdAt: new Date("2026-08-01"), model: "original", prompt: { version: 1 } }] } }]);
+  tx.researchFundJournalEntry.findMany.mockResolvedValue([{ id: BigInt(entry.id), entryDate: new Date(input.entryDate), createdAt: new Date("2026-08-02"), updatedAt: new Date(entry.updatedAt), description: "移動", note: "公開", memo: "非公開", source: "scan", status: "draft", splitGroup: "split", documentId: BigInt(3), lines: [{ side: "debit", accountKey: "taxi", account: { type: "expense" }, amount: new Prisma.Decimal(1200) }, { side: "credit", accountKey: "bank", account: { type: "asset" }, amount: new Prisma.Decimal(1200) }], document: { scanJobs: [{ createdAt: new Date("2026-08-03"), model: "later", prompt: { version: 2 } }, { createdAt: new Date("2026-08-01"), model: "original", prompt: { version: 1 } }] } }]);
   const rows = await repository.list("1"); expect(rows[0]).toMatchObject({ id: entry.id, amount: 1200, documentId: "3", memo: "非公開", model: "original", promptVersion: 1 });
   expect(tx.researchFundJournalEntry.findMany.mock.calls[0][0].where).toMatchObject({ bookId: BigInt(1), lines: { some: { side: "debit", account: { type: "expense" } } } });
 });
@@ -76,4 +85,23 @@ test("空の公開・非公開メモはNULLで保存し、破棄でも競合条�
     status: { in: ["draft", "approved"] }, source: { in: ["manual", "scan"] },
     lines: { some: { side: "debit", account: { type: "expense" } } },
   } });
+});
+
+
+test.each([
+  ["複数の費用借方", [{ side: "debit", accountKey: "taxi", amount: 500 }, { side: "debit", accountKey: "books-newspapers", amount: 700 }, { side: "credit", accountKey: "bank", amount: 1200 }]],
+  ["複数の貸方", [{ side: "debit", accountKey: "taxi", amount: 1200 }, { side: "credit", accountKey: "bank", amount: 500 }, { side: "credit", accountKey: "cash", amount: 700 }]],
+  ["現金決済", [{ side: "debit", accountKey: "taxi", amount: 1200 }, { side: "credit", accountKey: "cash", amount: 1200 }]],
+  ["貸借不一致", [{ side: "debit", accountKey: "taxi", amount: 1200 }, { side: "credit", accountKey: "bank", amount: 500 }]],
+  ["借方のみ", [{ side: "debit", accountKey: "taxi", amount: 1200 }]],
+] as const)("%sは一覧・取得から除外し、更新時も既存行を保持する", async (_name, lines) => {
+  const { repository, tx } = setup();
+  const unsupported = rowWithLines([...lines]);
+  tx.researchFundJournalEntry.findMany.mockResolvedValue([unsupported, rowWithLines()]);
+  await expect(repository.list("1")).resolves.toHaveLength(1);
+  tx.researchFundJournalEntry.findFirst.mockResolvedValue(unsupported);
+  await expect(repository.find("1", entry.id)).resolves.toBeNull();
+  await expect(repository.update("1", entry, input)).rejects.toThrow("この形式の仕訳は編集できません");
+  expect(tx.researchFundJournalLine.deleteMany).not.toHaveBeenCalled();
+  expect(tx.researchFundJournalLine.createMany).not.toHaveBeenCalled();
 });

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
@@ -1,0 +1,34 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { PrismaJournalReviewRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository";
+import type { JournalWrite, ReviewEntry } from "@/server/contexts/research-fund/domain/models/journal-review";
+const entry = { id: "9007199254740993", updatedAt: "2026-08-01T00:00:00.000Z" } as ReviewEntry;
+const input: JournalWrite = { entryDate: "2026-08-01", description: "移動", amount: 1200, accountKey: "taxi", note: "公開", memo: "非公開", hash: "hash", status: "approved", lines: [{ side: "debit", accountKey: "taxi", amount: 1200 }, { side: "credit", accountKey: "bank", amount: 1200 }] };
+function setup(count = 1) {
+  const tx = { researchFundJournalEntry: { updateMany: jest.fn().mockResolvedValue({ count }), deleteMany: jest.fn().mockResolvedValue({ count }), findMany: jest.fn(), findFirst: jest.fn(), create: jest.fn().mockResolvedValue({ id: BigInt(entry.id) }) }, researchFundJournalLine: { deleteMany: jest.fn(), createMany: jest.fn() } };
+  const transaction = jest.fn(async fn => fn(tx));
+  const repository = new PrismaJournalReviewRepository({ ...tx, $transaction: transaction } as unknown as PrismaClient);
+  return { repository, tx, transaction };
+}
+test("公開状態と更新日時をDBで照合してから同一トランザクションで行を置換", async () => {
+  const { repository, tx, transaction } = setup(); await repository.update("1", entry, input);
+  expect(transaction).toHaveBeenCalledTimes(1);
+  expect(tx.researchFundJournalEntry.updateMany).toHaveBeenCalledWith({ where: expect.objectContaining({ id: BigInt(entry.id), bookId: BigInt(1), status: { in: ["draft", "approved"] }, updatedAt: new Date(entry.updatedAt) }), data: expect.objectContaining({ status: "approved", memo: "非公開" }) });
+  expect(tx.researchFundJournalLine.deleteMany).toHaveBeenCalledWith({ where: { entryId: BigInt(entry.id) } });
+  expect(tx.researchFundJournalLine.createMany).toHaveBeenCalledWith({ data: input.lines.map(l => ({ ...l, entryId: BigInt(entry.id) })) });
+});
+test("競合した場合は複式行を変更しない。削除も拒否", async () => {
+  const { repository, tx } = setup(0);
+  await expect(repository.update("1", entry, input)).rejects.toThrow("更新・公開");
+  expect(tx.researchFundJournalLine.deleteMany).not.toHaveBeenCalled(); expect(tx.researchFundJournalLine.createMany).not.toHaveBeenCalled();
+  await expect(repository.discard("1", entry)).rejects.toThrow("更新・公開");
+});
+test("手動作成の source と帳簿、作成者、行を保存する", async () => {
+  const { repository, tx } = setup(); await expect(repository.create("1", input, "user")).resolves.toBe(entry.id);
+  expect(tx.researchFundJournalEntry.create).toHaveBeenCalledWith({ data: expect.objectContaining({ bookId: BigInt(1), createdById: "user", source: "manual", lines: { create: input.lines } }) });
+});
+test("一覧は帳簿内の支出に限定し、BigInt/Decimal/Dateとスキャン情報を変換", async () => {
+  const { repository, tx } = setup();
+  tx.researchFundJournalEntry.findMany.mockResolvedValue([{ id: BigInt(entry.id), entryDate: new Date(input.entryDate), createdAt: new Date("2026-08-02"), updatedAt: new Date(entry.updatedAt), description: "移動", note: "公開", memo: "非公開", source: "scan", status: "draft", splitGroup: "split", documentId: BigInt(3), lines: [{ side: "debit", accountKey: "taxi", account: { type: "expense" }, amount: new Prisma.Decimal(1200) }], document: { scanJobs: [{ createdAt: new Date("2026-08-03"), model: "later", prompt: { version: 2 } }, { createdAt: new Date("2026-08-01"), model: "original", prompt: { version: 1 } }] } }]);
+  const rows = await repository.list("1"); expect(rows[0]).toMatchObject({ id: entry.id, amount: 1200, documentId: "3", memo: "非公開", model: "original", promptVersion: 1 });
+  expect(tx.researchFundJournalEntry.findMany.mock.calls[0][0].where).toMatchObject({ bookId: BigInt(1), lines: { some: { side: "debit", account: { type: "expense" } } } });
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
@@ -4,7 +4,7 @@ import type { JournalWrite, ReviewEntry } from "@/server/contexts/research-fund/
 const entry = { id: "9007199254740993", updatedAt: "2026-08-01T00:00:00.000Z" } as ReviewEntry;
 const input: JournalWrite = { entryDate: "2026-08-01", description: "移動", amount: 1200, accountKey: "taxi", note: "公開", memo: "非公開", hash: "hash", status: "approved", lines: [{ side: "debit", accountKey: "taxi", amount: 1200 }, { side: "credit", accountKey: "bank", amount: 1200 }] };
 function setup(count = 1) {
-  const tx = { researchFundJournalEntry: { updateMany: jest.fn().mockResolvedValue({ count }), deleteMany: jest.fn().mockResolvedValue({ count }), findMany: jest.fn(), findFirst: jest.fn(), create: jest.fn().mockResolvedValue({ id: BigInt(entry.id) }) }, researchFundJournalLine: { deleteMany: jest.fn(), createMany: jest.fn() } };
+  const tx = { researchFundJournalEntry: { updateMany: jest.fn().mockResolvedValue({ count }), deleteMany: jest.fn().mockResolvedValue({ count }), findMany: jest.fn(), findFirst: jest.fn(), create: jest.fn().mockResolvedValue({ id: BigInt(entry.id) }) }, researchFundJournalLine: { deleteMany: jest.fn(), createMany: jest.fn() }, researchFundAccount: { findMany: jest.fn() }, researchFundBook: { findUnique: jest.fn() } };
   const transaction = jest.fn(async fn => fn(tx));
   const repository = new PrismaJournalReviewRepository({ ...tx, $transaction: transaction } as unknown as PrismaClient);
   return { repository, tx, transaction };
@@ -31,4 +31,49 @@ test("一覧は帳簿内の支出に限定し、BigInt/Decimal/Dateとスキャ�
   tx.researchFundJournalEntry.findMany.mockResolvedValue([{ id: BigInt(entry.id), entryDate: new Date(input.entryDate), createdAt: new Date("2026-08-02"), updatedAt: new Date(entry.updatedAt), description: "移動", note: "公開", memo: "非公開", source: "scan", status: "draft", splitGroup: "split", documentId: BigInt(3), lines: [{ side: "debit", accountKey: "taxi", account: { type: "expense" }, amount: new Prisma.Decimal(1200) }], document: { scanJobs: [{ createdAt: new Date("2026-08-03"), model: "later", prompt: { version: 2 } }, { createdAt: new Date("2026-08-01"), model: "original", prompt: { version: 1 } }] } }]);
   const rows = await repository.list("1"); expect(rows[0]).toMatchObject({ id: entry.id, amount: 1200, documentId: "3", memo: "非公開", model: "original", promptVersion: 1 });
   expect(tx.researchFundJournalEntry.findMany.mock.calls[0][0].where).toMatchObject({ bookId: BigInt(1), lines: { some: { side: "debit", account: { type: "expense" } } } });
+});
+
+test("手動仕訳を取得し、書類・メモの欠損値を表示用に変換する", async () => {
+  const { repository, tx } = setup();
+  tx.researchFundJournalEntry.findFirst.mockResolvedValue({
+    id: BigInt(entry.id), entryDate: new Date(input.entryDate), updatedAt: new Date(entry.updatedAt),
+    createdAt: new Date(input.entryDate), description: "移動", note: null, memo: null,
+    status: "draft", source: "manual", documentId: null, splitGroup: null, document: null,
+    lines: [{ side: "credit", accountKey: "bank", account: { type: "asset" }, amount: new Prisma.Decimal(1200) },
+      { side: "debit", accountKey: "taxi", account: { type: "expense" }, amount: new Prisma.Decimal(1200) }],
+  });
+  await expect(repository.find("1", entry.id)).resolves.toEqual({
+    id: entry.id, entryDate: input.entryDate, updatedAt: entry.updatedAt, description: "移動",
+    note: "", memo: "", status: "draft", source: "manual", documentId: null, splitGroup: null,
+    model: null, promptVersion: null, amount: 1200, accountKey: "taxi",
+  });
+  expect(tx.researchFundJournalEntry.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+    where: { id: BigInt(entry.id), bookId: BigInt(1), source: { in: ["manual", "scan"] },
+      lines: { some: { side: "debit", account: { type: "expense" } } } },
+  }));
+  tx.researchFundJournalEntry.findFirst.mockResolvedValue(null);
+  await expect(repository.find("9", entry.id)).resolves.toBeNull();
+});
+test("科目は表示順に取得し、帳簿が存在しなければ年度を返さない", async () => {
+  const { repository, tx } = setup();
+  const accounts = [{ key: "taxi", label: "タクシー代", type: "expense" }];
+  tx.researchFundAccount.findMany.mockResolvedValue(accounts);
+  await expect(repository.accounts()).resolves.toEqual(accounts);
+  expect(tx.researchFundAccount.findMany).toHaveBeenCalledWith({ orderBy: { displayOrder: "asc" } });
+  tx.researchFundBook.findUnique.mockResolvedValue({ financialYear: 2026 });
+  await expect(repository.year("1")).resolves.toBe(2026);
+  expect(tx.researchFundBook.findUnique).toHaveBeenCalledWith({ where: { id: BigInt(1) } });
+  tx.researchFundBook.findUnique.mockResolvedValue(null);
+  await expect(repository.year("1")).resolves.toBeNull();
+});
+test("空の公開・非公開メモはNULLで保存し、破棄でも競合条件を適用する", async () => {
+  const { repository, tx } = setup();
+  await repository.create("1", { ...input, note: "", memo: "" }, "user");
+  expect(tx.researchFundJournalEntry.create).toHaveBeenCalledWith({ data: expect.objectContaining({ note: null, memo: null }) });
+  await repository.discard("1", entry);
+  expect(tx.researchFundJournalEntry.deleteMany).toHaveBeenCalledWith({ where: {
+    id: BigInt(entry.id), bookId: BigInt(1), updatedAt: new Date(entry.updatedAt),
+    status: { in: ["draft", "approved"] }, source: { in: ["manual", "scan"] },
+    lines: { some: { side: "debit", account: { type: "expense" } } },
+  } });
 });

--- a/admin/tests/server/contexts/research-fund/presentation/actions/manage-journal-review.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/actions/manage-journal-review.test.ts
@@ -1,0 +1,39 @@
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { ManageJournalReviewUsecase } from "@/server/contexts/research-fund/application/usecases/manage-journal-review-usecase";
+import { mutateJournalReview } from "@/server/contexts/research-fund/presentation/actions/manage-journal-review";
+import type { JournalEdit } from "@/server/contexts/research-fund/domain/models/journal-review";
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/server/contexts/auth/presentation/loaders/require-auth", () => ({ requireAuth: jest.fn() }));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({ requireJournalTarget: jest.fn() }));
+jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+const input: JournalEdit = { entryDate: "2026-08-01", description: "移動", amount: 1200, accountKey: "taxi", note: "", memo: "" };
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(requireAuth).mockResolvedValue({ id: "user" } as Awaited<ReturnType<typeof requireAuth>>);
+  jest.mocked(requireJournalTarget).mockResolvedValue({ kind: "research-fund", key: "book:1", name: "議員", year: 2026, politicianId: "2", bookId: "1", draftCount: 0 });
+});
+afterEach(() => jest.restoreAllMocks());
+test("現在の対象を検証し、作成者をサーバー側で設定し、レイアウトを再検証", async () => {
+  const create = jest.spyOn(ManageJournalReviewUsecase.prototype, "create").mockResolvedValue("3");
+  await expect(mutateJournalReview("2", "1", { type: "create", input })).resolves.toEqual({ success: true, id: "3" });
+  expect(requireJournalTarget).toHaveBeenCalledWith("2", "1"); expect(create).toHaveBeenCalledWith("1", input, "user"); expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
+});
+test("別の対象への古いフォーム送信を拒否", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(null);
+  const create = jest.spyOn(ManageJournalReviewUsecase.prototype, "create");
+  await expect(mutateJournalReview("2", "1", { type: "create", input })).resolves.toMatchObject({ success: false });
+  expect(create).not.toHaveBeenCalled(); expect(revalidatePath).not.toHaveBeenCalled();
+});
+test("認証失敗時は更新しない", async () => {
+  jest.mocked(requireAuth).mockRejectedValueOnce(new Error("auth"));
+  const create = jest.spyOn(ManageJournalReviewUsecase.prototype, "create");
+  await expect(mutateJournalReview("2", "1", { type: "create", input })).rejects.toThrow("auth");
+  expect(create).not.toHaveBeenCalled(); expect(revalidatePath).not.toHaveBeenCalled();
+});
+test("内部エラーは漏らさず、失敗時に再検証しない", async () => {
+  jest.spyOn(ManageJournalReviewUsecase.prototype, "save").mockRejectedValue(new Error("private database detail"));
+  await expect(mutateJournalReview("2", "1", { type: "save", id: "3", updatedAt: "date", input, approve: true })).resolves.toEqual({ success: false, error: "仕訳の保存に失敗しました" });
+  expect(revalidatePath).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/presentation/actions/manage-journal-review.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/actions/manage-journal-review.test.ts
@@ -3,7 +3,7 @@ import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require
 import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
 import { ManageJournalReviewUsecase } from "@/server/contexts/research-fund/application/usecases/manage-journal-review-usecase";
 import { mutateJournalReview } from "@/server/contexts/research-fund/presentation/actions/manage-journal-review";
-import type { JournalEdit } from "@/server/contexts/research-fund/domain/models/journal-review";
+import { JournalReviewError, type JournalEdit } from "@/server/contexts/research-fund/domain/models/journal-review";
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 jest.mock("@/server/contexts/auth/presentation/loaders/require-auth", () => ({ requireAuth: jest.fn() }));
 jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({ requireJournalTarget: jest.fn() }));
@@ -35,5 +35,25 @@ test("認証失敗時は更新しない", async () => {
 test("内部エラーは漏らさず、失敗時に再検証しない", async () => {
   jest.spyOn(ManageJournalReviewUsecase.prototype, "save").mockRejectedValue(new Error("private database detail"));
   await expect(mutateJournalReview("2", "1", { type: "save", id: "3", updatedAt: "date", input, approve: true })).resolves.toEqual({ success: false, error: "仕訳の保存に失敗しました" });
+  expect(revalidatePath).not.toHaveBeenCalled();
+});
+
+test("保存と破棄は対象帳簿・更新日時を渡し、成功後に再検証する", async () => {
+  const save = jest.spyOn(ManageJournalReviewUsecase.prototype, "save").mockResolvedValue();
+  const discard = jest.spyOn(ManageJournalReviewUsecase.prototype, "discard").mockResolvedValue();
+  await expect(mutateJournalReview("2", "1", { type: "save", id: "3", updatedAt: "date", input, approve: true })).resolves.toEqual({ success: true });
+  expect(save).toHaveBeenCalledWith("1", "3", "date", input, true);
+  await expect(mutateJournalReview("2", "1", { type: "discard", id: "3", updatedAt: "date" })).resolves.toEqual({ success: true });
+  expect(discard).toHaveBeenCalledWith("1", "3", "date");
+  expect(revalidatePath).toHaveBeenCalledTimes(2);
+});
+
+test("利用者が解消できる業務エラーはメッセージを返す", async () => {
+  jest.spyOn(ManageJournalReviewUsecase.prototype, "discard").mockRejectedValue(new JournalReviewError("公開中の仕訳は編集・破棄できません"));
+  await expect(mutateJournalReview("2", "1", { type: "discard", id: "3", updatedAt: "date" })).resolves.toEqual({ success: false, error: "公開中の仕訳は編集・破棄できません" });
+  expect(revalidatePath).not.toHaveBeenCalled();
+});
+test("不正な操作を拒否して再検証しない", async () => {
+  await expect(mutateJournalReview("2", "1", { type: "unknown" } as never)).resolves.toEqual({ success: false, error: "操作が不正です" });
   expect(revalidatePath).not.toHaveBeenCalled();
 });

--- a/admin/tests/server/contexts/research-fund/presentation/loaders/load-journal-document.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/loaders/load-journal-document.test.ts
@@ -1,0 +1,38 @@
+import { createClient } from "@supabase/supabase-js";
+import { GetDocumentUsecase } from "@/server/contexts/research-fund/application/usecases/get-document-usecase";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { loadJournalDocument } from "@/server/contexts/research-fund/presentation/loaders/load-journal-document";
+jest.mock("@supabase/supabase-js", () => ({ createClient: jest.fn(() => ({})) }));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({ requireJournalTarget: jest.fn() }));
+jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.replaceProperty(process, "env", { ...process.env, SUPABASE_URL: "https://storage.example.test", SUPABASE_SERVICE_ROLE_KEY: "test-key", RESEARCH_FUND_DOCUMENT_BUCKET: "receipts" });
+  jest.mocked(requireJournalTarget).mockResolvedValue({ kind: "research-fund", key: "book:1", name: "議員", year: 2026, politicianId: "2", bookId: "1", draftCount: 0 });
+});
+afterEach(() => jest.restoreAllMocks());
+test("対象が不一致ならストレージにも書類にもアクセスしない", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(null);
+  const execute = jest.spyOn(GetDocumentUsecase.prototype, "execute");
+  await expect(loadJournalDocument("2", "1", "3")).resolves.toBeNull();
+  expect(requireJournalTarget).toHaveBeenCalledWith("2", "1");
+  expect(createClient).not.toHaveBeenCalled();
+  expect(execute).not.toHaveBeenCalled();
+});
+test.each(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "RESEARCH_FUND_DOCUMENT_BUCKET"])("%s がなければ署名URLを生成しない", async key => {
+  delete process.env[key];
+  await expect(loadJournalDocument("2", "1", "3")).rejects.toThrow("領収書ストレージが未設定です");
+  expect(createClient).not.toHaveBeenCalled();
+});
+test("検証した帳簿で5分有効の署名URLを取得する", async () => {
+  const execute = jest.spyOn(GetDocumentUsecase.prototype, "execute").mockResolvedValue({ status: "valid", value: {
+    document: { id: "3", bookId: "1", storageKey: "receipts/3", mime: "image/png", originalFilename: "receipt.png", createdAt: new Date("2026-08-01") }, signedUrl: "https://storage.example.test/signed-receipt",
+  } });
+  await expect(loadJournalDocument("2", "1", "3")).resolves.toEqual({ signedUrl: "https://storage.example.test/signed-receipt" });
+  expect(execute).toHaveBeenCalledWith({ bookId: "1", documentId: "3", expiresIn: 300 });
+  expect(createClient).toHaveBeenCalledWith("https://storage.example.test", "test-key", { auth: { persistSession: false, autoRefreshToken: false } });
+});
+test("書類が取得できない場合はURLを返さない", async () => {
+  jest.spyOn(GetDocumentUsecase.prototype, "execute").mockResolvedValue({ status: "invalid", errors: [] });
+  await expect(loadJournalDocument("2", "1", "3")).resolves.toBeNull();
+});

--- a/admin/tests/server/contexts/research-fund/presentation/loaders/load-journal-review.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/loaders/load-journal-review.test.ts
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+import { loadAdminTargets } from "@/server/contexts/shared/presentation/loaders/load-admin-targets";
+import { ManageJournalReviewUsecase } from "@/server/contexts/research-fund/application/usecases/manage-journal-review-usecase";
+import { loadJournalReview, requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+jest.mock("next/navigation", () => ({ notFound: jest.fn(() => { throw new Error("NOT_FOUND"); }) }));
+jest.mock("@/server/contexts/shared/presentation/loaders/load-admin-targets", () => ({ loadAdminTargets: jest.fn() }));
+jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+const target: AdminTarget = { kind: "research-fund", key: "book:1", name: "議員", year: 2026, politicianId: "2", bookId: "1", draftCount: 0 };
+function select(currentTarget: AdminTarget | null) {
+  jest.mocked(loadAdminTargets).mockResolvedValue({ targets: currentTarget ? [currentTarget] : [], currentTarget, cookieName: "admin-target-user" });
+}
+afterEach(() => jest.restoreAllMocks());
+beforeEach(() => jest.clearAllMocks());
+test.each([null, { ...target, bookId: "9" }, { ...target, politicianId: "9" },
+  { kind: "political-organization", key: "org:1", name: "団体", year: 2026, organizationId: "1" } as AdminTarget])("対象が一致しなければ一覧を取得しない: %j", async currentTarget => {
+  select(currentTarget);
+  const list = jest.spyOn(ManageJournalReviewUsecase.prototype, "list");
+  await expect(requireJournalTarget("2", "1")).resolves.toBeNull();
+  await expect(loadJournalReview("2", "1")).rejects.toThrow("NOT_FOUND");
+  expect(notFound).toHaveBeenCalled();
+  expect(list).not.toHaveBeenCalled();
+});
+test("一致した帳簿の一覧と現在の対象を返す", async () => {
+  select(target);
+  const data = { entries: [], accounts: [] };
+  const list = jest.spyOn(ManageJournalReviewUsecase.prototype, "list").mockResolvedValue(data);
+  await expect(loadJournalReview("2", "1")).resolves.toEqual({ ...data, target });
+  expect(list).toHaveBeenCalledWith("1");
+});
+test("認証を含む対象取得の失敗時は一覧を取得しない", async () => {
+  jest.mocked(loadAdminTargets).mockRejectedValue(new Error("auth"));
+  const list = jest.spyOn(ManageJournalReviewUsecase.prototype, "list");
+  await expect(loadJournalReview("2", "1")).rejects.toThrow("auth");
+  expect(list).not.toHaveBeenCalled();
+});

--- a/prisma/seeds/researchFundAccounts.ts
+++ b/prisma/seeds/researchFundAccounts.ts
@@ -49,6 +49,9 @@ const data: ResearchFundAccountSeedData[] = [
   { key: 'cash', label: '現金', type: 'asset' },
   { key: 'grant-income', label: '調査研究費収入', type: 'income' },
 
+  // 未確定の下書き用。確認済にする前に21分類のいずれかへ変更する。
+  { key: 'needs-review', label: '要確認', type: 'expense' },
+
   // 費用（調研費カテゴリ 21分類）
   { key: 'pc-electronics', label: 'PC・電子機器', type: 'expense', legalCategoryKey: 'equipment-supplies' },
   { key: 'stationery-supplies', label: '文房具・備品', type: 'expense', legalCategoryKey: 'equipment-supplies' },


### PR DESCRIPTION
議員室スタッフが下書きの支出を領収書と照合し、修正して確認済にできるよう、選択中の帳簿に「仕訳の確認・編集」画面を追加します。

- 件数付きステータスタブ・月絞り込み・一覧選択・↑↓キー・右側の領収書／編集パネルを実装。手動作成、保存、確認済への遷移、破棄に対応。
- 既存の複式仕訳ドメインで借方費用／貸方普通預金を生成し、仕訳と行を同じトランザクションで保存。公開済みの変更禁止、更新日時による競合検知、現在の対象帳簿の検証をサーバー側にも適用。
- 特記事項と非公開の備考を区別し、調研費21分類のピルを追加。未確定の下書き用に `needs-review` 科目をシードへ追加し、確認済にする前の科目確定を必須化。
- 領収書は認証・帳簿検証後に5分有効の署名URLで表示。既存の非公開バケット名を `RESEARCH_FUND_DOCUMENT_BUCKET` に指定（`admin/.env.example` に追記）。

Closes #1356

検証: `pnpm verify` 成功（admin 105 suites / 1,308 tests、webapp 17 suites / 139 tests。既存のintegration test 1件はskip）。`pnpm supabase:start` と `pnpm db:reset` の後にE2Eを実行し、webapp 14件成功、adminは対象切り替え後の画面遷移待ちを修正して全35件成功。新規E2Eで手動作成→一覧選択→編集→確認済、キーボード操作、月絞り込み、破棄、再読み込み後の保存内容を確認。

スコープアウトして起票したIssue: なし。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 研究費の仕訳レビュー画面を追加しました。
  - 仕訳の作成・編集・確認済み化・破棄、状態や月による絞り込みに対応しました。
  - 領収書のプレビューと原寸表示に対応しました。
  - 未確定の費目を「要確認」として表示します。
  - 未保存の変更がある場合、画面移動前に警告します。
  - 研究費書類を安全に表示する機能を追加しました。

- **ドキュメント**
  - 領収書プレビュー用の任意設定項目を追加しました。

- **テスト**
  - 仕訳レビューの一連の操作と関連処理を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->