### PR TITLE
fix(loop): スラッシュコマンドの ! 展開が失敗して 0 ターンで終了する問題を修正する

### DIFF
--- a/.claude/commands/loop-fix-main.md
+++ b/.claude/commands/loop-fix-main.md
@@ -13,7 +13,7 @@ description: main の CI 失敗を直す PR を作る（結果は待たない）
 
 - 現在のブランチ: !`git branch --show-current`
 - main の最新 CI: !`gh run list --branch main --workflow ci.yml --limit 1 --json databaseId,conclusion,displayTitle,url --jq '.[] | "\(.conclusion // "実行中") run=\(.databaseId) \(.displayTitle) \(.url)"'`
-- 失敗ジョブ: !`gh run list --branch main --workflow ci.yml --limit 1 --json databaseId --jq '.[0].databaseId' | xargs -I{} gh run view {} --json jobs --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>/dev/null || echo "(取得できず)"`
+- 失敗ジョブ: !`gh run view "$(gh run list --branch main --workflow ci.yml --limit 1 --json databaseId --jq '.[0].databaseId')" --json jobs --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>/dev/null || echo "(取得できず)"`
 
 ## 手順
 

--- a/.claude/commands/loop-implement.md
+++ b/.claude/commands/loop-implement.md
@@ -14,7 +14,7 @@ description: loop:ready の Issue を 1 つ実装し、PR 作成と auto-merge �
 - 現在のブランチ: !`git branch --show-current`
 - 変更状態: !`git status --short`
 - 対象 Issue: !`gh issue view $ARGUMENTS --json number,title,labels,author --jq '"#\(.number) \(.title) [\(.author.login)] labels=\([.labels[].name] | join(","))"'`
-- 起票者の関係性: !`gh api repos/{owner}/{repo}/issues/$ARGUMENTS --jq .author_association`
+- 起票者の関係性: !`gh api "repos/{owner}/{repo}/issues/$ARGUMENTS" --jq .author_association`
 
 ## 手順
 

--- a/docs/loop-engineering.md
+++ b/docs/loop-engineering.md
@@ -240,6 +240,10 @@ git stash list | grep loop-abandoned   # 中断セッションの退避作業（
 ループに自律実装させず人間が行う（`loop:human`）。セッションが自分の判定順序や信頼境界を書き換えられないよう、
 `docs/loop-session-rules.md` の絶対ルールでもこれらのファイルの編集を禁止している。手順書に書いたコマンドが実行環境で動くかは CI では検証されないため、
 変更したら必ずランナーのマシンで `./scripts/loop/state.sh | ./scripts/loop/decide.sh` を実行して裏を取る。
+コマンド定義（`.claude/commands/loop-*.md`）の「現在の状況」にある `!` コマンドは、1 つでも失敗すると Claude が 0 ターンで終了する
+（ランナーは `FAILED kind=deterministic reason=session-not-started` で止まる）。`!` コマンドを変えたら
+`claude -p "/loop-<cmd> <引数>" --max-turns 1` で展開が通ることを確認する。`{owner}/{repo}` を含む `gh api` のパスは
+シェルの波括弧展開を避けるため必ず引用符で囲む。
 
 ## 注意事項
 

--- a/scripts/loop-once.sh
+++ b/scripts/loop-once.sh
@@ -140,6 +140,12 @@ main() {
   local result
   result="$(grep -Eo 'LOOP_RESULT: [A-Z_]+[^\r]*' "$log_file" | tail -1 || true)"
   if [[ -z "$result" ]]; then
+    if grep -q 'セッション終了 (subtype: [a-z_]*, turns: 0,' "$log_file"; then
+      # モデルが一度も呼ばれていない = スラッシュコマンドの ! 展開が失敗した等、再実行しても直らない
+      echo "[loop-once] セッションが 0 ターンで終了しました。コマンド定義（.claude/commands/$command_name.md）の ! 展開が失敗している可能性があります" >&2
+      echo "[loop-once] LOOP_RESULT: FAILED kind=deterministic reason=session-not-started"
+      exit 5
+    fi
     echo "[loop-once] LOOP_RESULT: FAILED kind=transient reason=no-result-line"
     exit 1
   fi

--- a/scripts/loop/run-session.sh
+++ b/scripts/loop/run-session.sh
@@ -35,7 +35,9 @@ run_claude() {
             end
          ] | select(length > 0) | join("\n"))
       elif $e.type == "result" then
-        "[\(ts)] セッション終了 (turns: \($e.num_turns // "?"), cost: $\($e.total_cost_usd // 0))\n\($e.result // "")"
+        "[\(ts)] セッション終了 (subtype: \($e.subtype // "?"), turns: \($e.num_turns // "?"), cost: $\($e.total_cost_usd // 0))"
+        + (if ($e.errors // []) | length > 0 then "\nerrors: \($e.errors | tojson)" else "" end)
+        + "\n\($e.result // "")"
       else empty
       end'
 


### PR DESCRIPTION
## 目的（Why）

最新 main で `./scripts/loop.sh` を回すと、セッションが 0 ターン（cost $0）で終了し `no-result-line` の一過性失敗として 2 回で止まっていた。
原因は `loop-implement.md` の「現在の状況」で `gh api repos/{owner}/{repo}/issues/$ARGUMENTS` を引用符なしで書いていたこと。スラッシュコマンドの `!` 展開シェルが `{owner}` を波括弧展開して gh が失敗し、Claude が起動前に終了していた（#1267 と同種の事故）。

## 変更内容

- `loop-implement.md`: gh api のパスを引用符で囲む
- `loop-fix-main.md`: `xargs -I{}` を外してコマンド置換に置き換える（波括弧を `!` コマンドから排除）
- `scripts/loop/run-session.sh`: 進捗表示に result の `subtype` と `errors` を出す（起動失敗の理由がログに残る）
- `scripts/loop-once.sh`: 0 ターンで終了したセッションを `FAILED kind=deterministic reason=session-not-started` として即停止する（同じ失敗を 2 回繰り返さない）
- `docs/loop-engineering.md`: `!` コマンド変更時の確認手順と引用符の注意を追記

## 検証

- 4 コマンド（loop-implement / loop-fix-ci / loop-resolve-coderabbit / loop-fix-main）の「現在の状況」ブロックをそのまま持つ一時コマンドを作り、`claude -p "/<cmd> <引数>" --max-turns 1` で全件 `subtype=success turns=1` を確認（一時コマンドは削除済み）
- `bash -n` で構文確認。TS 変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * ループ機構の検証手順を追記しました。
  * コマンド失敗時の停止動作、変更内容の展開確認方法、`gh api` パスの引用に関する注意点を説明しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->