### PR TITLE
chore(coderabbit): レビュープロファイルを assertive から chill に下げる

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -19,7 +19,7 @@ reviews:
   high_level_summary_placeholder: "@coderabbitai summary"
 
   # レビュースタイル
-  profile: assertive
+  profile: chill
 
   # レビュー強化機能
   auto_apply_labels: true


### PR DESCRIPTION
## 目的（Why）

ループが出す PR はすべて CodeRabbit のレビューを通るため、指摘が付くたびに修理セッションが 1 つ消費される。
現在のプロファイルは 3 段階で最も指摘の多い `assertive` で、修正 push のたびに隣接する細かい指摘が 1 件ずつ増える
（PR #1394 では 3 ラウンド続き、3 ラウンド目は事実誤認だった）。
プロファイルを `chill` に下げることで、ループの修理ラウンドと人間の監査コストを減らす。

## 変更内容

- `.coderabbit.yml` の `reviews.profile` を `assertive` → `chill` に変更（1 行のみ）

`request_changes_workflow`、`path_filters`、`path_instructions`、`knowledge_base`、`pre_merge_checks` など
他の設定は変更していない。

## ローカル CI

`pnpm verify` 通過（test / typecheck / lint / knip / depcruise）。

```
Test Suites: 1 skipped, 107 passed, 107 of 108 total
Tests:       1 skipped, 1331 passed, 1332 total
Test Suites: 17 passed, 17 total
Tests:       139 passed, 139 total
✔ no dependency violations found (576 modules, 1747 dependencies cruised)
✔ no dependency violations found (184 modules, 312 dependencies cruised)
```

E2E は画面の導線・認証・フォーム・ルーティングに影響しない変更のため未実行。

## スコープアウトして起票した Issue

なし。

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)