### PR TITLE
feat(admin): 調研費の支給の登録画面を追加

### DIFF
--- a/admin/e2e/tests/grants.spec.ts
+++ b/admin/e2e/tests/grants.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+
+test("支給をテンプレートから1クリックで確認済登録し、二重生成を拒み、仕訳一覧に並べる", async ({ page }) => {
+  const year = new Date().getFullYear();
+  const currentMonth = new Date().getMonth() + 1;
+  const name = `e2e-grant-${Date.now()}`;
+  await page.goto("/politicians/new");
+  await page.getByLabel("氏名").fill(name);
+  await page.getByLabel("スラッグ").fill(name);
+  await page.getByLabel("当選日").fill(`${year}-01-01`);
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page).toHaveURL("/politicians");
+  const politicianCard = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name, exact: true }) });
+  await politicianCard.getByRole("link", { name: "年度帳簿" }).click();
+  await page.getByLabel(/^年度/).fill(String(year));
+  await page.getByRole("button", { name: "帳簿を作成" }).click();
+  await expect(page.getByRole("heading", { name: `${year}年度` })).toBeVisible();
+  await page.getByRole("button", { name: "現在の対象を切り替え" }).click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "load" }),
+    page.getByRole("button", { name: `${name}／${year}年度` }).click(),
+  ]);
+
+  await page.getByRole("link", { name: "支給の登録" }).click();
+  await expect(page.getByRole("heading", { name: "支給の登録" })).toBeVisible();
+  await expect(page.getByText("借方 普通預金 ／ 貸方 調査研究費収入")).toBeVisible();
+  await expect(page.getByText("下書きを経ずに「確認済」で作成されます")).toBeVisible();
+
+  const january = page.getByRole("listitem").filter({ hasText: "1月" }).first();
+  await expect(january).toContainText("¥1,000,000");
+  await january.getByRole("button", { name: "この月を登録" }).click();
+  await expect(january).toContainText("登録済み");
+  // 同月の二重生成は拒否される（登録済みの月にボタンは出ない）
+  await expect(january.getByRole("button", { name: "この月を登録" })).toHaveCount(0);
+  await page.reload();
+  await expect(page.getByRole("listitem").filter({ hasText: "1月" }).first()).toContainText("登録済み");
+  if (currentMonth < 12) {
+    await expect(page.getByRole("listitem").filter({ hasText: "12月" }).first()).toContainText("未到来");
+  }
+
+  await page.getByRole("link", { name: "仕訳の確認・編集" }).click();
+  const grantRow = page.getByRole("row").filter({ hasText: "調査研究費 1月分" });
+  await expect(grantRow).toContainText("確認済");
+  await expect(grantRow).toContainText("支給");
+  await expect(grantRow).toContainText("1,000,000");
+
+  await page.goto("/politicians");
+  await politicianCard.getByRole("button", { name: "削除", exact: true }).click();
+  await page.getByRole("button", { name: "削除する", exact: true }).click();
+  await expect(politicianCard).toHaveCount(0);
+});

--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/grants/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/grants/page.tsx
@@ -1,0 +1,12 @@
+import { GrantRegistration } from "@/client/components/research-fund/GrantRegistration";
+import { loadGrants } from "@/server/contexts/research-fund/presentation/loaders/load-grants";
+
+export default async function GrantsPage({
+  params,
+}: {
+  params: Promise<{ id: string; bookId: string }>;
+}) {
+  const { id, bookId } = await params;
+  const data = await loadGrants(id, bookId);
+  return <GrantRegistration key={bookId} {...data} />;
+}

--- a/admin/src/client/components/research-fund/GrantRegistration.tsx
+++ b/admin/src/client/components/research-fund/GrantRegistration.tsx
@@ -1,0 +1,122 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle } from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import { Card, CardContent, Button } from "@/client/components/ui";
+import type { ScheduledGrant } from "@/server/contexts/research-fund/domain/models/grant-schedule";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+import { registerGrant } from "@/server/contexts/research-fund/presentation/actions/register-grant";
+
+function noteOf(grant: ScheduledGrant, termStart: string) {
+  const termMonth = grant.month === termStart.slice(0, 7);
+  if (termMonth)
+    return `${termStart.replaceAll("-", ".")} 当選・初月分${grant.amount < 1_000_000 ? "（日割）" : ""}`;
+  const day = `支給日 ${Number(grant.month.slice(5, 7))}/1`;
+  return grant.status === "available" ? `${day}・振込を確認したら登録` : day;
+}
+
+export function GrantRegistration({
+  grants,
+  termStart,
+  target,
+}: {
+  grants: readonly ScheduledGrant[];
+  termStart: string;
+  financialYear: number;
+  target: Extract<AdminTarget, { kind: "research-fund" }>;
+}) {
+  const router = useRouter();
+  const [pendingMonth, setPendingMonth] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function register(month: string) {
+    setPendingMonth(month);
+    startTransition(async () => {
+      try {
+        const result = await registerGrant(target.politicianId, target.bookId, month);
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success(`${Number(month.slice(5, 7))}月分の支給を確認済で登録しました`);
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      } finally {
+        setPendingMonth(null);
+      }
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        label="Grants"
+        title="支給の登録"
+        description={`${target.name}・${target.year}年 — 毎月固定日に振り込まれる100万円を、1クリックで収入仕訳にします。`}
+      />
+      <Card className="mb-4 max-w-3xl">
+        <CardContent className="flex flex-wrap items-center gap-x-8 gap-y-4 p-6">
+          <div>
+            <div className="text-xs text-muted-foreground">支給日テンプレート</div>
+            <div className="text-sm font-bold">毎月 1日</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">金額</div>
+            <div className="font-latin text-sm font-bold">¥1,000,000</div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">仕訳の型</div>
+            <div className="text-[13px]">借方 普通預金 ／ 貸方 調査研究費収入</div>
+          </div>
+        </CardContent>
+      </Card>
+      <Card className="max-w-3xl">
+        <CardContent className="p-6">
+          <ul>
+            {grants.map((grant) => (
+              <li
+                key={grant.month}
+                className="flex items-center gap-4 border-b border-border-soft py-3 last:border-b-0"
+              >
+                <span className="font-latin w-14 text-sm font-bold">
+                  {Number(grant.month.slice(5, 7))}月
+                </span>
+                <span className="font-latin w-28 text-[13px]">
+                  ¥{grant.amount.toLocaleString("ja-JP")}
+                </span>
+                <span className="flex-1 text-xs text-muted-foreground">
+                  {noteOf(grant, termStart)}
+                </span>
+                {grant.status === "registered" && (
+                  <span className="inline-flex items-center gap-1.5 text-xs font-bold text-primary-hover">
+                    <CheckCircle size={15} weight="fill" />
+                    登録済み
+                  </span>
+                )}
+                {grant.status === "available" && (
+                  <Button size="xs" disabled={pending} onClick={() => register(grant.month)}>
+                    {pending && pendingMonth === grant.month ? "登録中…" : "この月を登録"}
+                  </Button>
+                )}
+                {grant.status === "upcoming" && (
+                  <span className="text-xs text-disabled-foreground">未到来</span>
+                )}
+              </li>
+            ))}
+          </ul>
+          {grants.length === 0 && (
+            <p className="p-4 text-center text-sm text-muted-foreground">
+              この年度に支給のある月はありません
+            </p>
+          )}
+          <p className="mt-3 text-xs text-muted-foreground">
+            登録した支給は下書きを経ずに「確認済」で作成されます（振込は機械的なため）。公開は公開画面から。
+          </p>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/admin/src/client/components/research-fund/JournalReview.tsx
+++ b/admin/src/client/components/research-fund/JournalReview.tsx
@@ -55,8 +55,10 @@ export function JournalReview({
   const [pending, startTransition] = useTransition();
   const monthly = entries.filter((e) => !month || e.entryDate.slice(5, 7) === month);
   const visible = monthly.filter((e) => status === "all" || e.status === status);
-  const selected = visible.find((e) => e.id === selectedId) ?? visible[0] ?? null;
-  const index = visible.findIndex((e) => e.id === selected?.id);
+  // 支給は支給の登録画面で扱うため、一覧には並べるが選択・編集の対象から外す。
+  const selectable = visible.filter((e) => e.source !== "grant");
+  const selected = selectable.find((e) => e.id === selectedId) ?? selectable[0] ?? null;
+  const index = selectable.findIndex((e) => e.id === selected?.id);
   function allowLeave() {
     return (
       !document.querySelector('[data-journal-dirty="true"]') ||
@@ -87,7 +89,7 @@ export function JournalReview({
         )
       )
         return;
-      const next = visible[index + (event.key === "ArrowDown" ? 1 : -1)];
+      const next = selectable[index + (event.key === "ArrowDown" ? 1 : -1)];
       if (next) {
         event.preventDefault();
         select(next.id);
@@ -233,20 +235,21 @@ export function JournalReview({
                           e.splitGroup === entry.splitGroup && e.documentId === entry.documentId,
                       )
                     : [];
+                  const grant = entry.source === "grant";
                   return (
                     <TableRow
                       key={entry.id}
-                      tabIndex={0}
+                      tabIndex={grant ? undefined : 0}
                       aria-selected={entry.id === selected?.id}
-                      onClick={() => select(entry.id)}
+                      onClick={grant ? undefined : () => select(entry.id)}
                       onKeyDown={(event) => {
-                        if (event.key === "Enter" || event.key === " ") {
+                        if (!grant && (event.key === "Enter" || event.key === " ")) {
                           event.preventDefault();
                           select(entry.id);
                         }
                       }}
                       className={cn(
-                        "cursor-pointer",
+                        !grant && "cursor-pointer",
                         entry.id === selected?.id && "bg-accent",
                         entry.accountKey === "needs-review" && "border-l-4 border-l-destructive",
                       )}
@@ -255,7 +258,13 @@ export function JournalReview({
                         {entry.entryDate.replaceAll("-", ".")}
                       </TableCell>
                       <TableCell>
-                        <ResearchFundCategoryPill accountKey={entry.accountKey} />
+                        {grant ? (
+                          <span className="inline-block whitespace-nowrap rounded-full border bg-accent px-3 py-0.5 text-xs font-medium text-accent-foreground">
+                            支給
+                          </span>
+                        ) : (
+                          <ResearchFundCategoryPill accountKey={entry.accountKey} />
+                        )}
                       </TableCell>
                       <TableCell>
                         <span>{entry.description}</span>
@@ -309,14 +318,14 @@ export function JournalReview({
                     <Button
                       variant="outline"
                       disabled={pending || index <= 0}
-                      onClick={() => select(visible[index - 1].id)}
+                      onClick={() => select(selectable[index - 1].id)}
                     >
                       前へ
                     </Button>
                     <Button
                       variant="outline"
-                      disabled={pending || index >= visible.length - 1}
-                      onClick={() => select(visible[index + 1].id)}
+                      disabled={pending || index >= selectable.length - 1}
+                      onClick={() => select(selectable[index + 1].id)}
                     >
                       次へ
                     </Button>

--- a/admin/src/server/contexts/research-fund/application/usecases/manage-grants-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/manage-grants-usecase.ts
@@ -1,0 +1,80 @@
+import "server-only";
+import {
+  GrantRegistrationError,
+  grantDescription,
+  grantEntryDate,
+  isGrantMonth,
+  japanCalendarDate,
+} from "@/server/contexts/research-fund/domain/models/grant-registration";
+import { GrantSchedule } from "@/server/contexts/research-fund/domain/models/grant-schedule";
+import { JournalEntryHash } from "@/server/contexts/research-fund/domain/models/journal-entry-hash";
+import { JournalPosting } from "@/server/contexts/research-fund/domain/models/journal-posting";
+import type { GrantRepository } from "@/server/contexts/research-fund/domain/repositories/grant-repository.interface";
+
+export class ManageGrantsUsecase {
+  constructor(private repository: GrantRepository) {}
+
+  async list(bookId: string, referenceDate: string = japanCalendarDate()) {
+    const book = await this.repository.book(bookId);
+    if (!book) throw new GrantRegistrationError("帳簿が見つかりません");
+    const schedule = GrantSchedule.generate({
+      termStart: book.termStart,
+      financialYear: book.financialYear,
+      referenceDate,
+      registeredMonths: await this.repository.registeredMonths(bookId),
+    });
+    if (schedule.status === "invalid") throw new GrantRegistrationError(schedule.errors[0].message);
+    return { grants: schedule.value, termStart: book.termStart, financialYear: book.financialYear };
+  }
+
+  /** 下書きを経ず確認済で支給の収入仕訳を作る。振込は機械的なため目視確認を挟まない。 */
+  async register(
+    bookId: string,
+    month: string,
+    userId: string,
+    referenceDate: string = japanCalendarDate(),
+  ) {
+    if (!isGrantMonth(month)) throw new GrantRegistrationError("月はYYYY-MM形式で指定してください");
+    const { grants, termStart } = await this.list(bookId, referenceDate);
+    const grant = grants.find((candidate) => candidate.month === month);
+    if (!grant) throw new GrantRegistrationError("この年度に支給のない月です");
+    if (grant.status === "registered")
+      throw new GrantRegistrationError("この月の支給はすでに登録されています");
+    if (grant.status === "upcoming") throw new GrantRegistrationError("支給日が到来していません");
+
+    const accounts = await this.repository.accounts();
+    const account = accounts.find((candidate) => candidate.key === "grant-income");
+    const assetAccount = accounts.find((candidate) => candidate.key === "bank");
+    if (!account || !assetAccount) throw new GrantRegistrationError("科目が見つかりません");
+    const posting = JournalPosting.generate({
+      pattern: "grant",
+      source: "grant",
+      amount: grant.amount,
+      account,
+      assetAccount,
+    });
+    if (posting.status === "invalid") throw new GrantRegistrationError(posting.errors[0].message);
+
+    const entryDate = grantEntryDate(month, termStart);
+    const description = grantDescription(month);
+    const hash = JournalEntryHash.generate({
+      entryDate,
+      amount: grant.amount,
+      description,
+      documentId: null,
+    });
+    if (hash.status === "invalid") throw new GrantRegistrationError(hash.errors[0].message);
+    return this.repository.create(
+      bookId,
+      month,
+      {
+        entryDate,
+        description,
+        amount: grant.amount,
+        hash: hash.value,
+        lines: posting.value.lines,
+      },
+      userId,
+    );
+  }
+}

--- a/admin/src/server/contexts/research-fund/domain/models/grant-registration.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/grant-registration.ts
@@ -1,0 +1,38 @@
+import type { JournalLine } from "@/server/contexts/research-fund/domain/models/journal-posting";
+
+export class GrantRegistrationError extends Error {}
+
+/** 支給1件分の登録内容。複式行は JournalPosting、重複検知の hash は JournalEntryHash が組み立てる。 */
+export interface GrantWrite {
+  /** 暦日を YYYY-MM-DD で指定する。タイムゾーンによる日付のずれを避ける。 */
+  entryDate: string;
+  description: string;
+  amount: number;
+  hash: string;
+  lines: readonly JournalLine[];
+}
+
+/** 年月を YYYY-MM で表す。GrantSchedule の month と同じ表記。 */
+export function isGrantMonth(value: string): boolean {
+  return /^\d{4}-(0[1-9]|1[0-2])$/.test(value);
+}
+
+/**
+ * 支給日の判定は日本時間の暦日で行う。
+ * UTC のままだと日本時間の 0〜9 時に前日扱いとなり、支給日当日に登録できなくなる。
+ */
+export function japanCalendarDate(now: Date = new Date()): string {
+  return new Date(now.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+/**
+ * 支給の仕訳日。テンプレートは毎月1日だが、当選月だけは当選日を使う。
+ * 当選日より前の日付で在職前の収入を計上しないため。
+ */
+export function grantEntryDate(month: string, termStart: string): string {
+  return month === termStart.slice(0, 7) ? termStart : `${month}-01`;
+}
+
+export function grantDescription(month: string): string {
+  return `調査研究費 ${Number(month.slice(5, 7))}月分`;
+}

--- a/admin/src/server/contexts/research-fund/domain/models/grant-schedule.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/grant-schedule.ts
@@ -14,7 +14,7 @@ export interface GrantSchedule {
   registeredMonths: readonly string[];
 }
 
-interface ScheduledGrant {
+export interface ScheduledGrant {
   month: string;
   amount: number;
   status: "registered" | "available" | "upcoming";

--- a/admin/src/server/contexts/research-fund/domain/repositories/grant-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/grant-repository.interface.ts
@@ -1,0 +1,17 @@
+import type { GrantWrite } from "@/server/contexts/research-fund/domain/models/grant-registration";
+import type { ResearchFundAccount } from "@/server/contexts/research-fund/domain/models/journal-posting";
+
+export interface GrantBook {
+  financialYear: number;
+  /** 支給の起点となる当選日（YYYY-MM-DD） */
+  termStart: string;
+}
+
+export interface GrantRepository {
+  book(bookId: string): Promise<GrantBook | null>;
+  /** 支給として登録済みの年月（YYYY-MM）。重複は呼び出し側で吸収する。 */
+  registeredMonths(bookId: string): Promise<string[]>;
+  accounts(): Promise<ResearchFundAccount[]>;
+  /** 同月の支給が既にあれば作成せず GrantRegistrationError を投げる。 */
+  create(bookId: string, month: string, input: GrantWrite, userId: string): Promise<string>;
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.ts
@@ -1,0 +1,67 @@
+import "server-only";
+import type { PrismaClient } from "@prisma/client";
+import {
+  GrantRegistrationError,
+  type GrantWrite,
+} from "@/server/contexts/research-fund/domain/models/grant-registration";
+import type { GrantRepository } from "@/server/contexts/research-fund/domain/repositories/grant-repository.interface";
+
+function monthRange(month: string) {
+  const start = new Date(`${month}-01T00:00:00.000Z`);
+  const end = new Date(start);
+  end.setUTCMonth(end.getUTCMonth() + 1);
+  return { gte: start, lt: end };
+}
+
+export class PrismaGrantRepository implements GrantRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async book(bookId: string) {
+    const row = await this.prisma.researchFundBook.findUnique({
+      where: { id: BigInt(bookId) },
+      select: { financialYear: true, politician: { select: { termStart: true } } },
+    });
+    return row
+      ? {
+          financialYear: row.financialYear,
+          termStart: row.politician.termStart.toISOString().slice(0, 10),
+        }
+      : null;
+  }
+
+  async registeredMonths(bookId: string) {
+    const rows = await this.prisma.researchFundJournalEntry.findMany({
+      where: { bookId: BigInt(bookId), source: "grant" },
+      select: { entryDate: true },
+    });
+    return rows.map((row) => row.entryDate.toISOString().slice(0, 7));
+  }
+
+  async accounts() {
+    return this.prisma.researchFundAccount.findMany({ orderBy: { displayOrder: "asc" } });
+  }
+
+  async create(bookId: string, month: string, input: GrantWrite, userId: string) {
+    return this.prisma.$transaction(async (tx) => {
+      // 同月の二重生成を拒否する。月初から翌月初の半開区間で判定する。
+      const duplicates = await tx.researchFundJournalEntry.count({
+        where: { bookId: BigInt(bookId), source: "grant", entryDate: monthRange(month) },
+      });
+      if (duplicates > 0) throw new GrantRegistrationError("この月の支給はすでに登録されています");
+      const row = await tx.researchFundJournalEntry.create({
+        data: {
+          bookId: BigInt(bookId),
+          entryDate: new Date(`${input.entryDate}T00:00:00.000Z`),
+          description: input.description,
+          // 振込は機械的なため下書きを経ずに確認済で作る。
+          status: "approved",
+          source: "grant",
+          hash: input.hash,
+          createdById: userId,
+          lines: { create: input.lines.map((line) => ({ ...line })) },
+        },
+      });
+      return String(row.id);
+    });
+  }
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.ts
@@ -24,13 +24,31 @@ const expenseWhere = {
   source: { in: ["manual", "scan"] },
   lines: { some: { side: "debit", account: { type: "expense" } } },
 } satisfies Prisma.ResearchFundJournalEntryWhereInput;
+// 支給は支給の登録画面で作るが、確認済の収入として一覧にも並べる（編集はさせない）。
+const grantWhere = {
+  source: "grant",
+  lines: { some: { side: "credit", accountKey: "grant-income" } },
+} satisfies Prisma.ResearchFundJournalEntryWhereInput;
+const listWhere = {
+  OR: [expenseWhere, grantWhere],
+} satisfies Prisma.ResearchFundJournalEntryWhereInput;
 function model(row: Row): ReviewEntry | null {
-  const expense = row.lines.find((l) => l.side === "debit" && l.account.type === "expense");
-  const bank = row.lines.find(
-    (l) => l.side === "credit" && l.accountKey === "bank" && l.account.type === "asset",
-  );
-  // このフォームが損失なく再生成できる「費用1行／普通預金1行」だけを扱う。
-  if (row.lines.length !== 2 || !expense || !bank || !expense.amount.equals(bank.amount))
+  const grant = row.source === "grant";
+  const amountLine = grant
+    ? row.lines.find((l) => l.side === "credit" && l.accountKey === "grant-income")
+    : row.lines.find((l) => l.side === "debit" && l.account.type === "expense");
+  const assetLine = grant
+    ? row.lines.find((l) => l.side === "debit" && l.accountKey === "bank")
+    : row.lines.find(
+        (l) => l.side === "credit" && l.accountKey === "bank" && l.account.type === "asset",
+      );
+  // このフォームが損失なく再生成できる「費用1行／普通預金1行」（支給は貸借が逆）だけを扱う。
+  if (
+    row.lines.length !== 2 ||
+    !amountLine ||
+    !assetLine ||
+    !amountLine.amount.equals(assetLine.amount)
+  )
     return null;
   // 書類の再スキャンで過去の仕訳に別のモデル・版を表示しない。
   const job = row.document?.scanJobs.find((j) => j.createdAt <= row.createdAt);
@@ -38,8 +56,8 @@ function model(row: Row): ReviewEntry | null {
     id: String(row.id),
     entryDate: row.entryDate.toISOString().slice(0, 10),
     description: row.description,
-    amount: expense.amount.toNumber(),
-    accountKey: expense.accountKey,
+    amount: amountLine.amount.toNumber(),
+    accountKey: amountLine.accountKey,
     note: row.note ?? "",
     memo: row.memo ?? "",
     status: row.status,
@@ -75,7 +93,7 @@ export class PrismaJournalReviewRepository implements JournalReviewRepository {
   async list(bookId: string) {
     return (
       await this.prisma.researchFundJournalEntry.findMany({
-        where: { bookId: BigInt(bookId), ...expenseWhere },
+        where: { bookId: BigInt(bookId), ...listWhere },
         include,
         orderBy: [{ entryDate: "desc" }, { id: "asc" }],
       })

--- a/admin/src/server/contexts/research-fund/presentation/actions/register-grant.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/register-grant.ts
@@ -1,0 +1,29 @@
+"use server";
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { ManageGrantsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-grants-usecase";
+import { GrantRegistrationError } from "@/server/contexts/research-fund/domain/models/grant-registration";
+import { PrismaGrantRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export async function registerGrant(politicianId: string, bookId: string, month: string) {
+  const user = await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    await new ManageGrantsUsecase(new PrismaGrantRepository(prisma)).register(
+      bookId,
+      month,
+      user.id,
+    );
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: error instanceof GrantRegistrationError ? error.message : "支給の登録に失敗しました",
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-grants.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-grants.ts
@@ -1,0 +1,13 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { ManageGrantsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-grants-usecase";
+import { PrismaGrantRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export async function loadGrants(politicianId: string, bookId: string) {
+  const target = await requireJournalTarget(politicianId, bookId);
+  if (!target) notFound();
+  const data = await new ManageGrantsUsecase(new PrismaGrantRepository(prisma)).list(bookId);
+  return { ...data, target };
+}

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-grants-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-grants-usecase.test.ts
@@ -1,0 +1,84 @@
+import { ManageGrantsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-grants-usecase";
+
+const accounts = [
+  { key: "grant-income", type: "income" as const },
+  { key: "bank", type: "asset" as const },
+];
+function setup(overrides: { termStart?: string; registeredMonths?: string[] } = {}) {
+  const repository = {
+    book: jest.fn().mockResolvedValue({
+      financialYear: 2026,
+      termStart: overrides.termStart ?? "2026-02-08",
+    }),
+    registeredMonths: jest.fn().mockResolvedValue(overrides.registeredMonths ?? []),
+    accounts: jest.fn().mockResolvedValue(accounts),
+    create: jest.fn().mockResolvedValue("10"),
+  };
+  return { repository, usecase: new ManageGrantsUsecase(repository) };
+}
+
+test("当選月以降だけを並べ、当選月は日割・当月まで登録可能にする", async () => {
+  const { usecase } = setup({ registeredMonths: ["2026-02"] });
+  const { grants, termStart } = await usecase.list("1", "2026-09-10");
+  expect(termStart).toBe("2026-02-08");
+  expect(grants[0]).toEqual({ month: "2026-02", amount: 750_000, status: "registered" });
+  expect(grants.map((grant) => grant.status)).toEqual([
+    "registered", "available", "available", "available", "available", "available",
+    "available", "available", "upcoming", "upcoming", "upcoming",
+  ]);
+});
+
+test("支給は下書きを経ず確認済で、借方 普通預金／貸方 調査研究費収入の複式行を作る", async () => {
+  const { repository, usecase } = setup();
+  await expect(usecase.register("1", "2026-05", "user", "2026-09-10")).resolves.toBe("10");
+  expect(repository.create).toHaveBeenCalledWith(
+    "1",
+    "2026-05",
+    {
+      entryDate: "2026-05-01",
+      description: "調査研究費 5月分",
+      amount: 1_000_000,
+      hash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      lines: [
+        { side: "debit", accountKey: "bank", amount: 1_000_000 },
+        { side: "credit", accountKey: "grant-income", amount: 1_000_000 },
+      ],
+    },
+    "user",
+  );
+});
+
+test("当選月は当選日を仕訳日にし、日割の金額で作る", async () => {
+  const { repository, usecase } = setup();
+  await usecase.register("1", "2026-02", "user", "2026-09-10");
+  expect(repository.create.mock.calls[0][2]).toMatchObject({
+    entryDate: "2026-02-08",
+    amount: 750_000,
+  });
+});
+
+test("同月の二重生成・未到来・年度外・不正な月は拒否する", async () => {
+  const registered = setup({ registeredMonths: ["2026-05"] });
+  await expect(registered.usecase.register("1", "2026-05", "user", "2026-09-10")).rejects.toThrow(
+    "すでに登録",
+  );
+  const { repository, usecase } = setup();
+  await expect(usecase.register("1", "2026-10", "user", "2026-09-10")).rejects.toThrow("到来");
+  await expect(usecase.register("1", "2026-01", "user", "2026-09-10")).rejects.toThrow("支給のない月");
+  await expect(usecase.register("1", "2027-05", "user", "2026-09-10")).rejects.toThrow("支給のない月");
+  await expect(usecase.register("1", "2026-13", "user", "2026-09-10")).rejects.toThrow("YYYY-MM");
+  expect(repository.create).not.toHaveBeenCalled();
+  expect(registered.repository.create).not.toHaveBeenCalled();
+});
+
+test("帳簿・科目が見つからない場合は作成しない", async () => {
+  const missingBook = setup();
+  missingBook.repository.book.mockResolvedValue(null);
+  await expect(missingBook.usecase.list("1", "2026-09-10")).rejects.toThrow("帳簿が見つかりません");
+  const missingAccount = setup();
+  missingAccount.repository.accounts.mockResolvedValue([{ key: "bank", type: "asset" }]);
+  await expect(
+    missingAccount.usecase.register("1", "2026-05", "user", "2026-09-10"),
+  ).rejects.toThrow("科目が見つかりません");
+  expect(missingAccount.repository.create).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/domain/models/grant-registration.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/grant-registration.test.ts
@@ -1,0 +1,33 @@
+import {
+  grantDescription,
+  grantEntryDate,
+  isGrantMonth,
+  japanCalendarDate,
+} from "@/server/contexts/research-fund/domain/models/grant-registration";
+
+test.each(["2026-01", "2026-12"])("年月 %s を受け付ける", (month) => {
+  expect(isGrantMonth(month)).toBe(true);
+});
+test.each(["2026-00", "2026-13", "2026-1", "2026-01-01", "", "abcd-01"])(
+  "不正な年月 %s を拒否する",
+  (month) => {
+    expect(isGrantMonth(month)).toBe(false);
+  },
+);
+
+test("日本時間の暦日で支給日を判定する（UTCの前日扱いを避ける）", () => {
+  expect(japanCalendarDate(new Date("2026-09-01T00:30:00.000Z"))).toBe("2026-09-01");
+  expect(japanCalendarDate(new Date("2026-08-31T15:00:00.000Z"))).toBe("2026-09-01");
+  expect(japanCalendarDate(new Date("2026-08-31T14:59:59.000Z"))).toBe("2026-08-31");
+});
+
+test("当選月は当選日、以降は毎月1日を仕訳日にする", () => {
+  expect(grantEntryDate("2026-02", "2026-02-08")).toBe("2026-02-08");
+  expect(grantEntryDate("2026-03", "2026-02-08")).toBe("2026-03-01");
+  expect(grantEntryDate("2027-02", "2026-02-08")).toBe("2027-02-01");
+});
+
+test("項目名は公開用に月を示す", () => {
+  expect(grantDescription("2026-05")).toBe("調査研究費 5月分");
+  expect(grantDescription("2026-12")).toBe("調査研究費 12月分");
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.test.ts
@@ -1,0 +1,100 @@
+import type { PrismaClient } from "@prisma/client";
+import { PrismaGrantRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository";
+import type { GrantWrite } from "@/server/contexts/research-fund/domain/models/grant-registration";
+
+const input: GrantWrite = {
+  entryDate: "2026-05-01",
+  description: "調査研究費 5月分",
+  amount: 1_000_000,
+  hash: "hash",
+  lines: [
+    { side: "debit", accountKey: "bank", amount: 1_000_000 },
+    { side: "credit", accountKey: "grant-income", amount: 1_000_000 },
+  ],
+};
+function setup(duplicates = 0) {
+  const tx = {
+    researchFundJournalEntry: {
+      count: jest.fn().mockResolvedValue(duplicates),
+      create: jest.fn().mockResolvedValue({ id: BigInt("9007199254740993") }),
+      findMany: jest.fn().mockResolvedValue([
+        { entryDate: new Date("2026-02-08T00:00:00.000Z") },
+        { entryDate: new Date("2026-03-01T00:00:00.000Z") },
+      ]),
+    },
+    researchFundBook: {
+      findUnique: jest.fn().mockResolvedValue({
+        financialYear: 2026,
+        politician: { termStart: new Date("2026-02-08T00:00:00.000Z") },
+      }),
+    },
+    researchFundAccount: { findMany: jest.fn().mockResolvedValue([]) },
+  };
+  const repository = new PrismaGrantRepository({
+    ...tx,
+    $transaction: jest.fn(async (fn: (client: unknown) => unknown) => fn(tx)),
+  } as unknown as PrismaClient);
+  return { repository, tx };
+}
+
+test("帳簿から年度と議員の当選日を暦日で取り出す", async () => {
+  const { repository, tx } = setup();
+  await expect(repository.book("1")).resolves.toEqual({
+    financialYear: 2026,
+    termStart: "2026-02-08",
+  });
+  expect(tx.researchFundBook.findUnique).toHaveBeenCalledWith(
+    expect.objectContaining({ where: { id: BigInt(1) } }),
+  );
+  tx.researchFundBook.findUnique.mockResolvedValue(null);
+  await expect(repository.book("1")).resolves.toBeNull();
+});
+
+test("登録済みの支給を年月で返す", async () => {
+  const { repository, tx } = setup();
+  await expect(repository.registeredMonths("1")).resolves.toEqual(["2026-02", "2026-03"]);
+  expect(tx.researchFundJournalEntry.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({ where: { bookId: BigInt(1), source: "grant" } }),
+  );
+});
+
+test("同月の支給が無ければ確認済の支給仕訳を複式行つきで作る", async () => {
+  const { repository, tx } = setup();
+  await expect(repository.create("1", "2026-05", input, "user")).resolves.toBe("9007199254740993");
+  expect(tx.researchFundJournalEntry.count).toHaveBeenCalledWith({
+    where: {
+      bookId: BigInt(1),
+      source: "grant",
+      entryDate: {
+        gte: new Date("2026-05-01T00:00:00.000Z"),
+        lt: new Date("2026-06-01T00:00:00.000Z"),
+      },
+    },
+  });
+  expect(tx.researchFundJournalEntry.create).toHaveBeenCalledWith({
+    data: expect.objectContaining({
+      bookId: BigInt(1),
+      entryDate: new Date("2026-05-01T00:00:00.000Z"),
+      status: "approved",
+      source: "grant",
+      hash: "hash",
+      createdById: "user",
+      lines: { create: input.lines },
+    }),
+  });
+});
+
+test("同一トランザクション内で同月の二重生成を拒否する", async () => {
+  const { repository, tx } = setup(1);
+  await expect(repository.create("1", "2026-05", input, "user")).rejects.toThrow("すでに登録");
+  expect(tx.researchFundJournalEntry.create).not.toHaveBeenCalled();
+});
+
+test("12月の支給は翌年1月との境界で判定する", async () => {
+  const { repository, tx } = setup();
+  await repository.create("1", "2026-12", { ...input, entryDate: "2026-12-01" }, "user");
+  expect(tx.researchFundJournalEntry.count.mock.calls[0][0].where.entryDate).toEqual({
+    gte: new Date("2026-12-01T00:00:00.000Z"),
+    lt: new Date("2027-01-01T00:00:00.000Z"),
+  });
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
@@ -35,11 +35,17 @@ test("手動作成の source と帳簿、作成者、行を保存する", async 
   const { repository, tx } = setup(); await expect(repository.create("1", input, "user")).resolves.toBe(entry.id);
   expect(tx.researchFundJournalEntry.create).toHaveBeenCalledWith({ data: expect.objectContaining({ bookId: BigInt(1), createdById: "user", source: "manual", lines: { create: input.lines } }) });
 });
-test("一覧は帳簿内の支出に限定し、BigInt/Decimal/Dateとスキャン情報を変換", async () => {
+test("一覧は帳簿内の支出と支給に限定し、BigInt/Decimal/Dateとスキャン情報を変換", async () => {
   const { repository, tx } = setup();
   tx.researchFundJournalEntry.findMany.mockResolvedValue([{ id: BigInt(entry.id), entryDate: new Date(input.entryDate), createdAt: new Date("2026-08-02"), updatedAt: new Date(entry.updatedAt), description: "移動", note: "公開", memo: "非公開", source: "scan", status: "draft", splitGroup: "split", documentId: BigInt(3), lines: [{ side: "debit", accountKey: "taxi", account: { type: "expense" }, amount: new Prisma.Decimal(1200) }, { side: "credit", accountKey: "bank", account: { type: "asset" }, amount: new Prisma.Decimal(1200) }], document: { scanJobs: [{ createdAt: new Date("2026-08-03"), model: "later", prompt: { version: 2 } }, { createdAt: new Date("2026-08-01"), model: "original", prompt: { version: 1 } }] } }]);
   const rows = await repository.list("1"); expect(rows[0]).toMatchObject({ id: entry.id, amount: 1200, documentId: "3", memo: "非公開", model: "original", promptVersion: 1 });
-  expect(tx.researchFundJournalEntry.findMany.mock.calls[0][0].where).toMatchObject({ bookId: BigInt(1), lines: { some: { side: "debit", account: { type: "expense" } } } });
+  expect(tx.researchFundJournalEntry.findMany.mock.calls[0][0].where).toMatchObject({ bookId: BigInt(1), OR: [{ source: { in: ["manual", "scan"] }, lines: { some: { side: "debit", account: { type: "expense" } } } }, { source: "grant", lines: { some: { side: "credit", accountKey: "grant-income" } } }] });
+});
+
+test("支給は貸方の調査研究費収入から金額を取り、確認済として一覧に並ぶ", async () => {
+  const { repository, tx } = setup();
+  tx.researchFundJournalEntry.findMany.mockResolvedValue([{ id: BigInt(entry.id), entryDate: new Date("2026-05-01"), createdAt: new Date("2026-05-01"), updatedAt: new Date(entry.updatedAt), description: "調査研究費 5月分", note: null, memo: null, source: "grant", status: "approved", splitGroup: null, documentId: null, document: null, lines: [{ side: "debit", accountKey: "bank", account: { type: "asset" }, amount: new Prisma.Decimal(1000000) }, { side: "credit", accountKey: "grant-income", account: { type: "income" }, amount: new Prisma.Decimal(1000000) }] }]);
+  await expect(repository.list("1")).resolves.toEqual([expect.objectContaining({ id: entry.id, entryDate: "2026-05-01", description: "調査研究費 5月分", amount: 1000000, accountKey: "grant-income", source: "grant", status: "approved", documentId: null })]);
 });
 
 test("手動仕訳を取得し、書類・メモの欠損値を表示用に変換する", async () => {

--- a/admin/tests/server/contexts/research-fund/presentation/actions/register-grant.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/actions/register-grant.test.ts
@@ -1,0 +1,48 @@
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { ManageGrantsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-grants-usecase";
+import { GrantRegistrationError } from "@/server/contexts/research-fund/domain/models/grant-registration";
+import { registerGrant } from "@/server/contexts/research-fund/presentation/actions/register-grant";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/server/contexts/auth/presentation/loaders/require-auth", () => ({ requireAuth: jest.fn() }));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({ requireJournalTarget: jest.fn() }));
+jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(requireAuth).mockResolvedValue({ id: "user" } as Awaited<ReturnType<typeof requireAuth>>);
+  jest.mocked(requireJournalTarget).mockResolvedValue({ kind: "research-fund", key: "book:1", name: "議員", year: 2026, politicianId: "2", bookId: "1", draftCount: 0 });
+});
+afterEach(() => jest.restoreAllMocks());
+
+test("現在の対象を検証し、作成者をサーバー側で設定し、レイアウトを再検証", async () => {
+  const register = jest.spyOn(ManageGrantsUsecase.prototype, "register").mockResolvedValue("3");
+  await expect(registerGrant("2", "1", "2026-05")).resolves.toEqual({ success: true });
+  expect(requireJournalTarget).toHaveBeenCalledWith("2", "1");
+  expect(register).toHaveBeenCalledWith("1", "2026-05", "user");
+  expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
+});
+
+test("別の対象への古いフォーム送信を拒否", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(null);
+  const register = jest.spyOn(ManageGrantsUsecase.prototype, "register");
+  await expect(registerGrant("2", "1", "2026-05")).resolves.toMatchObject({ success: false });
+  expect(register).not.toHaveBeenCalled();
+  expect(revalidatePath).not.toHaveBeenCalled();
+});
+
+test("認証失敗時は登録しない", async () => {
+  jest.mocked(requireAuth).mockRejectedValueOnce(new Error("auth"));
+  const register = jest.spyOn(ManageGrantsUsecase.prototype, "register");
+  await expect(registerGrant("2", "1", "2026-05")).rejects.toThrow("auth");
+  expect(register).not.toHaveBeenCalled();
+  expect(revalidatePath).not.toHaveBeenCalled();
+});
+
+test("利用者が解消できる業務エラーはメッセージを返し、内部エラーは漏らさない", async () => {
+  jest.spyOn(ManageGrantsUsecase.prototype, "register").mockRejectedValueOnce(new GrantRegistrationError("この月の支給はすでに登録されています"));
+  await expect(registerGrant("2", "1", "2026-05")).resolves.toEqual({ success: false, error: "この月の支給はすでに登録されています" });
+  jest.spyOn(ManageGrantsUsecase.prototype, "register").mockRejectedValueOnce(new Error("private database detail"));
+  await expect(registerGrant("2", "1", "2026-05")).resolves.toEqual({ success: false, error: "支給の登録に失敗しました" });
+  expect(revalidatePath).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/presentation/loaders/load-grants.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/loaders/load-grants.test.ts
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+import { ManageGrantsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-grants-usecase";
+import { loadGrants } from "@/server/contexts/research-fund/presentation/loaders/load-grants";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+jest.mock("next/navigation", () => ({ notFound: jest.fn(() => { throw new Error("NOT_FOUND"); }) }));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({ requireJournalTarget: jest.fn() }));
+jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+const target = { kind: "research-fund", key: "book:1", name: "議員", year: 2026, politicianId: "2", bookId: "1", draftCount: 0 } as const;
+beforeEach(() => jest.clearAllMocks());
+afterEach(() => jest.restoreAllMocks());
+
+test("対象が一致しなければ支給の予定を取得しない", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(null);
+  const list = jest.spyOn(ManageGrantsUsecase.prototype, "list");
+  await expect(loadGrants("2", "1")).rejects.toThrow("NOT_FOUND");
+  expect(notFound).toHaveBeenCalled();
+  expect(list).not.toHaveBeenCalled();
+});
+
+test("一致した帳簿の支給予定と現在の対象を返す", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(target);
+  const data = { grants: [], termStart: "2026-02-08", financialYear: 2026 };
+  const list = jest.spyOn(ManageGrantsUsecase.prototype, "list").mockResolvedValue(data);
+  await expect(loadGrants("2", "1")).resolves.toEqual({ ...data, target });
+  expect(list).toHaveBeenCalledWith("1");
+});


### PR DESCRIPTION
## 目的（Why）

議員室のスタッフが、毎月固定日に振り込まれる調査研究費 100万円を仕訳として登録する手段がなく、支給が帳簿に入らない状態を解消するため。支給が入らないと未使用（支給−支出）が計算できず、公開ページのサンキー左端が成り立たない。

## 変更内容

**支給の登録画面**（`/politicians/[id]/books/[bookId]/grants`、サイドバーの導線は既存）

- テンプレートカード: 支給日（毎月1日）・金額（¥1,000,000）・仕訳の型（借方 普通預金／貸方 調査研究費収入）
- 月次リスト: 登録済み（チェック）／登録可能（「この月を登録」primary）／未到来（グレー）
- 注記「登録した支給は下書きを経ずに『確認済』で作成されます」

**サーバー側**（research-fund コンテキスト）

- `ManageGrantsUsecase`: 既存の `GrantSchedule`（#1348）で当選月起点・月途中当選の日割を算出し、`JournalPosting.generate({ pattern: "grant" })` で複式行を生成して `status=approved` / `source=grant` で作成する
- 同月の二重生成は、usecase（登録済み月の判定）と repository（トランザクション内で同月件数を確認）の二段で拒否する
- 支給日は毎月1日だが、当選月だけは当選日を仕訳日にする（当選日より前に在職前の収入を計上しないため）
- 支給日の到来判定は日本時間の暦日で行う（UTC のままだと日本時間 0〜9 時に前日扱いになる）

**仕訳の確認・編集**

- 一覧のクエリに支給（`source=grant` / 貸方 調査研究費収入）を含め、「支給」ピル・確認済として表示する
- 支給は支給の登録画面で扱うため、一覧では選択・編集・↑↓移動の対象から外す（サーバー側は既に `ManageJournalReviewUsecase` が支給の編集を拒否済み）

Prisma schema の変更はありません（既存の `politicians.term_start` / `research_fund_journal_entries` をそのまま使用）。

## ローカル CI

- `pnpm verify` ✅（test 1359 passed / typecheck / lint / knip / depcruise すべて green）
- `pnpm test:e2e:admin` ✅ 36 passed（新規 `admin/e2e/tests/grants.spec.ts` を含む）
- `pnpm test:e2e:webapp` は `organization.spec.ts` が 1 件失敗しますが、**変更を stash した clean な main でも同じく失敗する**ローカル環境依存の既存不具合で、本 PR とは無関係です（webapp のコードには一切触れていません）

## スコープアウト

Issue の Out of scope（支給額テンプレートの編集 UI・年度末の返還仕訳・支給仕訳の取り消し）は実装していません。新規に起票した Issue はありません。

Closes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)