### PR TITLE
feat(admin): 読み取りプロンプト画面（版履歴・巻き戻し）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ data/reports/*
 !data/reports/donation-aggregation-sample.xml
 */.next/*
 .next
-prompts
+/prompts
 
 # dependencies
 /node_modules

--- a/admin/e2e/tests/prompts.spec.ts
+++ b/admin/e2e/tests/prompts.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+test("デフォルトから初版を保存し、編集して版を重ね、巻き戻す", async ({ page }) => {
+  const name = `e2e-prompt-${Date.now()}`;
+  await page.goto("/politicians/new");
+  await page.getByLabel("氏名").fill(name);
+  await page.getByLabel("スラッグ").fill(name);
+  await page.getByLabel("当選日").fill("2026-02-08");
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page).toHaveURL("/politicians");
+  const politicianCard = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name, exact: true }) });
+  await politicianCard.getByRole("link", { name: "年度帳簿" }).click();
+  await page.getByLabel(/^年度/).fill("2026");
+  await page.getByRole("button", { name: "帳簿を作成" }).click();
+  await expect(page.getByRole("heading", { name: "2026年度" })).toBeVisible();
+  await page.getByRole("button", { name: "現在の対象を切り替え" }).click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "load" }),
+    page.getByRole("button", { name: `${name}／2026年度` }).click(),
+  ]);
+  await page.getByRole("link", { name: "読み取りプロンプト" }).click();
+  await expect(page.getByRole("heading", { name: "読み取りプロンプト" })).toBeVisible();
+
+  // 版が無い議員はデフォルトテンプレートから始まり、自動生成部は参照だけできる
+  const body = page.getByLabel("プロンプト本文");
+  await expect(body).toHaveValue(/迷ったら needs-review/);
+  await expect(page.getByText("未保存（デフォルト）")).toBeVisible();
+  const details = page.getByText("システムが自動で付加します");
+  await expect(details).toBeHidden();
+  await page.getByText("自動で付加される部分を見る").click();
+  await expect(details).toBeVisible();
+  await expect(page.getByText("領収書の抽出結果を次のJSONスキーマに従って")).toBeVisible();
+
+  await page.getByRole("button", { name: "保存して v1 にする" }).click();
+  await expect(page.getByText("v1 有効")).toBeVisible();
+  const history = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name: "版履歴" }) }).getByRole("listitem");
+  await expect(history).toHaveCount(1);
+  await expect(history.first()).toContainText("初版");
+  await expect(history.first()).toContainText("0ジョブ");
+
+  // 変更を破棄すると保存済みの本文に戻る
+  await body.fill("破棄される本文");
+  await page.getByRole("button", { name: "変更を破棄" }).click();
+  await expect(body).toHaveValue(/迷ったら needs-review/);
+
+  await body.fill("一行目\n二行目");
+  await page.getByRole("button", { name: "保存して v2 にする" }).click();
+  await expect(page.getByText("v2 有効")).toBeVisible();
+  await expect(history).toHaveCount(2);
+  await expect(body).toHaveValue("一行目\n二行目");
+
+  // 巻き戻しは過去版を有効にするだけで、新しい版は作らない
+  await history.filter({ hasText: "v1" }).getByRole("button", { name: "巻き戻し" }).click();
+  await expect(page.getByText("v1 有効")).toBeVisible();
+  await expect(history).toHaveCount(2);
+  await expect(body).toHaveValue(/迷ったら needs-review/);
+  await expect(page.getByRole("button", { name: "保存して v3 にする" })).toBeVisible();
+  await page.reload();
+  await expect(page.getByText("v1 有効")).toBeVisible();
+});

--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/prompts/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/prompts/page.tsx
@@ -1,0 +1,12 @@
+import { PromptEditor } from "@/client/components/research-fund/PromptEditor";
+import { loadPrompts } from "@/server/contexts/research-fund/presentation/loaders/load-prompts";
+
+export default async function PromptsPage({
+  params,
+}: {
+  params: Promise<{ id: string; bookId: string }>;
+}) {
+  const { id, bookId } = await params;
+  const data = await loadPrompts(id, bookId);
+  return <PromptEditor key={`${data.activeVersion}`} {...data} />;
+}

--- a/admin/src/client/components/research-fund/PromptEditor.tsx
+++ b/admin/src/client/components/research-fund/PromptEditor.tsx
@@ -1,0 +1,168 @@
+"use client";
+import { useId, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button, Card, CardContent, Label, Textarea } from "@/client/components/ui";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import { cn } from "@/client/lib";
+import type { PromptOverview } from "@/server/contexts/research-fund/domain/models/prompt";
+import { mutatePrompt } from "@/server/contexts/research-fund/presentation/actions/manage-prompt";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+
+function formatDate(isoDate: string) {
+  return isoDate.slice(0, 10).replaceAll("-", ".");
+}
+
+export function PromptEditor({
+  versions,
+  body: savedBody,
+  activeVersion,
+  nextVersion,
+  automaticPrompt,
+  target,
+}: PromptOverview & { target: Extract<AdminTarget, { kind: "research-fund" }> }) {
+  const router = useRouter();
+  const fieldId = useId();
+  const [body, setBody] = useState(savedBody);
+  const [pending, startTransition] = useTransition();
+  const dirty = body !== savedBody;
+  // 版が 1 つも無いうちは、デフォルトテンプレートのまま保存して v1 を作れるようにする
+  const savable = body.trim().length > 0 && (dirty || activeVersion === null);
+
+  function run(mutation: Parameters<typeof mutatePrompt>[2], onSuccess: (message: string) => void) {
+    startTransition(async () => {
+      try {
+        const result = await mutatePrompt(target.politicianId, target.bookId, mutation);
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        onSuccess(
+          mutation.type === "save"
+            ? `v${result.version} として保存し、有効版にしました`
+            : `v${mutation.version} に巻き戻しました`,
+        );
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        label="Prompt"
+        title="読み取りプロンプト"
+        description={`${target.name}の議員室のスキャンで使う整理プロンプト。保存すると新しい版になり、各ジョブは使った版を記録します。`}
+      />
+      <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(300px,1fr)]">
+        <Card>
+          <CardContent className="p-5">
+            <details className="mb-4 rounded-lg border border-border-soft">
+              <summary className="cursor-pointer list-none px-4 py-3 text-sm font-bold">
+                自動で付加される部分を見る（出力スキーマ・費用カテゴリの語彙と定義）
+              </summary>
+              <div className="border-t border-border-soft px-4 py-3">
+                <p className="mb-2 text-xs text-muted-foreground">
+                  システムが自動で付加します。この画面からは編集できません。
+                </p>
+                <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-background p-3 text-xs">
+                  {automaticPrompt}
+                </pre>
+              </div>
+            </details>
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <Label htmlFor={fieldId}>プロンプト本文</Label>
+              <span
+                className={cn(
+                  "rounded-full border px-3 py-1 text-xs font-latin",
+                  activeVersion === null
+                    ? "text-muted-foreground"
+                    : "border-ring bg-accent text-accent-foreground",
+                )}
+              >
+                {activeVersion === null ? "未保存（デフォルト）" : `v${activeVersion} 有効`}
+              </span>
+            </div>
+            <Textarea
+              id={fieldId}
+              rows={16}
+              className="min-h-80 font-mono text-sm"
+              value={body}
+              disabled={pending}
+              onChange={(event) => setBody(event.target.value)}
+            />
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Button
+                disabled={pending || !savable}
+                onClick={() => run({ type: "save", body }, (message) => toast.success(message))}
+              >
+                保存して v{nextVersion} にする
+              </Button>
+              <Button
+                variant="outline"
+                disabled={pending || !dirty}
+                onClick={() => setBody(savedBody)}
+              >
+                変更を破棄
+              </Button>
+            </div>
+            {activeVersion === null && (
+              <p className="mt-3 text-xs text-muted-foreground">
+                まだ版がありません。デフォルトテンプレートを下敷きに編集し、保存すると v1
+                になります。
+              </p>
+            )}
+          </CardContent>
+        </Card>
+        <Card className="xl:sticky xl:top-6">
+          <CardContent className="p-5">
+            <h2 className="mb-3 font-bold">版履歴</h2>
+            {versions.length === 0 ? (
+              <p className="text-sm text-muted-foreground">保存するとここに版が並びます。</p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {versions.map((version) => (
+                  <li
+                    key={version.id}
+                    className={cn(
+                      "flex items-center gap-3 rounded-lg border border-border-soft p-3",
+                      version.isActive && "border-ring bg-accent",
+                    )}
+                  >
+                    <span className="font-latin font-bold">v{version.version}</span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm">{version.summary}</div>
+                      <div className="font-latin text-xs text-muted-foreground">
+                        {formatDate(version.updatedAt)}・{version.jobCount}ジョブ
+                      </div>
+                    </div>
+                    {version.isActive ? (
+                      <span className="rounded-full border border-ring px-2 py-1 text-xs text-accent-foreground">
+                        有効
+                      </span>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={pending}
+                        onClick={() =>
+                          run({ type: "rollback", version: version.version }, (message) =>
+                            toast.success(message),
+                          )
+                        }
+                      >
+                        巻き戻し
+                      </Button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/admin/src/server/contexts/research-fund/application/usecases/manage-prompt-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/manage-prompt-usecase.ts
@@ -1,0 +1,52 @@
+import "server-only";
+import {
+  PromptError,
+  normalizePromptBody,
+  summarizePromptChange,
+  type PromptOverview,
+} from "@/server/contexts/research-fund/domain/models/prompt";
+import type { PromptRepository } from "@/server/contexts/research-fund/domain/repositories/prompt-repository.interface";
+import {
+  DEFAULT_OFFICE_PROMPT,
+  buildAutomaticReceiptPrompt,
+} from "@/server/contexts/research-fund/domain/services/receipt-extraction-prompt";
+
+function validateId(id: string) {
+  if (!/^[1-9]\d*$/.test(id)) throw new PromptError("IDが不正です");
+}
+
+export class ManagePromptUsecase {
+  constructor(private repository: PromptRepository) {}
+
+  async list(politicianId: string): Promise<PromptOverview> {
+    validateId(politicianId);
+    const records = await this.repository.list(politicianId);
+    const versions = records.map((record, index) => ({
+      ...record,
+      // records は version の降順なので、次の要素が前の版にあたる
+      summary: summarizePromptChange(record.body, records[index + 1]?.body ?? null),
+    }));
+    const active = versions.find((version) => version.isActive) ?? versions[0] ?? null;
+    return {
+      versions,
+      body: active?.body ?? DEFAULT_OFFICE_PROMPT,
+      activeVersion: active?.version ?? null,
+      nextVersion: (versions[0]?.version ?? 0) + 1,
+      automaticPrompt: buildAutomaticReceiptPrompt(),
+    };
+  }
+
+  /** 新しい版として保存し、有効版にする。採番した版番号を返す */
+  async save(politicianId: string, body: unknown, userId: string): Promise<number> {
+    validateId(politicianId);
+    return this.repository.create(politicianId, normalizePromptBody(body), userId);
+  }
+
+  /** 過去の版を有効版に戻す。新しい版は作らない */
+  async rollback(politicianId: string, version: unknown): Promise<void> {
+    validateId(politicianId);
+    if (typeof version !== "number" || !Number.isInteger(version) || version < 1)
+      throw new PromptError("版の指定が不正です");
+    await this.repository.activate(politicianId, version);
+  }
+}

--- a/admin/src/server/contexts/research-fund/domain/models/prompt.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/prompt.ts
@@ -44,6 +44,13 @@ export function normalizePromptBody(body: unknown): string {
   return normalized;
 }
 
+/** 行ごとの出現回数。同じ行が複数回現れる本文でも増減を数えられるようにする */
+function countLines(body: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const line of body.split("\n")) counts.set(line, (counts.get(line) ?? 0) + 1);
+  return counts;
+}
+
 /**
  * 版履歴に出す変更要旨。
  * 変更要旨を保存する列は無いため、前版との行差分から機械的に導出する。
@@ -51,10 +58,15 @@ export function normalizePromptBody(body: unknown): string {
 export function summarizePromptChange(body: string, previousBody: string | null): string {
   if (previousBody === null) return "初版";
   if (previousBody === body) return "本文の変更なし";
-  const previousLines = previousBody.split("\n");
-  const lines = body.split("\n");
-  const added = lines.filter((line) => !previousLines.includes(line)).length;
-  const removed = previousLines.filter((line) => !lines.includes(line)).length;
+  const previousCounts = countLines(previousBody);
+  const counts = countLines(body);
+  let added = 0;
+  let removed = 0;
+  for (const line of new Set([...previousCounts.keys(), ...counts.keys()])) {
+    const diff = (counts.get(line) ?? 0) - (previousCounts.get(line) ?? 0);
+    if (diff > 0) added += diff;
+    else removed -= diff;
+  }
   if (added === 0 && removed === 0) return "行の並び替え";
   return [added > 0 && `+${added}行`, removed > 0 && `−${removed}行`].filter(Boolean).join("・");
 }

--- a/admin/src/server/contexts/research-fund/domain/models/prompt.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/prompt.ts
@@ -1,0 +1,60 @@
+export const PROMPT_BODY_MAX_LENGTH = 20000;
+
+/** 読み取りプロンプトの 1 版。version は議員ごとに 1 から連番。 */
+export interface PromptRecord {
+  id: string;
+  version: number;
+  body: string;
+  isActive: boolean;
+  /** ISO 8601。画面では YYYY.MM.DD で表示する */
+  updatedAt: string;
+  /** この版を使ったスキャンジョブ数 */
+  jobCount: number;
+}
+
+/** 版履歴に出す 1 行。変更要旨は前版との差分から導出する（本文以外の列は持たない） */
+export interface PromptVersion extends PromptRecord {
+  summary: string;
+}
+
+export interface PromptOverview {
+  versions: PromptVersion[];
+  /** エディタの初期値。版が 1 つも無ければデフォルトテンプレート */
+  body: string;
+  /** 有効版の版番号。版が 1 つも無ければ null */
+  activeVersion: number | null;
+  /** 保存すると採番される版番号 */
+  nextVersion: number;
+  /** システムが自動で付加する部分（参照専用） */
+  automaticPrompt: string;
+}
+
+export class PromptError extends Error {}
+
+/**
+ * 保存できる本文に正規化する。
+ * 末尾の空白だけを落とし、本文中の改行・インデントはプロンプトの意味を変えるため保つ。
+ */
+export function normalizePromptBody(body: unknown): string {
+  if (typeof body !== "string") throw new PromptError("プロンプト本文を入力してください");
+  const normalized = body.trim();
+  if (normalized.length === 0) throw new PromptError("プロンプト本文を入力してください");
+  if (normalized.length > PROMPT_BODY_MAX_LENGTH)
+    throw new PromptError(`プロンプト本文は${PROMPT_BODY_MAX_LENGTH}文字以内で入力してください`);
+  return normalized;
+}
+
+/**
+ * 版履歴に出す変更要旨。
+ * 変更要旨を保存する列は無いため、前版との行差分から機械的に導出する。
+ */
+export function summarizePromptChange(body: string, previousBody: string | null): string {
+  if (previousBody === null) return "初版";
+  if (previousBody === body) return "本文の変更なし";
+  const previousLines = previousBody.split("\n");
+  const lines = body.split("\n");
+  const added = lines.filter((line) => !previousLines.includes(line)).length;
+  const removed = previousLines.filter((line) => !lines.includes(line)).length;
+  if (added === 0 && removed === 0) return "行の並び替え";
+  return [added > 0 && `+${added}行`, removed > 0 && `−${removed}行`].filter(Boolean).join("・");
+}

--- a/admin/src/server/contexts/research-fund/domain/repositories/prompt-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/prompt-repository.interface.ts
@@ -1,0 +1,10 @@
+import type { PromptRecord } from "@/server/contexts/research-fund/domain/models/prompt";
+
+export interface PromptRepository {
+  /** 議員の全版を version の降順で返す */
+  list(politicianId: string): Promise<PromptRecord[]>;
+  /** 次の版を採番して保存し、有効版にする。採番した版番号を返す */
+  create(politicianId: string, body: string, userId: string): Promise<number>;
+  /** 既存の版を有効版にする（新しい版は作らない） */
+  activate(politicianId: string, version: number): Promise<void>;
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository.ts
@@ -1,0 +1,70 @@
+import "server-only";
+import { Prisma, type PrismaClient } from "@prisma/client";
+import {
+  PromptError,
+  type PromptRecord,
+} from "@/server/contexts/research-fund/domain/models/prompt";
+import type { PromptRepository } from "@/server/contexts/research-fund/domain/repositories/prompt-repository.interface";
+
+export class PrismaPromptRepository implements PromptRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async list(politicianId: string): Promise<PromptRecord[]> {
+    const rows = await this.prisma.researchFundPrompt.findMany({
+      where: { politicianId: BigInt(politicianId) },
+      orderBy: { version: "desc" },
+      include: { _count: { select: { scanJobs: true } } },
+    });
+    return rows.map((row) => ({
+      id: String(row.id),
+      version: row.version,
+      body: row.body,
+      isActive: row.isActive,
+      updatedAt: row.updatedAt.toISOString(),
+      jobCount: row._count.scanJobs,
+    }));
+  }
+
+  async create(politicianId: string, body: string, userId: string): Promise<number> {
+    const id = BigInt(politicianId);
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const latest = await tx.researchFundPrompt.findFirst({
+          where: { politicianId: id },
+          orderBy: { version: "desc" },
+          select: { version: true },
+        });
+        const version = (latest?.version ?? 0) + 1;
+        await tx.researchFundPrompt.updateMany({
+          where: { politicianId: id, isActive: true },
+          data: { isActive: false },
+        });
+        await tx.researchFundPrompt.create({
+          data: { politicianId: id, version, body, isActive: true, updatedById: userId },
+        });
+        return version;
+      });
+    } catch (error) {
+      // (politician_id, version) の一意制約。別の操作が先に同じ版を採番している
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")
+        throw new PromptError("別の操作で新しい版が保存されました。画面を再読み込みしてください");
+      throw error;
+    }
+  }
+
+  async activate(politicianId: string, version: number): Promise<void> {
+    const id = BigInt(politicianId);
+    await this.prisma.$transaction(async (tx) => {
+      const target = await tx.researchFundPrompt.findUnique({
+        where: { politicianId_version: { politicianId: id, version } },
+        select: { id: true },
+      });
+      if (!target) throw new PromptError("指定した版が見つかりません");
+      await tx.researchFundPrompt.updateMany({
+        where: { politicianId: id, isActive: true },
+        data: { isActive: false },
+      });
+      await tx.researchFundPrompt.update({ where: { id: target.id }, data: { isActive: true } });
+    });
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/actions/manage-prompt.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/manage-prompt.ts
@@ -1,0 +1,33 @@
+"use server";
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { ManagePromptUsecase } from "@/server/contexts/research-fund/application/usecases/manage-prompt-usecase";
+import { PromptError } from "@/server/contexts/research-fund/domain/models/prompt";
+import { PrismaPromptRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+type Mutation = { type: "save"; body: string } | { type: "rollback"; version: number };
+
+export async function mutatePrompt(politicianId: string, bookId: string, mutation: Mutation) {
+  const user = await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    const usecase = new ManagePromptUsecase(new PrismaPromptRepository(prisma));
+    let version: number | undefined;
+    if (mutation.type === "save")
+      version = await usecase.save(politicianId, mutation.body, user.id);
+    else if (mutation.type === "rollback") await usecase.rollback(politicianId, mutation.version);
+    else throw new PromptError("操作が不正です");
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const, version };
+  } catch (error) {
+    return {
+      success: false as const,
+      error:
+        error instanceof PromptError ? error.message : "読み取りプロンプトの保存に失敗しました",
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-prompts.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-prompts.ts
@@ -1,0 +1,16 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { ManagePromptUsecase } from "@/server/contexts/research-fund/application/usecases/manage-prompt-usecase";
+import { PrismaPromptRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export async function loadPrompts(politicianId: string, bookId: string) {
+  const target = await requireJournalTarget(politicianId, bookId);
+  if (!target) notFound();
+  // プロンプトは議員室（議員）ごと。年度帳簿をまたいで同じ版を使う
+  const data = await new ManagePromptUsecase(new PrismaPromptRepository(prisma)).list(
+    target.politicianId,
+  );
+  return { ...data, target };
+}

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-prompt-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-prompt-usecase.test.ts
@@ -1,0 +1,63 @@
+import { ManagePromptUsecase } from "@/server/contexts/research-fund/application/usecases/manage-prompt-usecase";
+import type { PromptRecord } from "@/server/contexts/research-fund/domain/models/prompt";
+import { DEFAULT_OFFICE_PROMPT, buildAutomaticReceiptPrompt } from "@/server/contexts/research-fund/domain/services/receipt-extraction-prompt";
+function setup() {
+  const repository = { list: jest.fn(), create: jest.fn(), activate: jest.fn() };
+  return { repository, usecase: new ManagePromptUsecase(repository) };
+}
+function record(version: number, body: string, isActive: boolean): PromptRecord {
+  return { id: String(version), version, body, isActive, updatedAt: "2026-09-01T00:00:00.000Z", jobCount: version };
+}
+test("版が1つも無ければデフォルトテンプレートから始め、保存はv1になる", async () => {
+  const { repository, usecase } = setup();
+  repository.list.mockResolvedValue([]);
+  await expect(usecase.list("2")).resolves.toEqual({
+    versions: [], body: DEFAULT_OFFICE_PROMPT, activeVersion: null, nextVersion: 1,
+    automaticPrompt: buildAutomaticReceiptPrompt(),
+  });
+});
+test("有効版の本文を編集対象にし、変更要旨と次の版番号を返す", async () => {
+  const { repository, usecase } = setup();
+  repository.list.mockResolvedValue([record(3, "a\nb\nc", false), record(2, "a\nb", true), record(1, "a", false)]);
+  const result = await usecase.list("2");
+  expect(result.body).toBe("a\nb");
+  expect(result.activeVersion).toBe(2);
+  expect(result.nextVersion).toBe(4);
+  expect(result.versions.map((v) => v.summary)).toEqual(["+1行", "+1行", "初版"]);
+});
+test("有効版が無ければ最新版を編集対象にする", async () => {
+  const { repository, usecase } = setup();
+  repository.list.mockResolvedValue([record(2, "新", false), record(1, "旧", false)]);
+  await expect(usecase.list("2")).resolves.toMatchObject({ body: "新", activeVersion: 2, nextVersion: 3 });
+});
+test("保存は正規化した本文と更新者を渡し、採番された版を返す", async () => {
+  const { repository, usecase } = setup();
+  repository.create.mockResolvedValue(4);
+  await expect(usecase.save("2", "  本文  ", "user")).resolves.toBe(4);
+  expect(repository.create).toHaveBeenCalledWith("2", "本文", "user");
+});
+test("空の本文は保存しない", async () => {
+  const { repository, usecase } = setup();
+  await expect(usecase.save("2", "   ", "user")).rejects.toThrow("プロンプト本文");
+  expect(repository.create).not.toHaveBeenCalled();
+});
+test("巻き戻しは既存の版を有効にするだけで、新しい版を作らない", async () => {
+  const { repository, usecase } = setup();
+  await usecase.rollback("2", 1);
+  expect(repository.activate).toHaveBeenCalledWith("2", 1);
+  expect(repository.create).not.toHaveBeenCalled();
+});
+test.each([0, -1, 1.5, NaN, "1", null])("不正な版の指定では巻き戻さない: %j", async (version) => {
+  const { repository, usecase } = setup();
+  await expect(usecase.rollback("2", version)).rejects.toThrow("版の指定");
+  expect(repository.activate).not.toHaveBeenCalled();
+});
+test.each(["", "0", "-1", "abc"])("不正な議員IDではリポジトリを呼ばない: %j", async (politicianId) => {
+  const { repository, usecase } = setup();
+  await expect(usecase.list(politicianId)).rejects.toThrow("ID");
+  await expect(usecase.save(politicianId, "本文", "user")).rejects.toThrow("ID");
+  await expect(usecase.rollback(politicianId, 1)).rejects.toThrow("ID");
+  expect(repository.list).not.toHaveBeenCalled();
+  expect(repository.create).not.toHaveBeenCalled();
+  expect(repository.activate).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-prompt-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-prompt-usecase.test.ts
@@ -1,8 +1,9 @@
 import { ManagePromptUsecase } from "@/server/contexts/research-fund/application/usecases/manage-prompt-usecase";
 import type { PromptRecord } from "@/server/contexts/research-fund/domain/models/prompt";
+import type { PromptRepository } from "@/server/contexts/research-fund/domain/repositories/prompt-repository.interface";
 import { DEFAULT_OFFICE_PROMPT, buildAutomaticReceiptPrompt } from "@/server/contexts/research-fund/domain/services/receipt-extraction-prompt";
 function setup() {
-  const repository = { list: jest.fn(), create: jest.fn(), activate: jest.fn() };
+  const repository: jest.Mocked<PromptRepository> = { list: jest.fn(), create: jest.fn(), activate: jest.fn() };
   return { repository, usecase: new ManagePromptUsecase(repository) };
 }
 function record(version: number, body: string, isActive: boolean): PromptRecord {

--- a/admin/tests/server/contexts/research-fund/domain/models/prompt.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/prompt.test.ts
@@ -18,6 +18,9 @@ test.each([
   ["a\nb\nc", "a\nb", "+1行"],
   ["a", "a\nb\nc", "−2行"],
   ["a\nx", "a\nb\nc", "+1行・−2行"],
+  ["a\na", "a", "+1行"],
+  ["a", "a\na", "−1行"],
+  ["a\n\nb", "a\nb", "+1行"],
 ])("前版との行差分を変更要旨にする: %j", (body, previous, expected) => {
   expect(summarizePromptChange(body, previous)).toBe(expected);
 });

--- a/admin/tests/server/contexts/research-fund/domain/models/prompt.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/prompt.test.ts
@@ -1,0 +1,23 @@
+import { PROMPT_BODY_MAX_LENGTH, normalizePromptBody, summarizePromptChange } from "@/server/contexts/research-fund/domain/models/prompt";
+test.each(["", "   \n\t ", null, undefined, 42, {}])("空・非文字列の本文は保存できない: %j", (body) => {
+  expect(() => normalizePromptBody(body)).toThrow("プロンプト本文");
+});
+test("前後の空白だけを落とし、本文中の改行とインデントは保つ", () => {
+  expect(normalizePromptBody("\n  一行目\n  - 項目\n\n")).toBe("一行目\n  - 項目");
+});
+test("上限を超える本文は保存できない", () => {
+  expect(normalizePromptBody("あ".repeat(PROMPT_BODY_MAX_LENGTH))).toHaveLength(PROMPT_BODY_MAX_LENGTH);
+  expect(() => normalizePromptBody("あ".repeat(PROMPT_BODY_MAX_LENGTH + 1))).toThrow("文字以内");
+});
+test("前版が無ければ初版", () => {
+  expect(summarizePromptChange("本文", null)).toBe("初版");
+});
+test.each([
+  ["a\nb", "a\nb", "本文の変更なし"],
+  ["a\nb", "b\na", "行の並び替え"],
+  ["a\nb\nc", "a\nb", "+1行"],
+  ["a", "a\nb\nc", "−2行"],
+  ["a\nx", "a\nb\nc", "+1行・−2行"],
+])("前版との行差分を変更要旨にする: %j", (body, previous, expected) => {
+  expect(summarizePromptChange(body, previous)).toBe(expected);
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository.test.ts
@@ -1,0 +1,56 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { PrismaPromptRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository";
+function setup() {
+  const table = { findMany: jest.fn(), findFirst: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), updateMany: jest.fn() };
+  const client = {
+    researchFundPrompt: table,
+    $transaction: jest.fn((run: (tx: unknown) => unknown) => run({ researchFundPrompt: table })),
+  };
+  return { table, client, repository: new PrismaPromptRepository(client as unknown as PrismaClient) };
+}
+test("版は降順に並べ、使用ジョブ数を数えて返す", async () => {
+  const { table, repository } = setup();
+  table.findMany.mockResolvedValue([
+    { id: BigInt(9), version: 2, body: "新", isActive: true, updatedAt: new Date("2026-09-02T03:04:05.000Z"), _count: { scanJobs: 7 } },
+  ]);
+  await expect(repository.list("2")).resolves.toEqual([
+    { id: "9", version: 2, body: "新", isActive: true, updatedAt: "2026-09-02T03:04:05.000Z", jobCount: 7 },
+  ]);
+  expect(table.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { politicianId: BigInt(2) }, orderBy: { version: "desc" } }));
+});
+test("保存は最新版の次を採番し、旧有効版を降ろしてから新版を有効にする", async () => {
+  const { table, client, repository } = setup();
+  table.findFirst.mockResolvedValue({ version: 3 });
+  await expect(repository.create("2", "本文", "user")).resolves.toBe(4);
+  expect(client.$transaction).toHaveBeenCalled();
+  expect(table.updateMany).toHaveBeenCalledWith({ where: { politicianId: BigInt(2), isActive: true }, data: { isActive: false } });
+  expect(table.create).toHaveBeenCalledWith({ data: { politicianId: BigInt(2), version: 4, body: "本文", isActive: true, updatedById: "user" } });
+});
+test("初回の保存はv1になる", async () => {
+  const { table, repository } = setup();
+  table.findFirst.mockResolvedValue(null);
+  await expect(repository.create("2", "本文", "user")).resolves.toBe(1);
+  expect(table.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ version: 1 }) }));
+});
+test("同時保存による版の重複は再読み込みを促すエラーにする", async () => {
+  const { table, repository } = setup();
+  table.findFirst.mockResolvedValue({ version: 3 });
+  table.create.mockRejectedValue(new Prisma.PrismaClientKnownRequestError("duplicate", { code: "P2002", clientVersion: "test" }));
+  await expect(repository.create("2", "本文", "user")).rejects.toThrow("再読み込み");
+});
+test("巻き戻しは対象の版だけを有効にし、新しい版を作らない", async () => {
+  const { table, repository } = setup();
+  table.findUnique.mockResolvedValue({ id: BigInt(5) });
+  await repository.activate("2", 1);
+  expect(table.findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { politicianId_version: { politicianId: BigInt(2), version: 1 } } }));
+  expect(table.updateMany).toHaveBeenCalledWith({ where: { politicianId: BigInt(2), isActive: true }, data: { isActive: false } });
+  expect(table.update).toHaveBeenCalledWith({ where: { id: BigInt(5) }, data: { isActive: true } });
+  expect(table.create).not.toHaveBeenCalled();
+});
+test("他の議員の版や存在しない版には巻き戻さない", async () => {
+  const { table, repository } = setup();
+  table.findUnique.mockResolvedValue(null);
+  await expect(repository.activate("2", 9)).rejects.toThrow("見つかりません");
+  expect(table.updateMany).not.toHaveBeenCalled();
+  expect(table.update).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/presentation/actions/manage-prompt.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/actions/manage-prompt.test.ts
@@ -1,0 +1,50 @@
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { ManagePromptUsecase } from "@/server/contexts/research-fund/application/usecases/manage-prompt-usecase";
+import { mutatePrompt } from "@/server/contexts/research-fund/presentation/actions/manage-prompt";
+import { PromptError } from "@/server/contexts/research-fund/domain/models/prompt";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/server/contexts/auth/presentation/loaders/require-auth", () => ({ requireAuth: jest.fn() }));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({ requireJournalTarget: jest.fn() }));
+jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(requireAuth).mockResolvedValue({ id: "user" } as Awaited<ReturnType<typeof requireAuth>>);
+  jest.mocked(requireJournalTarget).mockResolvedValue({ kind: "research-fund", key: "book:1", name: "議員", year: 2026, politicianId: "2", bookId: "1", draftCount: 0 });
+});
+afterEach(() => jest.restoreAllMocks());
+test("保存は更新者をサーバー側で設定し、採番された版を返してレイアウトを再検証", async () => {
+  const save = jest.spyOn(ManagePromptUsecase.prototype, "save").mockResolvedValue(4);
+  await expect(mutatePrompt("2", "1", { type: "save", body: "本文" })).resolves.toEqual({ success: true, version: 4 });
+  expect(requireJournalTarget).toHaveBeenCalledWith("2", "1");
+  expect(save).toHaveBeenCalledWith("2", "本文", "user");
+  expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
+});
+test("巻き戻しも対象を検証して再検証する", async () => {
+  const rollback = jest.spyOn(ManagePromptUsecase.prototype, "rollback").mockResolvedValue(undefined);
+  await expect(mutatePrompt("2", "1", { type: "rollback", version: 2 })).resolves.toEqual({ success: true, version: undefined });
+  expect(rollback).toHaveBeenCalledWith("2", 2);
+  expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
+});
+test("別の対象への古いフォーム送信を拒否", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(null);
+  const save = jest.spyOn(ManagePromptUsecase.prototype, "save");
+  await expect(mutatePrompt("2", "1", { type: "save", body: "本文" })).resolves.toMatchObject({ success: false });
+  expect(save).not.toHaveBeenCalled();
+  expect(revalidatePath).not.toHaveBeenCalled();
+});
+test("認証失敗時は保存しない", async () => {
+  jest.mocked(requireAuth).mockRejectedValueOnce(new Error("auth"));
+  const save = jest.spyOn(ManagePromptUsecase.prototype, "save");
+  await expect(mutatePrompt("2", "1", { type: "save", body: "本文" })).rejects.toThrow("auth");
+  expect(save).not.toHaveBeenCalled();
+  expect(revalidatePath).not.toHaveBeenCalled();
+});
+test("入力の不備は利用者に伝え、内部エラーは漏らさない", async () => {
+  jest.spyOn(ManagePromptUsecase.prototype, "save").mockRejectedValueOnce(new PromptError("プロンプト本文を入力してください"));
+  await expect(mutatePrompt("2", "1", { type: "save", body: " " })).resolves.toEqual({ success: false, error: "プロンプト本文を入力してください" });
+  jest.spyOn(ManagePromptUsecase.prototype, "save").mockRejectedValueOnce(new Error("private database detail"));
+  await expect(mutatePrompt("2", "1", { type: "save", body: "本文" })).resolves.toEqual({ success: false, error: "読み取りプロンプトの保存に失敗しました" });
+  expect(revalidatePath).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/presentation/loaders/load-prompts.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/loaders/load-prompts.test.ts
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+import { ManagePromptUsecase } from "@/server/contexts/research-fund/application/usecases/manage-prompt-usecase";
+import { loadPrompts } from "@/server/contexts/research-fund/presentation/loaders/load-prompts";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+jest.mock("next/navigation", () => ({ notFound: jest.fn(() => { throw new Error("NOT_FOUND"); }) }));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({ requireJournalTarget: jest.fn() }));
+jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+const target: Extract<AdminTarget, { kind: "research-fund" }> = { kind: "research-fund", key: "book:1", name: "議員", year: 2026, politicianId: "2", bookId: "1", draftCount: 0 };
+beforeEach(() => jest.clearAllMocks());
+afterEach(() => jest.restoreAllMocks());
+test("対象が一致しなければプロンプトを取得しない", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(null);
+  const list = jest.spyOn(ManagePromptUsecase.prototype, "list");
+  await expect(loadPrompts("2", "1")).rejects.toThrow("NOT_FOUND");
+  expect(notFound).toHaveBeenCalled();
+  expect(list).not.toHaveBeenCalled();
+});
+test("帳簿ではなく議員のプロンプトを取得し、現在の対象を添えて返す", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(target);
+  const data = { versions: [], body: "本文", activeVersion: null, nextVersion: 1, automaticPrompt: "自動" };
+  const list = jest.spyOn(ManagePromptUsecase.prototype, "list").mockResolvedValue(data);
+  await expect(loadPrompts("2", "1")).resolves.toEqual({ ...data, target });
+  expect(list).toHaveBeenCalledWith("2");
+});


### PR DESCRIPTION
## 目的（Why）

議員室のスタッフが、領収書の読み取り精度を自分たちのプロンプト（よく使う店・独自ルール・分割粒度のポリシー）で育てられるようにするため。保存は常に新版・有効版の切り替え・巻き戻しができるので、精度が落ちる変更をしても安全に戻せる。スキャンジョブは使った版を記録するため、この画面がスキャン（#1366 以降）の前提になる。

利用者は AI リテラシーが高い前提のため、システムが自動で付加する部分も画面から参照でき、「実際に何が送られるか」を隠さない。

## 変更内容

- `/politicians/[id]/books/[bookId]/prompts`（サイドバーの「読み取りプロンプト」）を追加
  - 本文エディタ（monospace）・「vN 有効」バッジ・「保存して vN+1 にする」・「変更を破棄」
  - エディタ上部に**自動生成部の折りたたみ参照**（`buildAutomaticReceiptPrompt()` の文字列をそのまま表示。読み取り専用・「システムが自動で付加します」の注記つき）
  - 右に版履歴（版番号・変更要旨・日付・使用ジョブ数・有効バッジ・「巻き戻し」）。巻き戻しは有効版を切り替えるだけで新しい版を作らない
  - 版が 1 つも無い議員は `DEFAULT_OFFICE_PROMPT` を初期値にし、保存すると v1 になる
- research-fund コンテキストに prompt のドメインモデル / リポジトリ / usecase / loader / server action を追加
  - 版は議員（議員室）ごとに独立。採番・有効版の切り替えはトランザクションで行い、`(politician_id, version)` の一意制約違反は再読み込みを促すエラーに変換する
  - action は `requireAuth` と現在の対象（`requireJournalTarget`）を検証し、更新者はサーバー側で設定する

### 判断したこと

- **schema は変更していない**（`research_fund_prompts` は #1349 で既に入っている）。そのため版履歴の**変更要旨は保存列が無く、前版との行差分から導出**している（`初版` / `+2行・−1行` / `行の並び替え` / `本文の変更なし`）。要旨を人が書けるようにするなら列の追加＝マイグレーションが必要なので、この PR では扱っていない。
- `.gitignore` の `prompts` がルート直下のスクラッチ用の意図に反して**あらゆる `prompts/` ディレクトリを無視**しており、`app/.../prompts/page.tsx` が commit から静かに漏れる状態だった。`/prompts` に限定した。

## ローカル CI

- `pnpm verify` ✅（admin 112 suites / 1374 tests、webapp 17 suites / 139 tests、typecheck・lint・knip・depcruise すべて green）
- `pnpm test:e2e` ✅ — admin 36 passed（新規 `prompts.spec.ts` 含む）、webapp 14 passed
  - 初回は webapp の 1 件が落ちたが、admin の E2E が作った政治団体で DB が汚れていたことによるもの。`pnpm db:reset` 後は green（本 PR とは無関係の既存のテスト間分離の問題として #1400 に起票）

## スコープ外

- テスト実行（1 枚流して結果を見る）: #1366
- 自動生成部（コード側）の編集 UI（参照のみ）

## スコープアウトして起票した Issue

- #1400 E2E の DB 状態がスイート間で共有され、admin の後に webapp を回すと落ちる

Closes #1363



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 読み取りプロンプトの管理画面を追加しました。
  - 本文を編集し、新しいバージョンとして保存できます。
  - バージョン履歴の確認や、過去バージョンへの巻き戻しに対応しました。
  - 未保存時はデフォルトテンプレートから編集を開始できます。
  - 自動生成されたプロンプトは参照専用で確認できます。
  - 保存済みの変更を破棄し、現在の有効バージョンへ戻せます。
  - 有効なバージョンは画面を再読み込みしても維持されます。

- **テスト**
  - 保存、版管理、巻き戻し、入力検証、認証エラーなどを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->