### PR TITLE
feat(admin): 調研費の公開画面を追加

### DIFF
--- a/admin/e2e/tests/publish.spec.ts
+++ b/admin/e2e/tests/publish.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+
+test("確認済の仕訳を選んでbefore/afterを見比べ、公開して公開範囲を更新する", async ({ page }) => {
+  const year = new Date().getFullYear();
+  const name = `e2e-publish-${Date.now()}`;
+  await page.goto("/politicians/new");
+  await page.getByLabel("氏名").fill(name);
+  await page.getByLabel("スラッグ").fill(name);
+  await page.getByLabel("当選日").fill(`${year}-01-01`);
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page).toHaveURL("/politicians");
+  const politicianCard = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name, exact: true }) });
+  await politicianCard.getByRole("link", { name: "年度帳簿" }).click();
+  await page.getByLabel(/^年度/).fill(String(year));
+  await page.getByRole("button", { name: "帳簿を作成" }).click();
+  await expect(page.getByRole("heading", { name: `${year}年度` })).toBeVisible();
+  await page.getByRole("button", { name: "現在の対象を切り替え" }).click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "load" }),
+    page.getByRole("button", { name: `${name}／${year}年度` }).click(),
+  ]);
+
+  // 公開できる材料をつくる: 支給1件（確認済）と、確認済にした支出1件
+  await page.getByRole("link", { name: "支給の登録" }).click();
+  await expect(page.getByRole("heading", { name: "支給の登録" })).toBeVisible();
+  await page.getByRole("listitem").filter({ hasText: "1月" }).first().getByRole("button", { name: "この月を登録" }).click();
+  await expect(page.getByRole("listitem").filter({ hasText: "1月" }).first()).toContainText("登録済み");
+  await page.getByRole("link", { name: "仕訳の確認・編集" }).click();
+  await expect(page.getByRole("heading", { name: "仕訳の確認・編集" })).toBeVisible();
+  await page.getByRole("button", { name: "手動で仕訳を作成" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("日付", { exact: true }).fill(`${year}-03-15`);
+  await dialog.getByLabel("金額", { exact: true }).fill("1500");
+  await dialog.getByLabel("項目名", { exact: true }).fill("視察先への移動");
+  await dialog.getByLabel("科目", { exact: true }).selectOption("taxi");
+  await dialog.getByRole("button", { name: "下書きを作成" }).click();
+  await expect(dialog).toBeHidden();
+  await page.getByRole("row").filter({ hasText: "視察先への移動" }).click();
+  await page.getByRole("button", { name: "確認済にする", exact: true }).click();
+  await expect(page.getByRole("row").filter({ hasText: "視察先への移動" })).toContainText("確認済");
+
+  await page.getByRole("link", { name: "公開", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "公開" })).toBeVisible();
+  await expect(page.getByText("確認済・未公開 2件")).toBeVisible();
+  await expect(page.getByRole("button", { name: "公開する仕訳を選んでください" })).toBeDisabled();
+  await expect(page.getByText("仕訳を選ぶとこちらが変化します")).toBeVisible();
+  await expect(page.getByText("現在の公開状態（未公開）")).toBeVisible();
+
+  // チェックすると after と差分文が即時に変わる
+  await page.getByRole("checkbox", { name: "調査研究費 1月分を公開対象にする" }).click();
+  await expect(page.getByText("公開すると：未使用 +¥1,000,000")).toBeVisible();
+  await page.getByRole("checkbox", { name: "視察先への移動を公開対象にする" }).click();
+  await expect(page.getByText("公開すると：タクシー代 +¥1,500・未使用 +¥998,500")).toBeVisible();
+  await expect(page.getByText("選択中の 2件 を公開した場合")).toBeVisible();
+
+  const publishButton = page.getByRole("button", { name: "2件（¥1,001,500）を公開する" });
+  await expect(publishButton).toBeEnabled();
+  await publishButton.click();
+  await expect(page.getByText(`2件を公開しました（公開範囲 〜${year}.03.31）`)).toBeVisible();
+  await expect(page.getByText("確認済・未公開 0件")).toBeVisible();
+  await expect(page.getByText("公開できる確認済の仕訳はありません")).toBeVisible();
+  await page.reload();
+  await expect(page.getByText(`現在の公開状態（〜${year}.03.31・¥1,500）`)).toBeVisible();
+
+  // 公開済みは仕訳一覧で「公開中」になり、帳簿の公開範囲も更新される
+  await page.getByRole("link", { name: "仕訳の確認・編集" }).click();
+  await expect(page.getByRole("heading", { name: "仕訳の確認・編集" })).toBeVisible();
+  await expect(page.getByRole("row").filter({ hasText: "視察先への移動" })).toContainText("公開中");
+  await page.getByRole("link", { name: "年度帳簿" }).click();
+  const bookCard = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name: `${year}年度` }) });
+  await expect(bookCard).toContainText("公開中");
+  await expect(bookCard).toContainText(`${year}.03.31まで`);
+
+  await page.goto("/politicians");
+  await politicianCard.getByRole("button", { name: "削除", exact: true }).click();
+  await page.getByRole("button", { name: "削除する", exact: true }).click();
+  await expect(politicianCard).toHaveCount(0);
+});

--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/publish/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/publish/page.tsx
@@ -1,0 +1,12 @@
+import { JournalPublication } from "@/client/components/research-fund/JournalPublication";
+import { loadPublication } from "@/server/contexts/research-fund/presentation/loaders/load-publication";
+
+export default async function PublishPage({
+  params,
+}: {
+  params: Promise<{ id: string; bookId: string }>;
+}) {
+  const { id, bookId } = await params;
+  const data = await loadPublication(id, bookId);
+  return <JournalPublication key={bookId} {...data} />;
+}

--- a/admin/src/client/components/research-fund/JournalPublication.tsx
+++ b/admin/src/client/components/research-fund/JournalPublication.tsx
@@ -1,0 +1,206 @@
+"use client";
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Globe } from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import { ResearchFundSankey } from "@/client/components/research-fund/ResearchFundSankey";
+import { Button, Card, CardContent, Checkbox } from "@/client/components/ui";
+import { cn, describePublishDelta, formatCurrency } from "@/client/lib";
+import type {
+  PublicationSnapshot,
+  PublishCandidate,
+} from "@/server/contexts/research-fund/domain/models/publication";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+import { publishJournalEntries } from "@/server/contexts/research-fund/presentation/actions/publish-journal-entries";
+import { aggregateResearchFund } from "@/shared/research-fund/aggregation";
+
+function aggregate(
+  rows: PublicationSnapshot["published"],
+  accounts: PublicationSnapshot["accounts"],
+) {
+  const result = aggregateResearchFund(rows, accounts);
+  return result.status === "valid" ? result.value : null;
+}
+
+function SankeyCard({
+  tag,
+  caption,
+  aggregation,
+}: {
+  tag: "BEFORE" | "AFTER";
+  caption: string;
+  aggregation: ReturnType<typeof aggregate>;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <div className="mb-2 flex flex-wrap items-baseline gap-2.5">
+          <span
+            className={cn(
+              "font-latin rounded-full px-2.5 py-0.5 text-[11px] font-bold",
+              tag === "AFTER"
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground",
+            )}
+          >
+            {tag}
+          </span>
+          <span className="text-[13px] text-muted-foreground">{caption}</span>
+        </div>
+        {aggregation ? (
+          <ResearchFundSankey
+            granted={aggregation.kpi.granted}
+            categories={aggregation.categories}
+          />
+        ) : (
+          <p className="py-10 text-center text-sm text-destructive">
+            集計できないデータが含まれています
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function JournalPublication({
+  published,
+  candidates,
+  accounts,
+  publishedThrough,
+  target,
+}: PublicationSnapshot & { target: Extract<AdminTarget, { kind: "research-fund" }> }) {
+  const router = useRouter();
+  const [checked, setChecked] = useState<readonly string[]>([]);
+  const [pending, startTransition] = useTransition();
+  const selected = candidates.filter((candidate) => checked.includes(candidate.id));
+  const selectedTotal = selected.reduce((sum, candidate) => sum + candidate.amount, 0);
+  const before = useMemo(() => aggregate(published, accounts), [published, accounts]);
+  const after = useMemo(
+    () => aggregate([...published, ...candidates.filter((c) => checked.includes(c.id))], accounts),
+    [published, accounts, candidates, checked],
+  );
+  const delta = before && after ? describePublishDelta(before, after) : null;
+
+  function toggle(candidate: PublishCandidate) {
+    setChecked((current) =>
+      current.includes(candidate.id)
+        ? current.filter((id) => id !== candidate.id)
+        : [...current, candidate.id],
+    );
+  }
+  function publish() {
+    startTransition(async () => {
+      try {
+        const result = await publishJournalEntries(target.politicianId, target.bookId, checked);
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success(
+          `${result.count}件を公開しました（公開範囲 〜${(result.publishedThrough ?? "").replaceAll("-", ".")}）`,
+        );
+        if (result.cacheWarning)
+          toast.warning(`公開しましたが、まる見えの更新に失敗しました: ${result.cacheWarning}`);
+        setChecked([]);
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        label="Publish"
+        title="公開"
+        description="確認済の仕訳を選ぶと、公開したときのサンキー図の変化を並べて確認できます。"
+      />
+      <div className="grid grid-cols-1 items-start gap-4 xl:grid-cols-[minmax(280px,380px)_minmax(0,1fr)]">
+        <Card>
+          <CardContent className="p-5">
+            <div className="mb-2.5 text-sm font-bold">
+              確認済・未公開{" "}
+              <span className="font-latin text-primary-hover">{candidates.length}</span>件
+            </div>
+            <ul className="grid gap-0.5">
+              {candidates.map((candidate) => (
+                <li key={candidate.id}>
+                  <label
+                    htmlFor={`publish-${candidate.id}`}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2",
+                      checked.includes(candidate.id) && "bg-accent",
+                    )}
+                  >
+                    <Checkbox
+                      id={`publish-${candidate.id}`}
+                      checked={checked.includes(candidate.id)}
+                      onCheckedChange={() => toggle(candidate)}
+                      disabled={pending}
+                      aria-label={`${candidate.description}を公開対象にする`}
+                    />
+                    <span className="font-latin w-12 shrink-0 text-[11.5px] text-muted-foreground">
+                      {candidate.date.slice(5).replace("-", "/")}
+                    </span>
+                    <span className="flex-1 text-[13px]">{candidate.description}</span>
+                    <span className="font-latin text-[12.5px] font-semibold">
+                      {formatCurrency(candidate.amount)}
+                    </span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+            {candidates.length === 0 && (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                公開できる確認済の仕訳はありません
+              </p>
+            )}
+            <Button
+              className="mt-3.5 w-full"
+              disabled={selected.length === 0 || pending}
+              onClick={publish}
+            >
+              <Globe size={15} />
+              {selected.length === 0
+                ? "公開する仕訳を選んでください"
+                : `${selected.length}件（${formatCurrency(selectedTotal)}）を公開する`}
+            </Button>
+            <p className="mt-2.5 text-xs leading-relaxed text-subtle-foreground">
+              公開すると「調研費まる見え」に即時反映され、公開範囲の表記
+              {publishedThrough
+                ? `（現在 〜${publishedThrough.replaceAll("-", ".")}）`
+                : "（現在 未公開）"}
+              も更新されます。
+            </p>
+          </CardContent>
+        </Card>
+        <div className="grid gap-3.5">
+          <SankeyCard
+            tag="BEFORE"
+            caption={
+              publishedThrough
+                ? `現在の公開状態（〜${publishedThrough.replaceAll("-", ".")}・${formatCurrency(before?.kpi.spent ?? 0)}）`
+                : "現在の公開状態（未公開）"
+            }
+            aggregation={before}
+          />
+          <SankeyCard
+            tag="AFTER"
+            caption={
+              selected.length === 0
+                ? "仕訳を選ぶとこちらが変化します"
+                : `選択中の ${selected.length}件 を公開した場合`
+            }
+            aggregation={after}
+          />
+          <p className="text-[13px] text-muted-foreground">
+            {delta ??
+              "左のリストで仕訳にチェックを入れると、費目ごとの増分と未使用の減少をここに表示します。"}
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/admin/src/client/components/research-fund/ResearchFundSankey.tsx
+++ b/admin/src/client/components/research-fund/ResearchFundSankey.tsx
@@ -1,0 +1,115 @@
+import { cn } from "@/client/lib";
+import type { ResearchFundCategoryTotal } from "@/shared/research-fund/aggregation";
+
+// viewBox 座標系（デザインハンドオフのプロトタイプ 560x216 に合わせる）
+const VIEW = { width: 560, height: 216 };
+const BODY = { top: 8, height: 160 };
+const NODE = { width: 12, leftX: 30, rightX: 400, gap: 4 };
+const LABEL = { offset: 6, fontSize: 10 };
+
+function ribbon(leftY: number, leftHeight: number, rightY: number, rightHeight: number): string {
+  const [x1, x2] = [NODE.leftX + NODE.width, NODE.rightX];
+  const [c1, c2] = [x1 + (x2 - x1) * 0.4, x1 + (x2 - x1) * 0.6];
+  return [
+    `M ${x1} ${leftY}`,
+    `C ${c1} ${leftY}, ${c2} ${rightY}, ${x2} ${rightY}`,
+    `L ${x2} ${rightY + rightHeight}`,
+    `C ${c2} ${rightY + rightHeight}, ${c1} ${leftY + leftHeight}, ${x1} ${leftY + leftHeight}`,
+    "Z",
+  ].join(" ");
+}
+
+function yen(amount: number): string {
+  return `¥${amount.toLocaleString("ja-JP")}`;
+}
+
+/**
+ * 公開の before / after を並べて見せるための簡易サンキー。
+ * 左ノード = 支給、右ノード = 費目（末尾に未使用）。金額は shared の集計サービスが出したものをそのまま描く。
+ */
+export function ResearchFundSankey({
+  granted,
+  categories,
+}: {
+  granted: number;
+  categories: readonly ResearchFundCategoryTotal[];
+}) {
+  // 支出が支給を超えて未使用が負になる場合も、描画上は 0 として扱う（金額はラベルで示す）。
+  const nodes = categories.map((category) => ({
+    ...category,
+    drawn: Math.max(0, category.totalAmount),
+  }));
+  const total = nodes.reduce((sum, node) => sum + node.drawn, 0);
+  if (granted <= 0 || total <= 0)
+    return (
+      <p className="py-10 text-center text-sm text-muted-foreground">
+        公開済みの支給・支出がまだありません
+      </p>
+    );
+  // 左は隙間なしの1本、右は費目どうしを離して積む。
+  const leftScale = BODY.height / total;
+  const rightScale = (BODY.height - NODE.gap * Math.max(0, nodes.length - 1)) / total;
+  let leftOffset = BODY.top;
+  let rightOffset = BODY.top;
+  const placed = nodes.map((node) => {
+    const [leftHeight, height] = [node.drawn * leftScale, node.drawn * rightScale];
+    const [leftY, y] = [leftOffset, rightOffset];
+    leftOffset += leftHeight;
+    rightOffset += height + NODE.gap;
+    return { ...node, leftY, leftHeight, y, height };
+  });
+  return (
+    <svg
+      viewBox={`0 0 ${VIEW.width} ${VIEW.height}`}
+      className="block h-auto w-full"
+      role="img"
+      aria-label={`支給 ${yen(granted)} の使いみち`}
+    >
+      {placed.map((node) => (
+        <path
+          key={node.key}
+          d={ribbon(node.leftY, node.leftHeight, node.y, node.height)}
+          className={node.kind === "unused" ? "fill-muted" : "fill-primary"}
+          opacity={node.kind === "unused" ? 0.55 : 0.28}
+        />
+      ))}
+      <rect
+        x={NODE.leftX}
+        y={BODY.top}
+        width={NODE.width}
+        height={BODY.height}
+        className="fill-primary"
+      />
+      <text
+        x={NODE.leftX}
+        y={BODY.top + BODY.height + 14}
+        className="fill-foreground font-latin"
+        fontSize={LABEL.fontSize}
+      >
+        {`支給 ${yen(granted)}`}
+      </text>
+      {placed.map((node) => (
+        <g key={node.key}>
+          <rect
+            x={NODE.rightX}
+            y={node.y}
+            width={NODE.width}
+            height={node.height}
+            className={cn(
+              node.kind === "unused" ? "fill-muted stroke-disabled-border" : "fill-primary",
+            )}
+            strokeWidth={node.kind === "unused" ? 1 : 0}
+          />
+          <text
+            x={NODE.rightX + NODE.width + LABEL.offset}
+            y={node.y + node.height / 2 + 3}
+            className={node.kind === "unused" ? "fill-muted-foreground" : "fill-foreground"}
+            fontSize={LABEL.fontSize}
+          >
+            {`${node.label} ${yen(node.totalAmount)}`}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/admin/src/client/lib/index.ts
+++ b/admin/src/client/lib/index.ts
@@ -14,3 +14,4 @@ export {
   toDonorFormSubmitData,
 } from "./donor-form";
 export type { DonorFormValues, DonorFormSubmitData } from "./donor-form";
+export { describePublishDelta } from "./research-fund-publish";

--- a/admin/src/client/lib/research-fund-publish.ts
+++ b/admin/src/client/lib/research-fund-publish.ts
@@ -1,0 +1,34 @@
+import type { ResearchFundAggregation } from "@/shared/research-fund/aggregation";
+
+function yen(amount: number): string {
+  return `¥${amount.toLocaleString("ja-JP")}`;
+}
+
+function signed(diff: number): string {
+  return `${diff < 0 ? "−" : "+"}${yen(Math.abs(diff))}`;
+}
+
+/**
+ * 公開前後の集計を突き合わせ、「公開すると：◯◯ +¥n・未使用 −¥n」の一文を作る。
+ * 費目は増分の大きい順に並べ、未使用は増減どちらでも常に末尾に置く。
+ */
+export function describePublishDelta(
+  before: ResearchFundAggregation,
+  after: ResearchFundAggregation,
+): string | null {
+  const previous = new Map(
+    before.categories.map((category) => [category.key, category.totalAmount]),
+  );
+  const parts = after.categories
+    .filter((category) => category.kind !== "unused")
+    .map((category) => ({
+      label: category.label,
+      diff: category.totalAmount - (previous.get(category.key) ?? 0),
+    }))
+    .filter((entry) => entry.diff !== 0)
+    .sort((a, b) => b.diff - a.diff)
+    .map((entry) => `${entry.label} ${signed(entry.diff)}`);
+  const unused = after.unused - before.unused;
+  if (unused !== 0) parts.push(`未使用 ${signed(unused)}`);
+  return parts.length === 0 ? null : `公開すると：${parts.join("・")}`;
+}

--- a/admin/src/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase.ts
@@ -1,0 +1,52 @@
+import "server-only";
+import { JournalEntry } from "@/server/contexts/research-fund/domain/models/journal-entry";
+import {
+  Publication,
+  PublicationError,
+} from "@/server/contexts/research-fund/domain/models/publication";
+import type { PublicationRepository } from "@/server/contexts/research-fund/domain/repositories/publication-repository.interface";
+import type { ICacheInvalidator } from "@/server/contexts/shared/domain/services/cache-invalidator.interface";
+
+export class PublishJournalEntriesUsecase {
+  constructor(
+    private repository: PublicationRepository,
+    private cacheInvalidator: ICacheInvalidator,
+  ) {}
+
+  async snapshot(bookId: string) {
+    const snapshot = await this.repository.snapshot(bookId);
+    if (!snapshot) throw new PublicationError("帳簿が見つかりません");
+    return snapshot;
+  }
+
+  async publish(bookId: string, ids: readonly string[]) {
+    const unique = [...new Set(ids)];
+    if (unique.length === 0) throw new PublicationError("公開する仕訳を選んでください");
+    if (unique.some((id) => !/^[1-9]\d*$/.test(id))) throw new PublicationError("仕訳IDが不正です");
+    const target = await this.repository.pending(bookId, unique);
+    if (!target) throw new PublicationError("帳簿が見つかりません");
+    if (target.entries.length !== unique.length)
+      throw new PublicationError("選んだ仕訳が見つかりません。画面を再読み込みしてください");
+    // 下書きは公開できない。確認済 → 公開済 の遷移だけをドメインが許す。
+    for (const entry of target.entries) {
+      if (JournalEntry.transition(entry, "published").status === "invalid")
+        throw new PublicationError(
+          "確認済の仕訳だけを公開できます。下書きは先に確認済にしてください",
+        );
+    }
+    const publishedThrough = Publication.advancePublishedThrough(
+      target.publishedThrough,
+      target.entries.map((entry) => entry.entryDate),
+    );
+    await this.repository.publish(bookId, unique, publishedThrough);
+    // 公開自体は確定しているので、キャッシュ無効化の失敗は警告として返す。
+    let cacheWarning: string | null = null;
+    try {
+      await this.cacheInvalidator.invalidateWebappCache();
+    } catch (error) {
+      cacheWarning =
+        error instanceof Error ? error.message : "ウェブアプリのキャッシュを更新できませんでした";
+    }
+    return { count: unique.length, publishedThrough, cacheWarning };
+  }
+}

--- a/admin/src/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase.ts
@@ -33,6 +33,11 @@ export class PublishJournalEntriesUsecase {
         throw new PublicationError(
           "確認済の仕訳だけを公開できます。下書きは先に確認済にしてください",
         );
+      // 画面のチェックリストに出ない仕訳は before / after で確認できないので公開させない。
+      if (!Publication.isPublishable(entry.rowCount))
+        throw new PublicationError(
+          "この画面で公開できない仕訳が含まれています。画面を再読み込みしてください",
+        );
     }
     const publishedThrough = Publication.advancePublishedThrough(
       target.publishedThrough,

--- a/admin/src/server/contexts/research-fund/domain/models/publication.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/publication.ts
@@ -19,6 +19,8 @@ export interface PublicationSnapshot {
 export interface PublishableEntry extends JournalEntry {
   id: string;
   entryDate: string;
+  /** 集計行に射影したときの行数。公開の候補かどうかの判定に使う。 */
+  rowCount: number;
 }
 
 export class PublicationError extends Error {}
@@ -29,6 +31,14 @@ function monthEnd(date: string): string {
 }
 
 export const Publication = {
+  /**
+   * 公開の候補にできるのは「費用1行／収入1行」に射影できる仕訳だけ。
+   * それ以外はこの画面の before / after に表せないため、候補に出さず公開もさせない。
+   */
+  isPublishable(rowCount: number): boolean {
+    return rowCount === 1;
+  },
+
   /**
    * 公開範囲（published_through）を、公開した仕訳の最新月末まで進める。
    * 既に先まで公開している場合は後退させない（過去分の追加公開で表記が戻らないように）。

--- a/admin/src/server/contexts/research-fund/domain/models/publication.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/publication.ts
@@ -1,0 +1,41 @@
+import type { JournalEntry } from "@/server/contexts/research-fund/domain/models/journal-entry";
+import type { ResearchFundCategory, ResearchFundRow } from "@/shared/research-fund/aggregation";
+
+/** 公開の候補として選べる確認済・未公開の仕訳。集計にそのまま渡せるよう行を兼ねる。 */
+export interface PublishCandidate extends ResearchFundRow {
+  id: string;
+  description: string;
+}
+
+/** 公開画面が描く before / after の材料。before は公開済みだけ、after は候補を足して集計する。 */
+export interface PublicationSnapshot {
+  published: ResearchFundRow[];
+  candidates: PublishCandidate[];
+  accounts: Record<string, ResearchFundCategory>;
+  publishedThrough: string | null;
+}
+
+/** 公開の可否判定に必要な最小限の仕訳。状態遷移は JournalEntry が持つ。 */
+export interface PublishableEntry extends JournalEntry {
+  id: string;
+  entryDate: string;
+}
+
+export class PublicationError extends Error {}
+
+function monthEnd(date: string): string {
+  const [year, month] = [Number(date.slice(0, 4)), Number(date.slice(5, 7))];
+  return new Date(Date.UTC(year, month, 0)).toISOString().slice(0, 10);
+}
+
+export const Publication = {
+  /**
+   * 公開範囲（published_through）を、公開した仕訳の最新月末まで進める。
+   * 既に先まで公開している場合は後退させない（過去分の追加公開で表記が戻らないように）。
+   */
+  advancePublishedThrough(current: string | null, dates: readonly string[]): string | null {
+    if (dates.length === 0) return current;
+    const latest = monthEnd(dates.reduce((a, b) => (a > b ? a : b)));
+    return current && current > latest ? current : latest;
+  },
+};

--- a/admin/src/server/contexts/research-fund/domain/repositories/publication-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/publication-repository.interface.ts
@@ -1,0 +1,16 @@
+import type {
+  PublicationSnapshot,
+  PublishableEntry,
+} from "@/server/contexts/research-fund/domain/models/publication";
+
+export interface PublicationRepository {
+  /** 公開画面の materials。帳簿が無ければ null。 */
+  snapshot(bookId: string): Promise<PublicationSnapshot | null>;
+  /** 指定した仕訳の現在の状態と、帳簿の公開範囲。帳簿が無ければ null。 */
+  pending(
+    bookId: string,
+    ids: readonly string[],
+  ): Promise<{ entries: PublishableEntry[]; publishedThrough: string | null } | null>;
+  /** 確認済の仕訳だけを published にし、公開範囲を更新する。 */
+  publish(bookId: string, ids: readonly string[], publishedThrough: string | null): Promise<void>;
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository.ts
@@ -1,0 +1,114 @@
+import "server-only";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import {
+  PublicationError,
+  type PublicationSnapshot,
+  type PublishCandidate,
+} from "@/server/contexts/research-fund/domain/models/publication";
+import type { PublicationRepository } from "@/server/contexts/research-fund/domain/repositories/publication-repository.interface";
+import type { ResearchFundRow } from "@/shared/research-fund/aggregation";
+
+const include = {
+  lines: { include: { account: true } },
+} satisfies Prisma.ResearchFundJournalEntryInclude;
+type Row = Prisma.ResearchFundJournalEntryGetPayload<{ include: typeof include }>;
+
+/** 集計に使うのは「借方の費用」と「貸方の調査研究費収入」だけ。相手勘定の普通預金は数えない。 */
+function rowsOf(entry: Row): ResearchFundRow[] {
+  const date = entry.entryDate.toISOString().slice(0, 10);
+  return entry.lines
+    .filter(
+      (line) =>
+        (line.side === "debit" && line.account.type === "expense") ||
+        (line.side === "credit" && line.accountKey === "grant-income"),
+    )
+    .map((line) => ({
+      date,
+      accountKey: line.accountKey,
+      amount: line.amount.toNumber(),
+      type: line.side === "debit" ? ("expense" as const) : ("grant" as const),
+    }));
+}
+
+export class PrismaPublicationRepository implements PublicationRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async snapshot(bookId: string): Promise<PublicationSnapshot | null> {
+    const book = await this.prisma.researchFundBook.findUnique({
+      where: { id: BigInt(bookId) },
+      include: {
+        journalEntries: {
+          where: { status: { in: ["approved", "published"] } },
+          include,
+          orderBy: [{ entryDate: "asc" }, { id: "asc" }],
+        },
+      },
+    });
+    if (!book) return null;
+    const published: ResearchFundRow[] = [];
+    const candidates: PublishCandidate[] = [];
+    const accounts: PublicationSnapshot["accounts"] = {};
+    for (const entry of book.journalEntries) {
+      const rows = rowsOf(entry);
+      for (const line of entry.lines)
+        accounts[line.accountKey] = {
+          label: line.account.label,
+          legalLabel: line.account.legalLabel ?? "",
+        };
+      if (entry.status === "published") {
+        published.push(...rows);
+        continue;
+      }
+      // 「費用1行／収入1行」に射影できる仕訳だけを公開の候補にする（それ以外はこの画面で扱えない）。
+      if (rows.length !== 1) continue;
+      candidates.push({ ...rows[0], id: String(entry.id), description: entry.description });
+    }
+    return {
+      published,
+      candidates,
+      accounts,
+      publishedThrough: book.publishedThrough?.toISOString().slice(0, 10) ?? null,
+    };
+  }
+
+  async pending(bookId: string, ids: readonly string[]) {
+    const book = await this.prisma.researchFundBook.findUnique({
+      where: { id: BigInt(bookId) },
+      select: { publishedThrough: true },
+    });
+    if (!book) return null;
+    const entries = await this.prisma.researchFundJournalEntry.findMany({
+      where: { bookId: BigInt(bookId), id: { in: ids.map((id) => BigInt(id)) } },
+      select: { id: true, status: true, entryDate: true },
+    });
+    return {
+      entries: entries.map((entry) => ({
+        id: String(entry.id),
+        status: entry.status,
+        entryDate: entry.entryDate.toISOString().slice(0, 10),
+      })),
+      publishedThrough: book.publishedThrough?.toISOString().slice(0, 10) ?? null,
+    };
+  }
+
+  async publish(bookId: string, ids: readonly string[], publishedThrough: string | null) {
+    await this.prisma.$transaction(async (tx) => {
+      // status: "approved" の条件が「下書きは公開できない」をDBレベルで担保する。
+      const result = await tx.researchFundJournalEntry.updateMany({
+        where: {
+          bookId: BigInt(bookId),
+          id: { in: ids.map((id) => BigInt(id)) },
+          status: "approved",
+        },
+        data: { status: "published", publishedAt: new Date() },
+      });
+      if (result.count !== ids.length)
+        throw new PublicationError("仕訳の状態が変わりました。画面を再読み込みしてください");
+      if (publishedThrough)
+        await tx.researchFundBook.update({
+          where: { id: BigInt(bookId) },
+          data: { publishedThrough: new Date(publishedThrough) },
+        });
+    });
+  }
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type { Prisma, PrismaClient } from "@prisma/client";
 import {
+  Publication,
   PublicationError,
   type PublicationSnapshot,
   type PublishCandidate,
@@ -60,7 +61,7 @@ export class PrismaPublicationRepository implements PublicationRepository {
         continue;
       }
       // 「費用1行／収入1行」に射影できる仕訳だけを公開の候補にする（それ以外はこの画面で扱えない）。
-      if (rows.length !== 1) continue;
+      if (!Publication.isPublishable(rows.length)) continue;
       candidates.push({ ...rows[0], id: String(entry.id), description: entry.description });
     }
     return {
@@ -79,13 +80,15 @@ export class PrismaPublicationRepository implements PublicationRepository {
     if (!book) return null;
     const entries = await this.prisma.researchFundJournalEntry.findMany({
       where: { bookId: BigInt(bookId), id: { in: ids.map((id) => BigInt(id)) } },
-      select: { id: true, status: true, entryDate: true },
+      include,
     });
     return {
       entries: entries.map((entry) => ({
         id: String(entry.id),
         status: entry.status,
         entryDate: entry.entryDate.toISOString().slice(0, 10),
+        // 候補の適格性は画面と同じ射影で測る（画面に出ない仕訳を公開させない）。
+        rowCount: rowsOf(entry).length,
       })),
       publishedThrough: book.publishedThrough?.toISOString().slice(0, 10) ?? null,
     };
@@ -104,9 +107,16 @@ export class PrismaPublicationRepository implements PublicationRepository {
       });
       if (result.count !== ids.length)
         throw new PublicationError("仕訳の状態が変わりました。画面を再読み込みしてください");
+      // 並行して別の月を公開しても公開範囲が後退しないよう、既存値より新しいときだけ前進させる。
       if (publishedThrough)
-        await tx.researchFundBook.update({
-          where: { id: BigInt(bookId) },
+        await tx.researchFundBook.updateMany({
+          where: {
+            id: BigInt(bookId),
+            OR: [
+              { publishedThrough: null },
+              { publishedThrough: { lt: new Date(publishedThrough) } },
+            ],
+          },
           data: { publishedThrough: new Date(publishedThrough) },
         });
     });

--- a/admin/src/server/contexts/research-fund/presentation/actions/publish-journal-entries.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/publish-journal-entries.ts
@@ -1,0 +1,27 @@
+"use server";
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { PublicationError } from "@/server/contexts/research-fund/domain/models/publication";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { publishJournalEntriesUsecase } from "@/server/contexts/research-fund/presentation/loaders/load-publication";
+
+export async function publishJournalEntries(
+  politicianId: string,
+  bookId: string,
+  ids: readonly string[],
+) {
+  await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    const result = await publishJournalEntriesUsecase().publish(bookId, ids);
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const, ...result };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: error instanceof PublicationError ? error.message : "仕訳の公開に失敗しました",
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-publication.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-publication.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { PublishJournalEntriesUsecase } from "@/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase";
+import { PrismaPublicationRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export function publishJournalEntriesUsecase() {
+  return new PublishJournalEntriesUsecase(
+    new PrismaPublicationRepository(prisma),
+    new WebappCacheInvalidator(),
+  );
+}
+
+export async function loadPublication(politicianId: string, bookId: string) {
+  const target = await requireJournalTarget(politicianId, bookId);
+  if (!target) notFound();
+  return { ...(await publishJournalEntriesUsecase().snapshot(bookId)), target };
+}

--- a/admin/tests/client/lib/research-fund-publish.test.ts
+++ b/admin/tests/client/lib/research-fund-publish.test.ts
@@ -1,0 +1,52 @@
+import { describePublishDelta } from "@/client/lib/research-fund-publish";
+import { aggregateResearchFund, type ResearchFundRow } from "@/shared/research-fund/aggregation";
+
+const accounts = {
+  taxi: { label: "タクシー代", legalLabel: "④ 交通費" },
+  postage: { label: "郵送料", legalLabel: "⑤ 通信費" },
+  "grant-income": { label: "調査研究費収入", legalLabel: "" },
+};
+function aggregate(rows: ResearchFundRow[]) {
+  const result = aggregateResearchFund(rows, accounts);
+  if (result.status === "invalid") throw new Error(result.errors[0].message);
+  return result.value;
+}
+const grant: ResearchFundRow = {
+  date: "2026-02-01",
+  accountKey: "grant-income",
+  amount: 1_000_000,
+  type: "grant",
+};
+const taxi: ResearchFundRow = {
+  date: "2026-08-13",
+  accountKey: "taxi",
+  amount: 1500,
+  type: "expense",
+};
+
+test("費目の増分と未使用の減少を一文にする", () => {
+  expect(describePublishDelta(aggregate([grant]), aggregate([grant, taxi]))).toBe(
+    "公開すると：タクシー代 +¥1,500・未使用 −¥1,500",
+  );
+});
+
+test("費目は増分の大きい順に並べ、未使用は常に末尾に置く", () => {
+  const after = aggregate([
+    grant,
+    taxi,
+    { date: "2026-08-20", accountKey: "postage", amount: 20_000, type: "expense" },
+  ]);
+  expect(describePublishDelta(aggregate([grant]), after)).toBe(
+    "公開すると：郵送料 +¥20,000・タクシー代 +¥1,500・未使用 −¥21,500",
+  );
+});
+
+test("支給を公開すると未使用が増える", () => {
+  expect(describePublishDelta(aggregate([]), aggregate([grant]))).toBe(
+    "公開すると：未使用 +¥1,000,000",
+  );
+});
+
+test("変化が無ければ何も返さない", () => {
+  expect(describePublishDelta(aggregate([grant]), aggregate([grant]))).toBeNull();
+});

--- a/admin/tests/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase.test.ts
@@ -1,0 +1,99 @@
+import { PublishJournalEntriesUsecase } from "@/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase";
+import type { PublishableEntry } from "@/server/contexts/research-fund/domain/models/publication";
+
+const approved: PublishableEntry[] = [
+  { id: "1", status: "approved", entryDate: "2026-08-13" },
+  { id: "2", status: "approved", entryDate: "2026-07-01" },
+];
+
+function setup(
+  overrides: { entries?: PublishableEntry[] | null; publishedThrough?: string | null } = {},
+) {
+  const repository = {
+    snapshot: jest.fn().mockResolvedValue({
+      published: [],
+      candidates: [],
+      accounts: {},
+      publishedThrough: null,
+    }),
+    pending: jest
+      .fn()
+      .mockResolvedValue(
+        overrides.entries === null
+          ? null
+          : {
+              entries: overrides.entries ?? approved,
+              publishedThrough: overrides.publishedThrough ?? null,
+            },
+      ),
+    publish: jest.fn().mockResolvedValue(undefined),
+  };
+  const cacheInvalidator = { invalidateWebappCache: jest.fn().mockResolvedValue(undefined) };
+  return {
+    repository,
+    cacheInvalidator,
+    usecase: new PublishJournalEntriesUsecase(repository, cacheInvalidator),
+  };
+}
+
+test("確認済の仕訳を公開し、公開範囲を最新月末まで進めてwebappのキャッシュを無効化する", async () => {
+  const { repository, cacheInvalidator, usecase } = setup();
+  await expect(usecase.publish("1", ["1", "2"])).resolves.toEqual({
+    count: 2,
+    publishedThrough: "2026-08-31",
+    cacheWarning: null,
+  });
+  expect(repository.publish).toHaveBeenCalledWith("1", ["1", "2"], "2026-08-31");
+  expect(cacheInvalidator.invalidateWebappCache).toHaveBeenCalledTimes(1);
+});
+
+test("下書きが混ざっていたら公開せず、キャッシュにも触らない", async () => {
+  const { repository, cacheInvalidator, usecase } = setup({
+    entries: [approved[0], { id: "2", status: "draft", entryDate: "2026-07-01" }],
+  });
+  await expect(usecase.publish("1", ["1", "2"])).rejects.toThrow("確認済の仕訳だけを公開できます");
+  expect(repository.publish).not.toHaveBeenCalled();
+  expect(cacheInvalidator.invalidateWebappCache).not.toHaveBeenCalled();
+});
+
+test("公開済みの再公開も拒否する", async () => {
+  const { repository, usecase } = setup({
+    entries: [{ id: "1", status: "published", entryDate: "2026-08-13" }],
+  });
+  await expect(usecase.publish("1", ["1"])).rejects.toThrow("確認済の仕訳だけを公開できます");
+  expect(repository.publish).not.toHaveBeenCalled();
+});
+
+test("未選択・不正なID・見つからない仕訳・帳簿なしは公開しない", async () => {
+  const empty = setup();
+  await expect(empty.usecase.publish("1", [])).rejects.toThrow("公開する仕訳を選んでください");
+  await expect(empty.usecase.publish("1", ["0"])).rejects.toThrow("仕訳IDが不正です");
+  await expect(empty.usecase.publish("1", ["1; drop"])).rejects.toThrow("仕訳IDが不正です");
+  expect(empty.repository.publish).not.toHaveBeenCalled();
+  const missing = setup({ entries: [approved[0]] });
+  await expect(missing.usecase.publish("1", ["1", "2"])).rejects.toThrow("選んだ仕訳が見つかりません");
+  const noBook = setup({ entries: null });
+  await expect(noBook.usecase.publish("1", ["1"])).rejects.toThrow("帳簿が見つかりません");
+});
+
+test("重複したIDは1件として扱う", async () => {
+  const { repository, usecase } = setup({ entries: [approved[0]] });
+  await expect(usecase.publish("1", ["1", "1"])).resolves.toMatchObject({ count: 1 });
+  expect(repository.pending).toHaveBeenCalledWith("1", ["1"]);
+  expect(repository.publish).toHaveBeenCalledWith("1", ["1"], "2026-08-31");
+});
+
+test("公開は確定済みなので、キャッシュ無効化の失敗は警告として返す", async () => {
+  const { cacheInvalidator, usecase } = setup({ entries: [approved[0]] });
+  cacheInvalidator.invalidateWebappCache.mockRejectedValue(new Error("接続に失敗しました"));
+  await expect(usecase.publish("1", ["1"])).resolves.toMatchObject({
+    count: 1,
+    cacheWarning: "接続に失敗しました",
+  });
+});
+
+test("帳簿が無ければスナップショットを返さない", async () => {
+  const { repository, usecase } = setup();
+  repository.snapshot.mockResolvedValue(null);
+  await expect(usecase.snapshot("1")).rejects.toThrow("帳簿が見つかりません");
+});

--- a/admin/tests/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/publish-journal-entries-usecase.test.ts
@@ -2,8 +2,8 @@ import { PublishJournalEntriesUsecase } from "@/server/contexts/research-fund/ap
 import type { PublishableEntry } from "@/server/contexts/research-fund/domain/models/publication";
 
 const approved: PublishableEntry[] = [
-  { id: "1", status: "approved", entryDate: "2026-08-13" },
-  { id: "2", status: "approved", entryDate: "2026-07-01" },
+  { id: "1", status: "approved", entryDate: "2026-08-13", rowCount: 1 },
+  { id: "2", status: "approved", entryDate: "2026-07-01", rowCount: 1 },
 ];
 
 function setup(
@@ -49,7 +49,7 @@ test("確認済の仕訳を公開し、公開範囲を最新月末まで進め�
 
 test("下書きが混ざっていたら公開せず、キャッシュにも触らない", async () => {
   const { repository, cacheInvalidator, usecase } = setup({
-    entries: [approved[0], { id: "2", status: "draft", entryDate: "2026-07-01" }],
+    entries: [approved[0], { id: "2", status: "draft", entryDate: "2026-07-01", rowCount: 1 }],
   });
   await expect(usecase.publish("1", ["1", "2"])).rejects.toThrow("確認済の仕訳だけを公開できます");
   expect(repository.publish).not.toHaveBeenCalled();
@@ -58,10 +58,19 @@ test("下書きが混ざっていたら公開せず、キャッシュにも触�
 
 test("公開済みの再公開も拒否する", async () => {
   const { repository, usecase } = setup({
-    entries: [{ id: "1", status: "published", entryDate: "2026-08-13" }],
+    entries: [{ id: "1", status: "published", entryDate: "2026-08-13", rowCount: 1 }],
   });
   await expect(usecase.publish("1", ["1"])).rejects.toThrow("確認済の仕訳だけを公開できます");
   expect(repository.publish).not.toHaveBeenCalled();
+});
+
+test("チェックリストに出ない仕訳（費用1行に射影できない仕訳）は公開しない", async () => {
+  const { repository, cacheInvalidator, usecase } = setup({
+    entries: [{ id: "1", status: "approved", entryDate: "2026-08-13", rowCount: 2 }],
+  });
+  await expect(usecase.publish("1", ["1"])).rejects.toThrow("この画面で公開できない仕訳");
+  expect(repository.publish).not.toHaveBeenCalled();
+  expect(cacheInvalidator.invalidateWebappCache).not.toHaveBeenCalled();
 });
 
 test("未選択・不正なID・見つからない仕訳・帳簿なしは公開しない", async () => {

--- a/admin/tests/server/contexts/research-fund/domain/models/publication.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/publication.test.ts
@@ -1,0 +1,18 @@
+import { Publication } from "@/server/contexts/research-fund/domain/models/publication";
+
+test("公開範囲を公開した仕訳の最新月末まで進める", () => {
+  expect(Publication.advancePublishedThrough(null, ["2026-08-13", "2026-07-01"])).toBe("2026-08-31");
+  expect(Publication.advancePublishedThrough("2026-06-30", ["2026-02-08"])).toBe("2026-06-30");
+  expect(Publication.advancePublishedThrough("2026-06-30", ["2026-07-31"])).toBe("2026-07-31");
+});
+
+test("うるう年の2月と12月の月末を暦どおりに求める", () => {
+  expect(Publication.advancePublishedThrough(null, ["2028-02-01"])).toBe("2028-02-29");
+  expect(Publication.advancePublishedThrough(null, ["2026-02-01"])).toBe("2026-02-28");
+  expect(Publication.advancePublishedThrough(null, ["2026-12-25"])).toBe("2026-12-31");
+});
+
+test("公開する仕訳が無ければ公開範囲は変えない", () => {
+  expect(Publication.advancePublishedThrough("2026-06-30", [])).toBe("2026-06-30");
+  expect(Publication.advancePublishedThrough(null, [])).toBeNull();
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository.test.ts
@@ -1,0 +1,127 @@
+import type { PrismaClient } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+import { PrismaPublicationRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository";
+
+function line(side: "debit" | "credit", accountKey: string, amount: number, type: string) {
+  return {
+    side,
+    accountKey,
+    amount: new Prisma.Decimal(amount),
+    account: { label: accountKey === "taxi" ? "タクシー代" : accountKey, type, legalLabel: null },
+  };
+}
+function entry(overrides: Record<string, unknown>) {
+  return {
+    id: BigInt(1),
+    entryDate: new Date("2026-08-13T00:00:00.000Z"),
+    description: "視察先への移動",
+    status: "approved",
+    lines: [line("debit", "taxi", 1500, "expense"), line("credit", "bank", 1500, "asset")],
+    ...overrides,
+  };
+}
+function setup(journalEntries: ReturnType<typeof entry>[], publishedThrough: Date | null = null) {
+  const tx = {
+    researchFundJournalEntry: {
+      updateMany: jest.fn().mockResolvedValue({ count: journalEntries.length }),
+      findMany: jest.fn().mockResolvedValue(journalEntries),
+    },
+    researchFundBook: {
+      findUnique: jest.fn().mockResolvedValue({ publishedThrough, journalEntries }),
+      update: jest.fn().mockResolvedValue({}),
+    },
+  };
+  const repository = new PrismaPublicationRepository({
+    ...tx,
+    $transaction: jest.fn(async (fn: (client: unknown) => unknown) => fn(tx)),
+  } as unknown as PrismaClient);
+  return { repository, tx };
+}
+
+test("公開済みは集計行に、確認済は公開の候補に振り分ける", async () => {
+  const { repository } = setup([
+    entry({ id: BigInt(1), status: "published" }),
+    entry({
+      id: BigInt(2),
+      status: "approved",
+      entryDate: new Date("2026-09-01T00:00:00.000Z"),
+      description: "調査研究費 9月分",
+      lines: [
+        line("debit", "bank", 1_000_000, "asset"),
+        line("credit", "grant-income", 1_000_000, "income"),
+      ],
+    }),
+  ], new Date("2026-08-31T00:00:00.000Z"));
+  await expect(repository.snapshot("1")).resolves.toEqual({
+    published: [{ date: "2026-08-13", accountKey: "taxi", amount: 1500, type: "expense" }],
+    candidates: [
+      {
+        id: "2",
+        description: "調査研究費 9月分",
+        date: "2026-09-01",
+        accountKey: "grant-income",
+        amount: 1_000_000,
+        type: "grant",
+      },
+    ],
+    accounts: {
+      taxi: { label: "タクシー代", legalLabel: "" },
+      bank: { label: "bank", legalLabel: "" },
+      "grant-income": { label: "grant-income", legalLabel: "" },
+    },
+    publishedThrough: "2026-08-31",
+  });
+});
+
+test("費用1行に射影できない仕訳は公開の候補にしない", async () => {
+  const { repository } = setup([
+    entry({
+      lines: [
+        line("debit", "taxi", 1000, "expense"),
+        line("debit", "postage", 500, "expense"),
+        line("credit", "bank", 1500, "asset"),
+      ],
+    }),
+  ]);
+  await expect(repository.snapshot("1")).resolves.toMatchObject({ candidates: [] });
+});
+
+test("帳簿が無ければ null を返す", async () => {
+  const { repository, tx } = setup([]);
+  tx.researchFundBook.findUnique.mockResolvedValue(null);
+  await expect(repository.snapshot("1")).resolves.toBeNull();
+  await expect(repository.pending("1", ["1"])).resolves.toBeNull();
+});
+
+test("公開対象の現在の状態と帳簿の公開範囲を返す", async () => {
+  const { repository, tx } = setup([entry({})], new Date("2026-07-31T00:00:00.000Z"));
+  await expect(repository.pending("1", ["1"])).resolves.toEqual({
+    entries: [{ id: "1", status: "approved", entryDate: "2026-08-13" }],
+    publishedThrough: "2026-07-31",
+  });
+  expect(tx.researchFundJournalEntry.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({ where: { bookId: BigInt(1), id: { in: [BigInt(1)] } } }),
+  );
+});
+
+test("確認済だけを公開済みにし、公開範囲を更新する", async () => {
+  const { repository, tx } = setup([entry({})]);
+  await repository.publish("1", ["1"], "2026-08-31");
+  expect(tx.researchFundJournalEntry.updateMany).toHaveBeenCalledWith({
+    where: { bookId: BigInt(1), id: { in: [BigInt(1)] }, status: "approved" },
+    data: { status: "published", publishedAt: expect.any(Date) },
+  });
+  expect(tx.researchFundBook.update).toHaveBeenCalledWith({
+    where: { id: BigInt(1) },
+    data: { publishedThrough: new Date("2026-08-31") },
+  });
+});
+
+test("状態が変わって更新できなかった仕訳があればロールバックする", async () => {
+  const { repository, tx } = setup([entry({})]);
+  tx.researchFundJournalEntry.updateMany.mockResolvedValue({ count: 0 });
+  await expect(repository.publish("1", ["1"], "2026-08-31")).rejects.toThrow(
+    "仕訳の状態が変わりました",
+  );
+  expect(tx.researchFundBook.update).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-publication.repository.test.ts
@@ -28,7 +28,7 @@ function setup(journalEntries: ReturnType<typeof entry>[], publishedThrough: Dat
     },
     researchFundBook: {
       findUnique: jest.fn().mockResolvedValue({ publishedThrough, journalEntries }),
-      update: jest.fn().mockResolvedValue({}),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
   };
   const repository = new PrismaPublicationRepository({
@@ -96,7 +96,7 @@ test("帳簿が無ければ null を返す", async () => {
 test("公開対象の現在の状態と帳簿の公開範囲を返す", async () => {
   const { repository, tx } = setup([entry({})], new Date("2026-07-31T00:00:00.000Z"));
   await expect(repository.pending("1", ["1"])).resolves.toEqual({
-    entries: [{ id: "1", status: "approved", entryDate: "2026-08-13" }],
+    entries: [{ id: "1", status: "approved", entryDate: "2026-08-13", rowCount: 1 }],
     publishedThrough: "2026-07-31",
   });
   expect(tx.researchFundJournalEntry.findMany).toHaveBeenCalledWith(
@@ -104,15 +104,33 @@ test("公開対象の現在の状態と帳簿の公開範囲を返す", async ()
   );
 });
 
-test("確認済だけを公開済みにし、公開範囲を更新する", async () => {
+test("候補にできない仕訳の行数もそのまま返し、公開の可否はユースケースが判定できる", async () => {
+  const { repository } = setup([
+    entry({
+      lines: [
+        line("debit", "taxi", 1000, "expense"),
+        line("debit", "postage", 500, "expense"),
+        line("credit", "bank", 1500, "asset"),
+      ],
+    }),
+  ]);
+  await expect(repository.pending("1", ["1"])).resolves.toMatchObject({
+    entries: [{ id: "1", rowCount: 2 }],
+  });
+});
+
+test("確認済だけを公開済みにし、公開範囲は既存値より新しいときだけ前進させる", async () => {
   const { repository, tx } = setup([entry({})]);
   await repository.publish("1", ["1"], "2026-08-31");
   expect(tx.researchFundJournalEntry.updateMany).toHaveBeenCalledWith({
     where: { bookId: BigInt(1), id: { in: [BigInt(1)] }, status: "approved" },
     data: { status: "published", publishedAt: expect.any(Date) },
   });
-  expect(tx.researchFundBook.update).toHaveBeenCalledWith({
-    where: { id: BigInt(1) },
+  expect(tx.researchFundBook.updateMany).toHaveBeenCalledWith({
+    where: {
+      id: BigInt(1),
+      OR: [{ publishedThrough: null }, { publishedThrough: { lt: new Date("2026-08-31") } }],
+    },
     data: { publishedThrough: new Date("2026-08-31") },
   });
 });
@@ -123,5 +141,5 @@ test("状態が変わって更新できなかった仕訳があればロール�
   await expect(repository.publish("1", ["1"], "2026-08-31")).rejects.toThrow(
     "仕訳の状態が変わりました",
   );
-  expect(tx.researchFundBook.update).not.toHaveBeenCalled();
+  expect(tx.researchFundBook.updateMany).not.toHaveBeenCalled();
 });

--- a/webapp/src/app/api/refresh/route.ts
+++ b/webapp/src/app/api/refresh/route.ts
@@ -21,6 +21,8 @@ export async function POST(request: NextRequest) {
     revalidateTag("transactions-for-csv", "max");
     revalidateTag("top-page-data", "max");
     revalidateTag("organizations", "max");
+    // 調研費（admin の公開画面から呼ばれる）。公開ページの loader がこのタグでキャッシュする。
+    revalidateTag("research-fund-page-data", "max");
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
## 目的（Why）

議員室の担当者が「人間の確認を通った仕訳だけを公開したいが、公開したらまる見え側の数字がどう変わるか分からない」という状態を解消するため。
公開前後のサンキーを並べて見せることで、「公開したら想定外の数字になった」を防ぐ。admin から webapp へデータが流れる唯一の出口にあたる画面。

## 変更内容

**公開画面（`/politicians/[id]/books/[bookId]/publish`）**
- 左: 確認済・未公開の仕訳チェックリスト（日付・項目・金額）と「n件（¥合計）を公開する」ボタン（未選択時 disabled）
- 右: サンキー before/after（BEFORE=グレータグ・AFTER=teal タグ。左ノード=支給、右=費目＋末尾に未使用〔淡色・細枠〕）
- チェックの変更で after と差分文（「公開すると：タクシー代 +¥1,500・未使用 −¥1,500」）が即時更新される
  （集計は #1350 の `aggregateResearchFund` をクライアントで呼ぶ。費目は増分の大きい順、未使用は常に末尾）

**公開の処理**
- `PublishJournalEntriesUsecase`: 確認済 → 公開済 の遷移だけを `JournalEntry.transition` で許し、下書き・公開済みの混入を拒否する
- `PrismaPublicationRepository`: `status: "approved"` を条件にした `updateMany` で下書きの公開を DB レベルでも防ぎ、
  件数が合わなければトランザクションごとロールバックする。`published_at` を記録し、帳簿の `published_through` を
  公開した仕訳の最新月末まで進める（既に先まで公開している場合は後退させない）
- 公開後に既存の `WebappCacheInvalidator` で webapp のキャッシュを無効化し、`webapp/api/refresh` に調研費のタグ
  `research-fund-page-data` を足した。公開自体は確定済みなので、無効化の失敗は警告 toast として返す（公開は取り消さない）

**テスト**
- ユニット: 公開範囲の月末計算 / usecase（下書き・公開済み・不正ID・重複ID・キャッシュ失敗）/ リポジトリ / 差分文の生成
- E2E: `admin/e2e/tests/publish.spec.ts`（支給と支出を確認済にする → チェックで差分文が変わる → 公開 → 仕訳一覧が「公開中」、帳簿の公開範囲が更新される）

## サンキーの実装についての補足（Issue のヒントからの逸脱）

Issue 本文は「サンキー実装は webapp の SankeyChart 流用」としていたが、流用せず admin 側に調研費専用の軽量な SVG サンキーを新設した。
webapp の `SankeyChart.tsx`（600行）＋ `useSankeyHelpers.ts`（340行）は政治資金ドメインに強く結合しており
（中央の「合計」ノード前提・万円表記・収入=緑/支出=赤・「現金残高」等のラベル特殊分岐）、調研費の形にもデザイントークンにも合わず、
流用するには稼働中の公開サイトが使う描画コンポーネントに調研費専用の分岐を足すことになるため。
`shared/` の既存の共有物も純粋な TS モジュールのみで、React コンポーネントを共有した前例が無い（`ResearchFundCategoryPill` も admin 側に作り直されている）。
webapp の調研費 公開ページが実装され「2つ目の利用者」ができた時点で共通化するほうが自然なので、#1401 に切り出した。

## ローカル CI

- `pnpm verify`: 通過（admin 1379 passed / 1 skipped、webapp 139 passed、typecheck / lint / knip / depcruise すべて green）
- `pnpm test:e2e:admin`（CI と同じ `--workers=1`）: 37 passed
- webapp の E2E は `organization.spec.ts` の1件が落ちるが、**この変更を stash した状態でも同じく落ちる既存の失敗**であることを確認済み

## スコープアウトして起票した Issue

- #1401 feat(research-fund): 調研費のサンキーを admin の公開プレビューと webapp の公開ページで共通化する

Closes #1358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 確認済みの仕訳を選択して公開できるようになりました。
  - 公開前後の支給額・費目別集計をサンキー図で比較できます。
  - 公開による増減を金額付きで確認できます。
  - 公開範囲や公開状態が保存され、仕訳一覧・帳簿画面にも反映されます。
  - 公開対象外の仕訳を検証し、安全に公開できるようになりました。
  - 公開後は関連ページの表示が自動的に更新されます。

- **テスト**
  - 仕訳の公開、入力検証、集計表示、公開状態の保持に関するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->