### PR TITLE
fix(admin): E2E をローカルでも本番ビルドに当てて不安定な失敗をなくす

### DIFF
--- a/admin/playwright.config.ts
+++ b/admin/playwright.config.ts
@@ -4,6 +4,16 @@ import { defineConfig, devices } from "@playwright/test";
 // storageState を使い回す（spec ごとの beforeEach ログインを廃止）
 export const STORAGE_STATE = "e2e/.output/.auth/user.json";
 
+// E2E は CI と同じ本番ビルド（next build → next start）に対して回す。
+// dev サーバー（Turbopack）だと並行実行中もルートの都度ビルドで Fast Refresh が走り、
+// 配信中の RSC ストリームが中断されることがある
+// （サーバー側 `Error: aborted / ECONNRESET`、ブラウザ側 `Error: Connection closed.`）。
+// ページはハードリロードで復帰するものの、その間はハイドレーション前の SSR された DOM が
+// クリック可能に見えるため、Playwright のクリックがハンドラの付く前に落ちて握り潰される。
+// 「この月を登録」を押しても「登録済み」に変わらない不安定さはこれが原因だった。
+// デバッグで dev サーバーに当てたいときだけ E2E_DEV_SERVER=1 を付ける。
+const useDevServer = process.env.E2E_DEV_SERVER === "1";
+
 export default defineConfig({
   testDir: "./e2e/tests",
   outputDir: "./e2e/.output/test-results",
@@ -28,9 +38,17 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? "pnpm start --port 3001" : "pnpm dev",
+    // CI は前段のステップでビルド済みなのでビルドし直さない。
+    command: process.env.CI
+      ? "pnpm start --port 3001"
+      : useDevServer
+        ? "pnpm dev"
+        : "pnpm build && pnpm start --port 3001",
     url: "http://localhost:3001/login",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    // 既存のサーバーは dev サーバー指定のときだけ再利用する。
+    // 本番ビルドで回す既定では、3001 で動いている dev サーバーを拾って
+    // 上記の不安定さに逆戻りしないよう、明示的に止めてもらう。
+    reuseExistingServer: useDevServer,
+    timeout: 300 * 1000,
   },
 });

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -239,8 +239,12 @@ pnpm supabase:start && pnpm db:reset && pnpm test:e2e
 - `pnpm test:e2e` は webapp → admin の順に実行します。admin だけ回すなら `pnpm test:e2e:admin`
 - `pnpm test:e2e:admin` / `pnpm test:e2e:ui` は起動中の Supabase から接続情報を自動取得するため、
   `admin/.env.local` のキー設定は不要です（`pnpm --filter admin test:e2e` と直接呼ぶ場合は自動取得されません）
-- ポート 3001 で admin の開発サーバーが既に動いている場合はそれを再利用します。
-  環境変数を変えた直後や挙動が怪しいときは、その開発サーバーを止めてから実行してください
+- admin の E2E は CI と同じ本番ビルド（`next build` → `next start --port 3001`）を自動で起動します。
+  ポート 3001 で開発サーバーが動いていると起動できないので、先に止めてください
+  （dev サーバーは並行実行中に Fast Refresh で RSC ストリームが切れ、
+  ハイドレーション前のクリックが握り潰されて E2E が不安定になるため使いません）
+- デバッグ目的で dev サーバーに当てたいときは `E2E_DEV_SERVER=1 pnpm test:e2e:admin`。
+  この場合は起動中の開発サーバーを再利用します（結果は CI と一致しないことがあります）
 
 ```bash
 pnpm test:e2e:admin                    # admin の E2E（ヘッドレス）


### PR DESCRIPTION
## 目的（Why）

admin の E2E をフルで回す開発者・ループセッションが、実装は正しいのに
「この月を登録」が「登録済み」に変わらず落ちる偽陽性に振り回される状態を解消するため。
CI が不定期に赤くなり loop PR のマージが止まる原因でもある。

## 原因

ローカルで `pnpm test:e2e` を回して再現させ、trace を確認した。

- 失敗時、クリックに対応するサーバーアクションの POST が**そもそも飛んでいない**
  （DB にも仕訳が作られていなかったので、再検証待ちや楽観的更新の問題ではない）
- クリックの直前にページで `Error: Connection closed.` が発生し、ハードリロードが走っていた。
  同時刻の dev サーバー側ログは `⨯ Error: aborted { code: 'ECONNRESET' }`
- dev サーバー（Turbopack）は並行実行中もルートを都度ビルドして Fast Refresh を流すため、
  配信中の RSC ストリームが切れる。復帰までの間はハイドレーション前の SSR された DOM が
  クリック可能に見えるので、Playwright のクリックがハンドラの付く前に落ちて握り潰される
- grants だけでなく、同じ run で落ちた journal-review / prompts も同一の `Connection closed.` が出ていた
  （＝ grants 固有のバグではなく、dev サーバーに当てている E2E 全体の問題）

CI は本番ビルド（`pnpm start`）・`workers: 1`・`retries: 2` なので発生確率が下がるだけで、
ローカルは dev サーバー・並行実行・リトライ無しのため頻発していた。

## 変更内容

- `admin/playwright.config.ts`: ローカルの `webServer` を `pnpm dev` から
  `pnpm build && pnpm start --port 3001` に変更（CI は前段でビルド済みなので従来どおり `pnpm start`）
  - `reuseExistingServer` を `false` にし、3001 で動いている dev サーバーを拾って
    元の不安定さに戻らないようにした
  - ビルド込みで足りるよう `timeout` を 300 秒に延長
  - デバッグ用に `E2E_DEV_SERVER=1` を付けたときだけ従来どおり dev サーバーを再利用する
- `docs/getting-started.md`: E2E 節の「開発サーバーを再利用します」を実際の挙動に更新

`expect` のタイムアウトは変更していない（Issue の指定どおり、時間で誤魔化さない）。

## ローカル CI の実行結果

- `pnpm verify` … green（admin 1409 passed / 1 skipped、webapp 139 passed、typecheck・lint・knip・depcruise いずれも違反なし）
- `pnpm supabase:start && pnpm db:reset && pnpm test:e2e` … **5 回連続 green**（webapp 14 passed / admin 46 passed）
  - 修正前は同じ手順で 2 回試して 2 回とも失敗（1 回目 grants のみ、2 回目 grants + journal-review + prompts）

## スコープアウトして起票した Issue

- #1406 webapp E2E: ローカル実行も dev サーバーではなく本番ビルドに当てる（同じ構成が webapp 側に残っている）

Closes #1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 管理画面のE2Eテストが、既定で本番ビルドを使用して実行されるようになりました。
  * E2Eテストの起動待機時間が延長され、実行の安定性が向上しました。
  * `E2E_DEV_SERVER=1` を指定すると、開発サーバーを再利用してテストできます。

* **ドキュメント**
  * 管理画面のE2Eテストの実行方法と、開発サーバー利用時の手順を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->