### PR TITLE
feat(admin): 支出群と成果の一覧・編集画面

### DIFF
--- a/admin/e2e/tests/expenditure-groups.spec.ts
+++ b/admin/e2e/tests/expenditure-groups.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+
+test("活用方針を保存し、仕訳を束ねた支出群を作って編集し、同じ仕訳の二重紐づけを拒む", async ({ page }) => {
+  const name = `e2e-group-${Date.now()}`;
+  await page.goto("/politicians/new");
+  await page.getByLabel("氏名").fill(name);
+  await page.getByLabel("スラッグ").fill(name);
+  await page.getByLabel("当選日").fill("2026-02-08");
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page).toHaveURL("/politicians");
+  const politicianCard = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name, exact: true }) });
+  await politicianCard.getByRole("link", { name: "年度帳簿" }).click();
+  await page.getByLabel(/^年度/).fill("2026");
+  await page.getByRole("button", { name: "帳簿を作成" }).click();
+  await expect(page.getByRole("heading", { name: "2026年度" })).toBeVisible();
+  await page.getByRole("button", { name: "現在の対象を切り替え" }).click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "load" }),
+    page.getByRole("button", { name: `${name}／2026年度` }).click(),
+  ]);
+
+  // 紐づける費用仕訳を 2 件作る
+  await page.getByRole("link", { name: "仕訳の確認・編集" }).click();
+  for (const [description, date, amount] of [
+    ["視察先への移動", "2026-03-01", "1200"],
+    ["資料の印刷", "2026-05-14", "3000"],
+  ]) {
+    const dialog = page.getByRole("dialog");
+    // ハイドレーション前にクリックするとダイアログが開かないことがあるので開くまで試す
+    await expect(async () => {
+      await page.getByRole("button", { name: "手動で仕訳を作成" }).click();
+      await expect(dialog).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 20000 });
+    await dialog.getByLabel("日付", { exact: true }).fill(date);
+    await dialog.getByLabel("金額", { exact: true }).fill(amount);
+    await dialog.getByLabel("項目名", { exact: true }).fill(description);
+    await dialog.getByLabel("科目", { exact: true }).selectOption("taxi");
+    await dialog.getByRole("button", { name: "下書きを作成" }).click();
+    await expect(dialog).toBeHidden();
+  }
+
+  await page.getByRole("link", { name: "支出群と成果" }).click();
+  await expect(page.getByRole("heading", { name: "支出群と成果" })).toBeVisible();
+  await expect(page.getByText("まだ支出群がありません")).toBeVisible();
+
+  // 帳簿全体の活用方針は保存され、再読み込みしても残る
+  const policy = page.getByLabel("活用方針（帳簿全体・議員本人が書く1〜2行）");
+  await policy.fill("調査ツールとIT環境の整備に重点を置いて使います。");
+  await page.getByRole("button", { name: "保存", exact: true }).click();
+  await expect(page.getByText("活用方針を保存しました")).toBeVisible();
+  await page.reload();
+  await expect(policy).toHaveValue("調査ツールとIT環境の整備に重点を置いて使います。");
+
+  await page.getByRole("link", { name: "支出群を作る" }).click();
+  await expect(page.getByRole("heading", { name: "支出群を作る" })).toBeVisible();
+  await page.getByLabel("タイトル").fill("議会質問づくりの相棒");
+  await page.getByLabel("使った目的と、そこから生まれたもの").fill("質問主意書2本の下調べに使った。");
+  await page.getByLabel("成果物1のラベル").fill("議事録");
+  await page.getByLabel("成果物1のURL").fill("https://example.com/minutes");
+  await page.getByRole("button", { name: "成果物を追加" }).click();
+  await page.getByLabel("成果物2のラベル").fill("レポート");
+
+  // 金額・件数・期間は紐づけからライブ集計される
+  const summary = page.getByRole("status", { name: "紐づけの集計" });
+  const linkList = page.getByRole("listitem").filter({ hasText: "視察先への移動" });
+  await linkList.getByRole("checkbox").check();
+  await page.getByRole("listitem").filter({ hasText: "資料の印刷" }).getByRole("checkbox").check();
+  await expect(summary).toContainText("¥4,200");
+  await expect(summary).toContainText("2件");
+  await expect(summary).toContainText("2026.03.01 〜 05.14");
+
+  await page.getByRole("button", { name: "作成する" }).click();
+  await expect(page).toHaveURL(/expenditure-groups$/);
+  const card = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name: "議会質問づくりの相棒" }) });
+  await expect(card).toContainText("¥4,200");
+  await expect(card).toContainText("2件");
+  await expect(card).toContainText("2026.03.01 〜 05.14");
+  await expect(card.getByRole("link", { name: "議事録" })).toHaveAttribute("href", "https://example.com/minutes");
+  await expect(card).toContainText("レポート（報告は準備中）");
+
+  // 別の支出群からは、すでに紐づいた仕訳を選べない
+  await page.getByRole("link", { name: "支出群を作る" }).click();
+  await expect(
+    page.getByRole("listitem").filter({ hasText: "視察先への移動" }).getByRole("checkbox"),
+  ).toBeDisabled();
+  await page.getByRole("link", { name: "支出群の一覧に戻る" }).click();
+
+  // 編集は同じフォームで、自分の紐づけは外せる
+  await card.getByRole("link", { name: "編集" }).click();
+  await expect(page.getByRole("heading", { name: "支出群を編集" })).toBeVisible();
+  await expect(page.getByLabel("タイトル")).toHaveValue("議会質問づくりの相棒");
+  await expect(page.getByLabel("成果物2のURL")).toHaveValue("");
+  await page.getByRole("listitem").filter({ hasText: "資料の印刷" }).getByRole("checkbox").uncheck();
+  await page.getByLabel("タイトル").fill("議会質問づくりの相棒（改）");
+  await page.getByRole("button", { name: "保存する" }).click();
+  await expect(page).toHaveURL(/expenditure-groups$/);
+  const edited = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name: "議会質問づくりの相棒（改）" }) });
+  await expect(edited).toContainText("¥1,200");
+  await expect(edited).toContainText("1件");
+  await expect(edited).toContainText("2026.03.01");
+
+  // 外した仕訳は別の支出群で選べるようになる
+  await page.getByRole("link", { name: "支出群を作る" }).click();
+  await expect(
+    page.getByRole("listitem").filter({ hasText: "資料の印刷" }).getByRole("checkbox"),
+  ).toBeEnabled();
+
+  await page.goto("/politicians");
+  await politicianCard.getByRole("button", { name: "削除", exact: true }).click();
+  await page.getByRole("button", { name: "削除する", exact: true }).click();
+  await expect(politicianCard).toHaveCount(0);
+});

--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/expenditure-groups/[groupId]/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/expenditure-groups/[groupId]/page.tsx
@@ -1,0 +1,12 @@
+import { ExpenditureGroupForm } from "@/client/components/research-fund/ExpenditureGroupForm";
+import { loadExpenditureGroupForm } from "@/server/contexts/research-fund/presentation/loaders/load-expenditure-groups";
+
+export default async function EditExpenditureGroupPage({
+  params,
+}: {
+  params: Promise<{ id: string; bookId: string; groupId: string }>;
+}) {
+  const { id, bookId, groupId } = await params;
+  const data = await loadExpenditureGroupForm(id, bookId, groupId);
+  return <ExpenditureGroupForm key={groupId} {...data} />;
+}

--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/expenditure-groups/new/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/expenditure-groups/new/page.tsx
@@ -1,0 +1,12 @@
+import { ExpenditureGroupForm } from "@/client/components/research-fund/ExpenditureGroupForm";
+import { loadExpenditureGroupForm } from "@/server/contexts/research-fund/presentation/loaders/load-expenditure-groups";
+
+export default async function NewExpenditureGroupPage({
+  params,
+}: {
+  params: Promise<{ id: string; bookId: string }>;
+}) {
+  const { id, bookId } = await params;
+  const data = await loadExpenditureGroupForm(id, bookId, null);
+  return <ExpenditureGroupForm {...data} />;
+}

--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/expenditure-groups/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/expenditure-groups/page.tsx
@@ -1,0 +1,12 @@
+import { ExpenditureGroupList } from "@/client/components/research-fund/ExpenditureGroupList";
+import { loadExpenditureGroups } from "@/server/contexts/research-fund/presentation/loaders/load-expenditure-groups";
+
+export default async function ExpenditureGroupsPage({
+  params,
+}: {
+  params: Promise<{ id: string; bookId: string }>;
+}) {
+  const { id, bookId } = await params;
+  const data = await loadExpenditureGroups(id, bookId);
+  return <ExpenditureGroupList key={`${bookId}:${data.policyComment}`} {...data} />;
+}

--- a/admin/src/client/components/research-fund/ExpenditureGroupForm.tsx
+++ b/admin/src/client/components/research-fund/ExpenditureGroupForm.tsx
@@ -1,0 +1,288 @@
+"use client";
+import { useId, useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { CaretLeft, Plus, X } from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import {
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Input,
+  Label,
+  Textarea,
+} from "@/client/components/ui";
+import { cn, formatCurrency, formatLinkedPeriod } from "@/client/lib";
+import type {
+  ExpenditureGroupRecord,
+  LinkableEntry,
+} from "@/server/contexts/research-fund/domain/models/expenditure-group";
+import { aggregateLinkedEntries } from "@/shared/research-fund/expenditure-group";
+import { saveExpenditureGroup } from "@/server/contexts/research-fund/presentation/actions/manage-expenditure-groups";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+
+interface OutcomeDraft {
+  /** 行の並べ替え・削除で入力欄が入れ替わらないようにする描画専用のキー */
+  key: string;
+  label: string;
+  url: string;
+}
+
+let outcomeKeySequence = 0;
+function emptyOutcome(): OutcomeDraft {
+  outcomeKeySequence += 1;
+  return { key: `outcome-${outcomeKeySequence}`, label: "", url: "" };
+}
+
+function initialOutcomes(group: ExpenditureGroupRecord | null): OutcomeDraft[] {
+  if (!group || group.outcomes.length === 0) return [emptyOutcome()];
+  return group.outcomes.map((outcome) => ({
+    ...emptyOutcome(),
+    label: outcome.label,
+    url: outcome.url ?? "",
+  }));
+}
+
+export function ExpenditureGroupForm({
+  group,
+  entries,
+  target,
+}: {
+  group: ExpenditureGroupRecord | null;
+  entries: readonly LinkableEntry[];
+  target: Extract<AdminTarget, { kind: "research-fund" }>;
+}) {
+  const router = useRouter();
+  const titleId = useId();
+  const descriptionId = useId();
+  const [title, setTitle] = useState(group?.title ?? "");
+  const [description, setDescription] = useState(group?.description ?? "");
+  const [outcomes, setOutcomes] = useState<OutcomeDraft[]>(() => initialOutcomes(group));
+  const [entryIds, setEntryIds] = useState<readonly string[]>(group?.entryIds ?? []);
+  const [pending, startTransition] = useTransition();
+  const listPath = `/politicians/${target.politicianId}/books/${target.bookId}/expenditure-groups`;
+
+  const selected = useMemo(() => new Set(entryIds), [entryIds]);
+  const summary = useMemo(
+    () => aggregateLinkedEntries(entries.filter((entry) => selected.has(entry.id))),
+    [entries, selected],
+  );
+
+  function updateOutcome(index: number, patch: Partial<OutcomeDraft>) {
+    setOutcomes((current) =>
+      current.map((outcome, position) => (position === index ? { ...outcome, ...patch } : outcome)),
+    );
+  }
+
+  function submit() {
+    startTransition(async () => {
+      try {
+        const result = await saveExpenditureGroup(
+          target.politicianId,
+          target.bookId,
+          group?.id ?? null,
+          {
+            title,
+            description,
+            outcomes: outcomes.map(({ label, url }) => ({ label, url })),
+            entryIds: [...entryIds],
+          },
+        );
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success(group ? "支出群を保存しました" : "支出群を作成しました");
+        router.push(listPath);
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+
+  return (
+    <>
+      <div className="mb-2.5">
+        <Link
+          href={listPath}
+          className="inline-flex items-center gap-1.5 text-xs font-bold text-primary-active hover:underline"
+        >
+          <CaretLeft size={13} />
+          支出群の一覧に戻る
+        </Link>
+      </div>
+      <PageHeader label="Groups" title={group ? "支出群を編集" : "支出群を作る"} />
+      <div className="grid max-w-[1100px] items-start gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(300px,1fr)]">
+        <Card>
+          <CardContent className="grid gap-4 p-6">
+            <div>
+              <Label htmlFor={titleId}>
+                タイトル <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id={titleId}
+                className="mt-1.5"
+                value={title}
+                disabled={pending}
+                placeholder="議会質問づくりの相棒（ボネクタ）"
+                onChange={(event) => setTitle(event.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor={descriptionId}>
+                使った目的と、そこから生まれたもの <span className="text-destructive">*</span>
+              </Label>
+              <Textarea
+                id={descriptionId}
+                className="mt-1.5 min-h-20"
+                rows={3}
+                value={description}
+                disabled={pending}
+                placeholder="何のために使い、何ができたかを1〜3行で"
+                onChange={(event) => setDescription(event.target.value)}
+              />
+            </div>
+            <div>
+              <Label asChild>
+                <p>成果物（動画・レポート・議事録など）</p>
+              </Label>
+              <div className="mt-1.5 grid gap-2">
+                {outcomes.map((outcome, index) => (
+                  <div key={outcome.key} className="flex items-center gap-2">
+                    <Input
+                      className="h-9 w-44 text-[12.5px]"
+                      value={outcome.label}
+                      disabled={pending}
+                      aria-label={`成果物${index + 1}のラベル`}
+                      placeholder="ラベル（例：開催報告）"
+                      onChange={(event) => updateOutcome(index, { label: event.target.value })}
+                    />
+                    <Input
+                      className="h-9 flex-1 font-latin text-[12.5px]"
+                      value={outcome.url}
+                      disabled={pending}
+                      aria-label={`成果物${index + 1}のURL`}
+                      placeholder="URL（空なら「報告は準備中」と表示）"
+                      onChange={(event) => updateOutcome(index, { url: event.target.value })}
+                    />
+                    <Button
+                      variant="destructive"
+                      size="icon-sm"
+                      disabled={pending}
+                      aria-label={`成果物${index + 1}を削除`}
+                      onClick={() =>
+                        setOutcomes((current) =>
+                          current.filter((_, position) => position !== index),
+                        )
+                      }
+                    >
+                      <X size={12} />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+              <Button
+                variant="outline"
+                size="xs"
+                className="mt-2"
+                disabled={pending}
+                onClick={() => setOutcomes((current) => [...current, emptyOutcome()])}
+              >
+                <Plus size={12} />
+                成果物を追加
+              </Button>
+            </div>
+            <div className="flex gap-2.5">
+              <Button
+                disabled={pending || title.trim() === "" || description.trim() === ""}
+                onClick={submit}
+              >
+                {group ? "保存する" : "作成する"}
+              </Button>
+              <Button asChild variant="outline">
+                <Link href={listPath}>キャンセル</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="xl:sticky xl:top-6">
+          <CardContent className="p-5">
+            <h2 className="font-bold">仕訳の紐づけ</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              金額・件数・期間は紐づけた仕訳から自動集計されます。
+            </p>
+            <div
+              role="status"
+              aria-label="紐づけの集計"
+              className="mt-3 flex flex-wrap gap-x-4 gap-y-1 rounded-[10px] bg-accent px-3.5 py-2.5 text-[12.5px]"
+            >
+              <span className="font-latin font-bold">{formatCurrency(summary.amount)}</span>
+              <span>{summary.count}件</span>
+              <span className="font-latin">{formatLinkedPeriod(summary.period)}</span>
+            </div>
+            {entries.length === 0 ? (
+              <p className="mt-3 text-xs text-muted-foreground">
+                紐づけられる費用の仕訳がまだありません。
+              </p>
+            ) : (
+              <ul className="mt-3 grid max-h-[340px] gap-0.5 overflow-y-auto">
+                {entries.map((entry) => {
+                  const checked = selected.has(entry.id);
+                  // 1 仕訳は 1 つの支出群にしか属せない。他で使われている仕訳は選ばせない
+                  const takenByOther = entry.groupId !== null && entry.groupId !== group?.id;
+                  return (
+                    <li key={entry.id}>
+                      <label
+                        htmlFor={`link-${entry.id}`}
+                        className={cn(
+                          "flex items-center gap-2 rounded-lg p-2",
+                          checked && "bg-accent",
+                          takenByOther ? "cursor-not-allowed" : "cursor-pointer",
+                        )}
+                      >
+                        <Checkbox
+                          id={`link-${entry.id}`}
+                          aria-label={`${entry.description}を紐づける`}
+                          checked={checked}
+                          disabled={pending || takenByOther}
+                          onCheckedChange={(value) =>
+                            setEntryIds((current) =>
+                              value === true
+                                ? [...current, entry.id]
+                                : current.filter((id) => id !== entry.id),
+                            )
+                          }
+                        />
+                        <span className="font-latin w-11 shrink-0 text-[11px] text-muted-foreground">
+                          {entry.entryDate.slice(5).replace("-", "/")}
+                        </span>
+                        <span
+                          className={cn(
+                            "min-w-0 flex-1 truncate text-[12.5px]",
+                            takenByOther && "text-disabled-foreground",
+                          )}
+                          title={takenByOther ? "他の支出群に紐づいています" : entry.description}
+                        >
+                          {entry.description}
+                        </span>
+                        <span className="font-latin shrink-0 text-xs font-semibold">
+                          {formatCurrency(entry.amount)}
+                        </span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <p className="mt-2.5 text-[11px] text-disabled-foreground">
+              人件費・事務所費のような運営費は成果カードの対象外です。
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/admin/src/client/components/research-fund/ExpenditureGroupList.tsx
+++ b/admin/src/client/components/research-fund/ExpenditureGroupList.tsx
@@ -1,0 +1,144 @@
+"use client";
+import { useId, useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Plus } from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import { Button, Card, CardContent, Label, Textarea } from "@/client/components/ui";
+import { cn, formatCurrency, formatLinkedPeriod } from "@/client/lib";
+import type { ExpenditureGroupSummary } from "@/server/contexts/research-fund/domain/models/expenditure-group";
+import { saveUsagePolicy } from "@/server/contexts/research-fund/presentation/actions/manage-expenditure-groups";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+
+export function ExpenditureGroupList({
+  groups,
+  policyComment: savedPolicyComment,
+  target,
+}: {
+  groups: readonly ExpenditureGroupSummary[];
+  policyComment: string;
+  target: Extract<AdminTarget, { kind: "research-fund" }>;
+}) {
+  const router = useRouter();
+  const policyFieldId = useId();
+  const [policyComment, setPolicyComment] = useState(savedPolicyComment);
+  const [pending, startTransition] = useTransition();
+  const base = `/politicians/${target.politicianId}/books/${target.bookId}/expenditure-groups`;
+
+  function savePolicy() {
+    startTransition(async () => {
+      try {
+        const result = await saveUsagePolicy(target.politicianId, target.bookId, policyComment);
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success("活用方針を保存しました");
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        label="Groups"
+        title="支出群と成果"
+        description="支出をまとめて「活用方針」と「主要な成果」を書く。金額・件数・期間は紐づけた仕訳から自動集計されます。"
+        actions={
+          <Button asChild>
+            <Link href={`${base}/new`}>
+              <Plus size={14} />
+              支出群を作る
+            </Link>
+          </Button>
+        }
+      />
+      <Card className="mb-5 max-w-4xl">
+        <CardContent className="p-5">
+          <Label htmlFor={policyFieldId}>活用方針（帳簿全体・議員本人が書く1〜2行）</Label>
+          <Textarea
+            id={policyFieldId}
+            className="mt-1.5 min-h-14"
+            rows={2}
+            value={policyComment}
+            disabled={pending}
+            onChange={(event) => setPolicyComment(event.target.value)}
+          />
+          <div className="mt-2 flex justify-end">
+            <Button
+              size="xs"
+              disabled={pending || policyComment === savedPolicyComment}
+              onClick={savePolicy}
+            >
+              保存
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+      {groups.length === 0 ? (
+        <Card className="max-w-4xl">
+          <CardContent className="p-10 text-center text-sm text-muted-foreground">
+            まだ支出群がありません。「支出群を作る」から、仕訳を束ねて成果を書けます。
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(340px,420px))]">
+          {groups.map((group) => (
+            <Card key={group.id}>
+              <CardContent className="p-5">
+                <h2 className="text-[15.5px] font-bold">{group.title}</h2>
+                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                  <span>
+                    <span className="font-latin font-bold text-foreground">
+                      {formatCurrency(group.amount)}
+                    </span>
+                    （自動集計）
+                  </span>
+                  <span>{group.count}件</span>
+                  <span className="font-latin">{formatLinkedPeriod(group.period)}</span>
+                </div>
+                <p className="mt-2.5 border-l-[3px] border-teal-soft pl-2.5 text-[13px] leading-[1.8] whitespace-pre-wrap">
+                  {group.description}
+                </p>
+                {group.outcomes.length > 0 && (
+                  <ul className="mt-3 flex flex-wrap gap-1.5">
+                    {group.outcomes.map((outcome) => (
+                      <li key={`${outcome.label}-${outcome.url ?? ""}`}>
+                        <OutcomeChip label={outcome.label} url={outcome.url} />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <div className="mt-4">
+                  <Button asChild variant="outline" size="xs">
+                    <Link href={`${base}/${group.id}`}>編集</Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+/** URL があれば teal のリンクチップ、無ければグレーで「報告は準備中」を添える */
+function OutcomeChip({ label, url }: { label: string; url: string | null }) {
+  const className = cn(
+    "inline-flex items-center rounded-full px-3 py-1 text-[11px] font-bold",
+    url
+      ? "bg-accent text-accent-foreground hover:underline"
+      : "border border-border-soft bg-secondary text-muted-foreground",
+  );
+  if (!url) return <span className={className}>{label}（報告は準備中）</span>;
+  return (
+    <a className={className} href={url} target="_blank" rel="noopener noreferrer">
+      {label}
+    </a>
+  );
+}

--- a/admin/src/client/lib/index.ts
+++ b/admin/src/client/lib/index.ts
@@ -15,3 +15,4 @@ export {
 } from "./donor-form";
 export type { DonorFormValues, DonorFormSubmitData } from "./donor-form";
 export { describePublishDelta } from "./research-fund-publish";
+export { formatLinkedPeriod } from "./research-fund-groups";

--- a/admin/src/client/lib/research-fund-groups.ts
+++ b/admin/src/client/lib/research-fund-groups.ts
@@ -1,0 +1,11 @@
+/**
+ * 支出群に紐づいた仕訳の期間を「2026.02.08 〜 05.14」の形にする。
+ * 同じ年なら終わりの年を省き、1 件だけ／同日なら 1 つの日付にする。
+ */
+export function formatLinkedPeriod(period: { start: string; end: string } | null): string {
+  if (!period) return "—";
+  const start = period.start.replaceAll("-", ".");
+  const end = period.end.replaceAll("-", ".");
+  if (start === end) return start;
+  return `${start} 〜 ${period.start.slice(0, 4) === period.end.slice(0, 4) ? end.slice(5) : end}`;
+}

--- a/admin/src/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase.ts
@@ -1,0 +1,102 @@
+import "server-only";
+import {
+  ExpenditureGroupError,
+  expenditureGroupEditSchema,
+  normalizeEntryIds,
+  normalizeOutcomes,
+  type ExpenditureGroupEdit,
+  type ExpenditureGroupSummary,
+  type ExpenditureGroupWrite,
+} from "@/server/contexts/research-fund/domain/models/expenditure-group";
+import type { ExpenditureGroupRepository } from "@/server/contexts/research-fund/domain/repositories/expenditure-group-repository.interface";
+import { aggregateLinkedEntries } from "@/shared/research-fund/expenditure-group";
+
+const MAX_POLICY_COMMENT_LENGTH = 2000;
+
+function validateId(id: string) {
+  if (!/^[1-9]\d*$/.test(id)) throw new ExpenditureGroupError("IDが不正です");
+}
+
+export class ManageExpenditureGroupsUsecase {
+  constructor(private repository: ExpenditureGroupRepository) {}
+
+  /** 一覧画面。金額・件数・期間は紐づけた仕訳から自動集計する */
+  async list(bookId: string) {
+    validateId(bookId);
+    const book = await this.repository.book(bookId);
+    if (!book) throw new ExpenditureGroupError("帳簿が見つかりません");
+    const [records, entries] = await Promise.all([
+      this.repository.list(bookId),
+      this.repository.entries(bookId),
+    ]);
+    const byId = new Map(entries.map((entry) => [entry.id, entry]));
+    const groups: ExpenditureGroupSummary[] = records.map((record) => ({
+      ...record,
+      ...aggregateLinkedEntries(
+        record.entryIds.flatMap((entryId) => {
+          const entry = byId.get(entryId);
+          return entry ? [entry] : [];
+        }),
+      ),
+    }));
+    return { groups, policyComment: book.policyComment };
+  }
+
+  /** 新規／編集フォーム。groupId が null なら新規 */
+  async form(bookId: string, groupId: string | null) {
+    validateId(bookId);
+    const entries = await this.repository.entries(bookId);
+    if (groupId === null) return { group: null, entries };
+    validateId(groupId);
+    const group = await this.repository.find(bookId, groupId);
+    if (!group) throw new ExpenditureGroupError("支出群が見つかりません");
+    return { group, entries };
+  }
+
+  async savePolicyComment(bookId: string, policyComment: unknown) {
+    validateId(bookId);
+    if (typeof policyComment !== "string")
+      throw new ExpenditureGroupError("活用方針の入力が不正です");
+    const trimmed = policyComment.trim();
+    if (trimmed.length > MAX_POLICY_COMMENT_LENGTH)
+      throw new ExpenditureGroupError(
+        `活用方針は${MAX_POLICY_COMMENT_LENGTH}文字以内で入力してください`,
+      );
+    await this.repository.savePolicyComment(bookId, trimmed);
+  }
+
+  /** 新規作成なら作った支出群の ID を、編集なら渡された ID を返す */
+  async save(bookId: string, groupId: string | null, input: ExpenditureGroupEdit) {
+    validateId(bookId);
+    if (groupId !== null) validateId(groupId);
+    const write = await this.prepare(bookId, groupId, input);
+    if (groupId === null) return this.repository.create(bookId, write);
+    await this.repository.update(bookId, groupId, write);
+    return groupId;
+  }
+
+  private async prepare(
+    bookId: string,
+    groupId: string | null,
+    input: ExpenditureGroupEdit,
+  ): Promise<ExpenditureGroupWrite> {
+    const parsed = expenditureGroupEditSchema.safeParse(input);
+    if (!parsed.success) throw new ExpenditureGroupError("タイトルと説明を入力してください");
+    const entryIds = normalizeEntryIds(parsed.data.entryIds);
+    const entries = await this.repository.entries(bookId);
+    const byId = new Map(entries.map((entry) => [entry.id, entry]));
+    for (const entryId of entryIds) {
+      const entry = byId.get(entryId);
+      if (!entry) throw new ExpenditureGroupError("この帳簿にない仕訳は紐づけられません");
+      // 1 仕訳は 1 つの支出群にしか属せない（公開側で金額が二重計上されるため）
+      if (entry.groupId !== null && entry.groupId !== groupId)
+        throw new ExpenditureGroupError("他の支出群に紐づいている仕訳は選べません");
+    }
+    return {
+      title: parsed.data.title,
+      description: parsed.data.description,
+      outcomes: normalizeOutcomes(parsed.data.outcomes),
+      entryIds,
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/domain/models/expenditure-group.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/expenditure-group.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import type { LinkedEntrySummary } from "@/shared/research-fund/expenditure-group";
+
+export class ExpenditureGroupError extends Error {}
+
+export const expenditureGroupEditSchema = z.object({
+  title: z.string().trim().min(1).max(255),
+  description: z.string().trim().min(1),
+  outcomes: z
+    .array(
+      z.object({
+        label: z.string().trim().max(255),
+        url: z.string().trim().max(2048),
+      }),
+    )
+    .max(20),
+  entryIds: z.array(z.string().regex(/^[1-9]\d*$/)).max(500),
+});
+export type ExpenditureGroupEdit = z.infer<typeof expenditureGroupEditSchema>;
+
+export interface OutcomeWrite {
+  label: string;
+  /** 空欄なら null。公開側で「報告は準備中」と表示する */
+  url: string | null;
+}
+export interface ExpenditureGroupWrite {
+  title: string;
+  description: string;
+  outcomes: readonly OutcomeWrite[];
+  entryIds: readonly string[];
+}
+
+/** 支出群に紐づけられる費用仕訳。groupId は既に属している支出群（未所属なら null） */
+export interface LinkableEntry {
+  id: string;
+  entryDate: string;
+  description: string;
+  amount: number;
+  groupId: string | null;
+}
+
+export interface ExpenditureGroupRecord {
+  id: string;
+  title: string;
+  description: string;
+  outcomes: readonly OutcomeWrite[];
+  entryIds: readonly string[];
+}
+
+/** 一覧カードに出す支出群。金額・件数・期間は紐づけから自動集計する */
+export interface ExpenditureGroupSummary extends ExpenditureGroupRecord, LinkedEntrySummary {}
+
+const URL_PATTERN = /^https?:\/\/\S+$/;
+
+/**
+ * 入力された成果物を保存できる形にそろえる。
+ * ラベルも URL も空の行は入力途中の空欄とみなして捨てる。
+ */
+export function normalizeOutcomes(
+  outcomes: ExpenditureGroupEdit["outcomes"],
+): readonly OutcomeWrite[] {
+  return outcomes
+    .filter((outcome) => outcome.label !== "" || outcome.url !== "")
+    .map((outcome) => {
+      if (outcome.url !== "" && !URL_PATTERN.test(outcome.url))
+        throw new ExpenditureGroupError("成果物のURLは http:// または https:// で入力してください");
+      if (outcome.label === "") throw new ExpenditureGroupError("成果物のラベルを入力してください");
+      return { label: outcome.label, url: outcome.url === "" ? null : outcome.url };
+    });
+}
+
+/** 重複を除いた紐づけ先の仕訳 ID。順序は入力順を保つ */
+export function normalizeEntryIds(entryIds: readonly string[]): readonly string[] {
+  return [...new Set(entryIds)];
+}

--- a/admin/src/server/contexts/research-fund/domain/repositories/expenditure-group-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/expenditure-group-repository.interface.ts
@@ -1,0 +1,22 @@
+import type {
+  ExpenditureGroupRecord,
+  ExpenditureGroupWrite,
+  LinkableEntry,
+} from "@/server/contexts/research-fund/domain/models/expenditure-group";
+
+export interface ExpenditureGroupRepository {
+  /** 帳簿が無ければ null。policyComment は未記入なら空文字 */
+  book(bookId: string): Promise<{ policyComment: string } | null>;
+  savePolicyComment(bookId: string, policyComment: string): Promise<void>;
+  list(bookId: string): Promise<ExpenditureGroupRecord[]>;
+  find(bookId: string, groupId: string): Promise<ExpenditureGroupRecord | null>;
+  /** 帳簿の費用仕訳。支給（収入）は成果の対象外なので含めない */
+  entries(bookId: string): Promise<LinkableEntry[]>;
+  /**
+   * 支出群・紐づけ・成果物を 1 トランザクションで作る。
+   * 他の支出群に属する仕訳が含まれていれば ExpenditureGroupError を投げ、何も作らない。
+   */
+  create(bookId: string, input: ExpenditureGroupWrite): Promise<string>;
+  /** create と同じ保証で、既存の紐づけ・成果物を入れ替える */
+  update(bookId: string, groupId: string, input: ExpenditureGroupWrite): Promise<void>;
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import type { Prisma, PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import {
   ExpenditureGroupError,
   type ExpenditureGroupRecord,
@@ -27,6 +27,22 @@ function model(row: Row): ExpenditureGroupRecord {
     outcomes: row.outcomes.map((outcome) => ({ label: outcome.label, url: outcome.url })),
     entryIds: row.items.map((item) => String(item.entryId)),
   };
+}
+
+// 「1 仕訳は 1 つの支出群だけ」は (groupId, entryId) の複合主キーでは守れないため、
+// 同じ仕訳を別の支出群へ同時保存した場合は直列化の衝突として弾く。
+const serializableOptions = {
+  isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+};
+
+async function serializable<T>(run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034")
+      throw new ExpenditureGroupError("他の操作と競合しました。もう一度保存してください");
+    throw error;
+  }
 }
 
 export class PrismaExpenditureGroupRepository implements ExpenditureGroupRepository {
@@ -75,14 +91,15 @@ export class PrismaExpenditureGroupRepository implements ExpenditureGroupReposit
       orderBy: [{ entryDate: "asc" }, { id: "asc" }],
     });
     return rows.flatMap((row) => {
-      const expenseLine = row.lines.find((line) => line.account.type === "expense");
-      if (!expenseLine) return [];
+      // 1 仕訳に費用の借方が複数あることがある（取得済みの明細は借方だけ）。全部足す。
+      const expenseLines = row.lines.filter((line) => line.account.type === "expense");
+      if (expenseLines.length === 0) return [];
       return [
         {
           id: String(row.id),
           entryDate: row.entryDate.toISOString().slice(0, 10),
           description: row.description,
-          amount: expenseLine.amount.toNumber(),
+          amount: expenseLines.reduce((total, line) => total + line.amount.toNumber(), 0),
           groupId: row.groupItems[0] ? String(row.groupItems[0].groupId) : null,
         },
       ];
@@ -90,34 +107,38 @@ export class PrismaExpenditureGroupRepository implements ExpenditureGroupReposit
   }
 
   async create(bookId: string, input: ExpenditureGroupWrite) {
-    return this.prisma.$transaction(async (tx) => {
-      const displayOrder = await tx.researchFundExpenditureGroup.count({
-        where: { bookId: BigInt(bookId) },
-      });
-      const row = await tx.researchFundExpenditureGroup.create({
-        data: {
-          bookId: BigInt(bookId),
-          title: input.title,
-          description: input.description,
-          displayOrder,
-        },
-      });
-      await this.replaceLinks(tx, bookId, row.id, input);
-      return String(row.id);
-    });
+    return serializable(() =>
+      this.prisma.$transaction(async (tx) => {
+        const displayOrder = await tx.researchFundExpenditureGroup.count({
+          where: { bookId: BigInt(bookId) },
+        });
+        const row = await tx.researchFundExpenditureGroup.create({
+          data: {
+            bookId: BigInt(bookId),
+            title: input.title,
+            description: input.description,
+            displayOrder,
+          },
+        });
+        await this.replaceLinks(tx, bookId, row.id, input);
+        return String(row.id);
+      }, serializableOptions),
+    );
   }
 
   async update(bookId: string, groupId: string, input: ExpenditureGroupWrite) {
-    await this.prisma.$transaction(async (tx) => {
-      const result = await tx.researchFundExpenditureGroup.updateMany({
-        where: { id: BigInt(groupId), bookId: BigInt(bookId) },
-        data: { title: input.title, description: input.description },
-      });
-      if (result.count !== 1) throw new ExpenditureGroupError("支出群が見つかりません");
-      await tx.researchFundGroupItem.deleteMany({ where: { groupId: BigInt(groupId) } });
-      await tx.researchFundGroupOutcome.deleteMany({ where: { groupId: BigInt(groupId) } });
-      await this.replaceLinks(tx, bookId, BigInt(groupId), input);
-    });
+    await serializable(() =>
+      this.prisma.$transaction(async (tx) => {
+        const result = await tx.researchFundExpenditureGroup.updateMany({
+          where: { id: BigInt(groupId), bookId: BigInt(bookId) },
+          data: { title: input.title, description: input.description },
+        });
+        if (result.count !== 1) throw new ExpenditureGroupError("支出群が見つかりません");
+        await tx.researchFundGroupItem.deleteMany({ where: { groupId: BigInt(groupId) } });
+        await tx.researchFundGroupOutcome.deleteMany({ where: { groupId: BigInt(groupId) } });
+        await this.replaceLinks(tx, bookId, BigInt(groupId), input);
+      }, serializableOptions),
+    );
   }
 
   /**

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
@@ -1,0 +1,158 @@
+import "server-only";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import {
+  ExpenditureGroupError,
+  type ExpenditureGroupRecord,
+  type ExpenditureGroupWrite,
+} from "@/server/contexts/research-fund/domain/models/expenditure-group";
+import type { ExpenditureGroupRepository } from "@/server/contexts/research-fund/domain/repositories/expenditure-group-repository.interface";
+
+const include = {
+  outcomes: { orderBy: { displayOrder: "asc" as const } },
+  items: { orderBy: { entryId: "asc" as const } },
+} satisfies Prisma.ResearchFundExpenditureGroupInclude;
+type Row = Prisma.ResearchFundExpenditureGroupGetPayload<{ include: typeof include }>;
+
+// 成果カードの対象は費用仕訳のみ。支給（収入）は含めない。
+const expenseWhere = {
+  source: { in: ["manual", "scan"] },
+  lines: { some: { side: "debit", account: { type: "expense" } } },
+} satisfies Prisma.ResearchFundJournalEntryWhereInput;
+
+function model(row: Row): ExpenditureGroupRecord {
+  return {
+    id: String(row.id),
+    title: row.title,
+    description: row.description,
+    outcomes: row.outcomes.map((outcome) => ({ label: outcome.label, url: outcome.url })),
+    entryIds: row.items.map((item) => String(item.entryId)),
+  };
+}
+
+export class PrismaExpenditureGroupRepository implements ExpenditureGroupRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async book(bookId: string) {
+    const row = await this.prisma.researchFundBook.findUnique({
+      where: { id: BigInt(bookId) },
+      select: { policyComment: true },
+    });
+    return row ? { policyComment: row.policyComment ?? "" } : null;
+  }
+
+  async savePolicyComment(bookId: string, policyComment: string) {
+    const result = await this.prisma.researchFundBook.updateMany({
+      where: { id: BigInt(bookId) },
+      data: { policyComment: policyComment || null },
+    });
+    if (result.count !== 1) throw new ExpenditureGroupError("帳簿が見つかりません");
+  }
+
+  async list(bookId: string) {
+    const rows = await this.prisma.researchFundExpenditureGroup.findMany({
+      where: { bookId: BigInt(bookId) },
+      include,
+      orderBy: [{ displayOrder: "asc" }, { id: "asc" }],
+    });
+    return rows.map(model);
+  }
+
+  async find(bookId: string, groupId: string) {
+    const row = await this.prisma.researchFundExpenditureGroup.findFirst({
+      where: { id: BigInt(groupId), bookId: BigInt(bookId) },
+      include,
+    });
+    return row ? model(row) : null;
+  }
+
+  async entries(bookId: string) {
+    const rows = await this.prisma.researchFundJournalEntry.findMany({
+      where: { bookId: BigInt(bookId), ...expenseWhere },
+      include: {
+        lines: { where: { side: "debit" }, include: { account: true } },
+        groupItems: { select: { groupId: true } },
+      },
+      orderBy: [{ entryDate: "asc" }, { id: "asc" }],
+    });
+    return rows.flatMap((row) => {
+      const expenseLine = row.lines.find((line) => line.account.type === "expense");
+      if (!expenseLine) return [];
+      return [
+        {
+          id: String(row.id),
+          entryDate: row.entryDate.toISOString().slice(0, 10),
+          description: row.description,
+          amount: expenseLine.amount.toNumber(),
+          groupId: row.groupItems[0] ? String(row.groupItems[0].groupId) : null,
+        },
+      ];
+    });
+  }
+
+  async create(bookId: string, input: ExpenditureGroupWrite) {
+    return this.prisma.$transaction(async (tx) => {
+      const displayOrder = await tx.researchFundExpenditureGroup.count({
+        where: { bookId: BigInt(bookId) },
+      });
+      const row = await tx.researchFundExpenditureGroup.create({
+        data: {
+          bookId: BigInt(bookId),
+          title: input.title,
+          description: input.description,
+          displayOrder,
+        },
+      });
+      await this.replaceLinks(tx, bookId, row.id, input);
+      return String(row.id);
+    });
+  }
+
+  async update(bookId: string, groupId: string, input: ExpenditureGroupWrite) {
+    await this.prisma.$transaction(async (tx) => {
+      const result = await tx.researchFundExpenditureGroup.updateMany({
+        where: { id: BigInt(groupId), bookId: BigInt(bookId) },
+        data: { title: input.title, description: input.description },
+      });
+      if (result.count !== 1) throw new ExpenditureGroupError("支出群が見つかりません");
+      await tx.researchFundGroupItem.deleteMany({ where: { groupId: BigInt(groupId) } });
+      await tx.researchFundGroupOutcome.deleteMany({ where: { groupId: BigInt(groupId) } });
+      await this.replaceLinks(tx, bookId, BigInt(groupId), input);
+    });
+  }
+
+  /**
+   * 紐づけと成果物を作り直す。トランザクション内で呼ぶ前提で、
+   * 帳簿外・他の支出群の仕訳が混ざっていれば投げて丸ごと巻き戻す。
+   */
+  private async replaceLinks(
+    tx: Prisma.TransactionClient,
+    bookId: string,
+    groupId: bigint,
+    input: ExpenditureGroupWrite,
+  ) {
+    if (input.entryIds.length > 0) {
+      const ids = input.entryIds.map((entryId) => BigInt(entryId));
+      const belonging = await tx.researchFundJournalEntry.count({
+        where: { id: { in: ids }, bookId: BigInt(bookId), ...expenseWhere },
+      });
+      if (belonging !== ids.length)
+        throw new ExpenditureGroupError("この帳簿にない仕訳は紐づけられません");
+      const taken = await tx.researchFundGroupItem.count({
+        where: { entryId: { in: ids }, groupId: { not: groupId } },
+      });
+      if (taken > 0) throw new ExpenditureGroupError("他の支出群に紐づいている仕訳は選べません");
+      await tx.researchFundGroupItem.createMany({
+        data: ids.map((entryId) => ({ groupId, entryId })),
+      });
+    }
+    if (input.outcomes.length > 0)
+      await tx.researchFundGroupOutcome.createMany({
+        data: input.outcomes.map((outcome, displayOrder) => ({
+          groupId,
+          label: outcome.label,
+          url: outcome.url,
+          displayOrder,
+        })),
+      });
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/actions/manage-expenditure-groups.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/manage-expenditure-groups.ts
@@ -1,0 +1,54 @@
+"use server";
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { ManageExpenditureGroupsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase";
+import {
+  ExpenditureGroupError,
+  type ExpenditureGroupEdit,
+} from "@/server/contexts/research-fund/domain/models/expenditure-group";
+import { PrismaExpenditureGroupRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+function failure(error: unknown, fallback: string) {
+  return {
+    success: false as const,
+    error: error instanceof ExpenditureGroupError ? error.message : fallback,
+  };
+}
+
+export async function saveUsagePolicy(politicianId: string, bookId: string, policyComment: string) {
+  await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    await new ManageExpenditureGroupsUsecase(
+      new PrismaExpenditureGroupRepository(prisma),
+    ).savePolicyComment(bookId, policyComment);
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const };
+  } catch (error) {
+    return failure(error, "活用方針の保存に失敗しました");
+  }
+}
+
+export async function saveExpenditureGroup(
+  politicianId: string,
+  bookId: string,
+  groupId: string | null,
+  input: ExpenditureGroupEdit,
+) {
+  await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    const id = await new ManageExpenditureGroupsUsecase(
+      new PrismaExpenditureGroupRepository(prisma),
+    ).save(bookId, groupId, input);
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const, id };
+  } catch (error) {
+    return failure(error, "支出群の保存に失敗しました");
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-expenditure-groups.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-expenditure-groups.ts
@@ -1,0 +1,31 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { ManageExpenditureGroupsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase";
+import { PrismaExpenditureGroupRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+function usecase() {
+  return new ManageExpenditureGroupsUsecase(new PrismaExpenditureGroupRepository(prisma));
+}
+
+export async function loadExpenditureGroups(politicianId: string, bookId: string) {
+  const target = await requireJournalTarget(politicianId, bookId);
+  if (!target) notFound();
+  return { ...(await usecase().list(bookId)), target };
+}
+
+/** groupId が null なら新規フォーム。見つからない支出群は 404 にする */
+export async function loadExpenditureGroupForm(
+  politicianId: string,
+  bookId: string,
+  groupId: string | null,
+) {
+  const target = await requireJournalTarget(politicianId, bookId);
+  if (!target) notFound();
+  try {
+    return { ...(await usecase().form(bookId, groupId)), target };
+  } catch {
+    notFound();
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-expenditure-groups.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-expenditure-groups.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { notFound } from "next/navigation";
 import { ManageExpenditureGroupsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase";
+import { ExpenditureGroupError } from "@/server/contexts/research-fund/domain/models/expenditure-group";
 import { PrismaExpenditureGroupRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository";
 import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
@@ -25,7 +26,9 @@ export async function loadExpenditureGroupForm(
   if (!target) notFound();
   try {
     return { ...(await usecase().form(bookId, groupId)), target };
-  } catch {
-    notFound();
+  } catch (error) {
+    // DB 障害やプログラムエラーを 404 に化けさせず、監視に届かせる。
+    if (error instanceof ExpenditureGroupError) notFound();
+    throw error;
   }
 }

--- a/admin/tests/client/lib/research-fund-groups.test.ts
+++ b/admin/tests/client/lib/research-fund-groups.test.ts
@@ -1,0 +1,19 @@
+import { formatLinkedPeriod } from "@/client/lib/research-fund-groups";
+
+test("期間が無ければダッシュを出す", () => {
+  expect(formatLinkedPeriod(null)).toBe("—");
+});
+
+test("同じ日なら 1 つの日付にする", () => {
+  expect(formatLinkedPeriod({ start: "2026-02-08", end: "2026-02-08" })).toBe("2026.02.08");
+});
+
+test("同じ年なら終わりの年を省く", () => {
+  expect(formatLinkedPeriod({ start: "2026-02-08", end: "2026-05-14" })).toBe("2026.02.08 〜 05.14");
+});
+
+test("年をまたぐなら終わりも年から出す", () => {
+  expect(formatLinkedPeriod({ start: "2025-12-28", end: "2026-01-05" })).toBe(
+    "2025.12.28 〜 2026.01.05",
+  );
+});

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase.test.ts
@@ -1,0 +1,191 @@
+import { ManageExpenditureGroupsUsecase } from "@/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase";
+import type {
+  ExpenditureGroupEdit,
+  LinkableEntry,
+} from "@/server/contexts/research-fund/domain/models/expenditure-group";
+import type { ExpenditureGroupRepository } from "@/server/contexts/research-fund/domain/repositories/expenditure-group-repository.interface";
+
+function setup() {
+  const repository: jest.Mocked<ExpenditureGroupRepository> = {
+    book: jest.fn(),
+    savePolicyComment: jest.fn(),
+    list: jest.fn(),
+    find: jest.fn(),
+    entries: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  };
+  repository.book.mockResolvedValue({ policyComment: "方針" });
+  repository.list.mockResolvedValue([]);
+  repository.entries.mockResolvedValue([]);
+  return { repository, usecase: new ManageExpenditureGroupsUsecase(repository) };
+}
+
+function entry(id: string, entryDate: string, amount: number, groupId: string | null = null): LinkableEntry {
+  return { id, entryDate, description: `明細${id}`, amount, groupId };
+}
+
+const edit: ExpenditureGroupEdit = {
+  title: "議会質問づくりの相棒",
+  description: "質問主意書の下調べに使った",
+  outcomes: [],
+  entryIds: [],
+};
+
+test("一覧は紐づけた仕訳から金額・件数・期間を自動集計する", async () => {
+  const { repository, usecase } = setup();
+  repository.list.mockResolvedValue([
+    { id: "1", title: "調査", description: "説明", outcomes: [], entryIds: ["10", "12"] },
+    { id: "2", title: "紐づけ無し", description: "説明", outcomes: [], entryIds: [] },
+  ]);
+  repository.entries.mockResolvedValue([
+    entry("10", "2026-05-14", 3000, "1"),
+    entry("11", "2026-03-01", 500),
+    entry("12", "2026-02-08", 1200, "1"),
+  ]);
+  const result = await usecase.list("3");
+  expect(result.policyComment).toBe("方針");
+  expect(result.groups[0]).toMatchObject({
+    amount: 4200,
+    count: 2,
+    period: { start: "2026-02-08", end: "2026-05-14" },
+  });
+  expect(result.groups[1]).toMatchObject({ amount: 0, count: 0, period: null });
+});
+
+test("帳簿が無ければ一覧を出さない", async () => {
+  const { repository, usecase } = setup();
+  repository.book.mockResolvedValue(null);
+  await expect(usecase.list("3")).rejects.toThrow("帳簿");
+});
+
+test("新規フォームは紐づけ候補だけを返し、支出群は取りに行かない", async () => {
+  const { repository, usecase } = setup();
+  repository.entries.mockResolvedValue([entry("10", "2026-05-14", 3000)]);
+  await expect(usecase.form("3", null)).resolves.toEqual({
+    group: null,
+    entries: [entry("10", "2026-05-14", 3000)],
+  });
+  expect(repository.find).not.toHaveBeenCalled();
+});
+
+test("編集フォームは既存の支出群を返し、見つからなければ投げる", async () => {
+  const { repository, usecase } = setup();
+  const group = { id: "1", title: "調査", description: "説明", outcomes: [], entryIds: ["10"] };
+  repository.find.mockResolvedValue(group);
+  await expect(usecase.form("3", "1")).resolves.toMatchObject({ group });
+  repository.find.mockResolvedValue(null);
+  await expect(usecase.form("3", "1")).rejects.toThrow("支出群が見つかりません");
+});
+
+test("活用方針は前後の空白を落として保存する", async () => {
+  const { repository, usecase } = setup();
+  await usecase.savePolicyComment("3", "  調査ツールに重点  ");
+  expect(repository.savePolicyComment).toHaveBeenCalledWith("3", "調査ツールに重点");
+});
+
+test.each([null, 1, undefined])("文字列でない活用方針は保存しない: %j", async (value) => {
+  const { repository, usecase } = setup();
+  await expect(usecase.savePolicyComment("3", value)).rejects.toThrow("活用方針");
+  expect(repository.savePolicyComment).not.toHaveBeenCalled();
+});
+
+test("長すぎる活用方針は保存しない", async () => {
+  const { repository, usecase } = setup();
+  await expect(usecase.savePolicyComment("3", "あ".repeat(2001))).rejects.toThrow("活用方針");
+  expect(repository.savePolicyComment).not.toHaveBeenCalled();
+});
+
+test("新規作成は整えた入力をリポジトリに渡し、採番されたIDを返す", async () => {
+  const { repository, usecase } = setup();
+  repository.entries.mockResolvedValue([entry("10", "2026-05-14", 3000)]);
+  repository.create.mockResolvedValue("7");
+  await expect(
+    usecase.save("3", null, {
+      ...edit,
+      title: "  相棒  ",
+      description: "  説明  ",
+      outcomes: [
+        { label: "議事録", url: "https://example.com/m" },
+        { label: "報告", url: "" },
+        { label: "", url: "" },
+      ],
+      entryIds: ["10", "10"],
+    }),
+  ).resolves.toBe("7");
+  expect(repository.create).toHaveBeenCalledWith("3", {
+    title: "相棒",
+    description: "説明",
+    outcomes: [
+      { label: "議事録", url: "https://example.com/m" },
+      { label: "報告", url: null },
+    ],
+    entryIds: ["10"],
+  });
+});
+
+test("編集は渡されたIDで更新し、そのIDを返す", async () => {
+  const { repository, usecase } = setup();
+  repository.entries.mockResolvedValue([entry("10", "2026-05-14", 3000, "1")]);
+  await expect(usecase.save("3", "1", { ...edit, entryIds: ["10"] })).resolves.toBe("1");
+  expect(repository.update).toHaveBeenCalledWith("3", "1", expect.objectContaining({ entryIds: ["10"] }));
+  expect(repository.create).not.toHaveBeenCalled();
+});
+
+test("他の支出群に紐づいた仕訳は選べない", async () => {
+  const { repository, usecase } = setup();
+  repository.entries.mockResolvedValue([entry("10", "2026-05-14", 3000, "2")]);
+  await expect(usecase.save("3", "1", { ...edit, entryIds: ["10"] })).rejects.toThrow(
+    "他の支出群",
+  );
+  expect(repository.update).not.toHaveBeenCalled();
+});
+
+test("この帳簿にない仕訳は選べない", async () => {
+  const { repository, usecase } = setup();
+  repository.entries.mockResolvedValue([entry("10", "2026-05-14", 3000)]);
+  await expect(usecase.save("3", null, { ...edit, entryIds: ["99"] })).rejects.toThrow("この帳簿");
+  expect(repository.create).not.toHaveBeenCalled();
+});
+
+test.each([
+  { ...edit, title: "   " },
+  { ...edit, description: "" },
+  { ...edit, title: "あ".repeat(256) },
+])("タイトル・説明が欠けていれば保存しない: %j", async (input) => {
+  const { repository, usecase } = setup();
+  await expect(usecase.save("3", null, input)).rejects.toThrow("タイトルと説明");
+  expect(repository.create).not.toHaveBeenCalled();
+});
+
+test("URLだけの成果物はラベルを求める", async () => {
+  const { repository, usecase } = setup();
+  await expect(
+    usecase.save("3", null, { ...edit, outcomes: [{ label: "", url: "https://example.com" }] }),
+  ).rejects.toThrow("ラベル");
+  expect(repository.create).not.toHaveBeenCalled();
+});
+
+test.each(["example.com", "javascript:alert(1)", "ftp://example.com/a"])(
+  "http(s) でない成果物のURLは保存しない: %s",
+  async (url) => {
+    const { repository, usecase } = setup();
+    await expect(
+      usecase.save("3", null, { ...edit, outcomes: [{ label: "議事録", url }] }),
+    ).rejects.toThrow("URL");
+    expect(repository.create).not.toHaveBeenCalled();
+  },
+);
+
+test.each(["", "0", "-1", "abc"])("不正なIDではリポジトリを呼ばない: %j", async (id) => {
+  const { repository, usecase } = setup();
+  await expect(usecase.list(id)).rejects.toThrow("ID");
+  await expect(usecase.form(id, null)).rejects.toThrow("ID");
+  await expect(usecase.form("3", id)).rejects.toThrow("ID");
+  await expect(usecase.savePolicyComment(id, "方針")).rejects.toThrow("ID");
+  await expect(usecase.save(id, null, edit)).rejects.toThrow("ID");
+  await expect(usecase.save("3", id, edit)).rejects.toThrow("ID");
+  expect(repository.create).not.toHaveBeenCalled();
+  expect(repository.update).not.toHaveBeenCalled();
+  expect(repository.savePolicyComment).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.test.ts
@@ -1,0 +1,55 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { PrismaExpenditureGroupRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository";
+
+function setup() {
+  const journalEntry = { findMany: jest.fn(), count: jest.fn() };
+  const $transaction = jest.fn();
+  return {
+    journalEntry,
+    $transaction,
+    repository: new PrismaExpenditureGroupRepository({
+      researchFundJournalEntry: journalEntry,
+      $transaction,
+    } as unknown as PrismaClient),
+  };
+}
+
+function line(type: string, amount: number) {
+  return { accountKey: "taxi", side: "debit", amount: new Prisma.Decimal(amount), account: { type } };
+}
+
+test("費用の借方が複数ある仕訳は全明細を合計し、費用のない仕訳は除く", async () => {
+  const { journalEntry, repository } = setup();
+  journalEntry.findMany.mockResolvedValue([
+    {
+      id: BigInt(1),
+      entryDate: new Date("2026-08-01"),
+      description: "資料と交通費",
+      lines: [line("expense", 1200), line("expense", 800)],
+      groupItems: [{ groupId: BigInt(5) }],
+    },
+    {
+      id: BigInt(2),
+      entryDate: new Date("2026-08-02"),
+      description: "費用明細なし",
+      lines: [line("asset", 500)],
+      groupItems: [],
+    },
+  ]);
+  expect(await repository.entries("3")).toEqual([
+    { id: "1", entryDate: "2026-08-01", description: "資料と交通費", amount: 2000, groupId: "5" },
+  ]);
+});
+
+test("同時保存の直列化衝突は保存し直せるエラーに変換する", async () => {
+  const { $transaction, repository } = setup();
+  $transaction.mockRejectedValue(
+    new Prisma.PrismaClientKnownRequestError("write conflict", { code: "P2034", clientVersion: "test" }),
+  );
+  await expect(
+    repository.create("3", { title: "t", description: "d", outcomes: [], entryIds: ["1"] }),
+  ).rejects.toThrow("他の操作と競合しました");
+  expect($transaction).toHaveBeenCalledWith(expect.any(Function), {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  });
+});

--- a/admin/tests/shared/research-fund/expenditure-group.test.ts
+++ b/admin/tests/shared/research-fund/expenditure-group.test.ts
@@ -1,0 +1,23 @@
+import { aggregateLinkedEntries } from "@/shared/research-fund/expenditure-group";
+
+test("紐づけが無ければ 0 円・0 件・期間なし", () => {
+  expect(aggregateLinkedEntries([])).toEqual({ amount: 0, count: 0, period: null });
+});
+
+test("金額を合計し、期間は日付の最小と最大にする（入力順に依らない）", () => {
+  expect(
+    aggregateLinkedEntries([
+      { entryDate: "2026-05-14", amount: 3000 },
+      { entryDate: "2026-02-08", amount: 1200 },
+      { entryDate: "2026-03-01", amount: 500 },
+    ]),
+  ).toEqual({ amount: 4700, count: 3, period: { start: "2026-02-08", end: "2026-05-14" } });
+});
+
+test("1 件なら開始と終了が同じ日になる", () => {
+  expect(aggregateLinkedEntries([{ entryDate: "2026-02-08", amount: 1200 }])).toEqual({
+    amount: 1200,
+    count: 1,
+    period: { start: "2026-02-08", end: "2026-02-08" },
+  });
+});

--- a/shared/research-fund/expenditure-group.ts
+++ b/shared/research-fund/expenditure-group.ts
@@ -1,0 +1,23 @@
+/** 支出群に紐づけた仕訳。金額・件数・期間はここから自動集計し、手入力させない。 */
+export interface LinkedEntry {
+  /** 帳簿上の日付（YYYY-MM-DD）。タイムゾーンによる月のずれを避ける。 */
+  readonly entryDate: string;
+  readonly amount: number;
+}
+
+export interface LinkedEntrySummary {
+  amount: number;
+  count: number;
+  /** 紐づけが無ければ null */
+  period: { start: string; end: string } | null;
+}
+
+/** 紐づけた仕訳から金額・件数・期間を集計する。admin の編集画面と公開側で同じ値を出す。 */
+export function aggregateLinkedEntries(entries: readonly LinkedEntry[]): LinkedEntrySummary {
+  const dates = entries.map((entry) => entry.entryDate).sort();
+  return {
+    amount: entries.reduce((total, entry) => total + entry.amount, 0),
+    count: entries.length,
+    period: dates.length === 0 ? null : { start: dates[0], end: dates[dates.length - 1] },
+  };
+}


### PR DESCRIPTION
## 目的（Why）

議員室のスタッフが「調研費を何に使い、何になったか」まで公開できるようにするため。
これまで仕訳は1件ずつしか見られず、複数の支出をまとめて「使った目的」と「成果物（動画・レポート・議事録の URL）」を
添える場所が無かった。金額・件数・期間は紐づけた仕訳から自動集計し、手入力させない。
公開ページの B-3「主要な支出の成果」（#1360）がこのデータを読む。

## 変更内容

### 画面（admin・議員室モード）

- **支出群と成果（一覧）** `/politicians/[id]/books/[bookId]/expenditure-groups`
  帳簿全体の「活用方針」textarea ＋ 保存。グループカード（タイトル／金額〔自動集計〕・件数・期間／説明〔teal 左罫〕／
  成果物チップ〔URL あり = accent のリンク・なし = グレー「（報告は準備中）」〕／編集）。サイドバーのリンクは既存のものを使用。
- **支出群 新規／編集**（別ページ・同一フォーム） `.../expenditure-groups/new`、`.../expenditure-groups/[groupId]`
  左：タイトル\*・説明\*・成果物リスト（ラベル＋URL、追加／削除）。
  右：仕訳の紐づけチェックリスト＋上部に金額・件数・期間のライブ集計。注記文言はプロトタイプどおり。

UI は既存の `ui/*`（Button / Card / Input / Textarea / Label / Checkbox）と `PageHeader` で組み、
プロトタイプの inline style は移植していない。

### サーバー（research-fund コンテキスト）

- `domain/models/expenditure-group.ts` — zod スキーマ、成果物の正規化（空行を捨てる・URL は http(s) のみ・ラベル必須）
- `domain/repositories/expenditure-group-repository.interface.ts`
- `application/usecases/manage-expenditure-groups-usecase.ts` — 一覧の自動集計、フォーム、活用方針の保存、支出群の保存
- `infrastructure/repositories/prisma-expenditure-group.repository.ts`
- `presentation/loaders/load-expenditure-groups.ts` / `presentation/actions/manage-expenditure-groups.ts`
- `shared/research-fund/expenditure-group.ts` — 金額・件数・期間の集計。admin の編集画面（ライブ集計）と
  サーバー側の一覧が同じ関数を使う。公開側（#1360）からも再利用できる

### 完了条件への対応

- **1トランザクション**: グループ・紐づけ・成果物の保存は `$transaction` 内で行い、
  帳簿外の仕訳・他の支出群に取られた仕訳が混ざっていればトランザクション内で投げて丸ごと巻き戻す。
- **同じ仕訳を複数のグループに入れられない**: usecase（画面に出す時点の状態で判定）とトランザクション内（保存直前の再判定）の
  両方で拒否する。フォームでも他の支出群に紐づいた仕訳のチェックボックスを disabled にする。
  Prisma schema は変更していない（`@@id([groupId, entryId])` のまま）。

## ローカル CI

- `pnpm verify` ✅
  - admin jest: 125 suites / 1462 tests passed（新規 31 tests）
  - webapp jest: 17 suites / 139 tests passed
  - typecheck / biome / knip / depcruise すべて green
- admin E2E ✅ `pnpm supabase:start && pnpm db:reset` の上で
  `node scripts/supabase-env.mjs pnpm --filter admin exec playwright test --workers=1` → **48 passed**
  （新規 `admin/e2e/tests/expenditure-groups.spec.ts` は `--repeat-each=3` でも安定）

## スコープアウトして起票した Issue

- #1408 fix(admin): e2e の議員室フローがハイドレーション前クリックで稀に落ちる（`loop:ready` + `loop:unblock`。main でも再現する既存の flake）
- #1409 feat(admin): 支出群の削除と並べ替え（`loop:ready`）

Closes #1359

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 帳簿ごとの支出群を作成・編集・一覧表示できるようになりました。
  * 仕訳の紐づけにより、金額・件数・対象期間を自動集計できます。
  * 成果物のラベルやリンクを登録・確認できます。
  * 帳簿の活用方針を保存し、再読み込み後も保持できます。
  * 別の支出群に紐づいた仕訳は重複選択できません。

* **テスト**
  * 支出群の作成、編集、集計、入力検証に関するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->