### PR TITLE
test(admin): e2e のハイドレーション前クリックを clickUntil で待つ

### DIFF
--- a/admin/e2e/helpers/interactions.ts
+++ b/admin/e2e/helpers/interactions.ts
@@ -1,0 +1,49 @@
+import { expect, type Locator } from "@playwright/test";
+
+// 1 回の試行で「クリックが効いたか」を見極める猶予
+const ATTEMPT_TIMEOUT = 5_000;
+// クリックが効くまで再試行を続ける合計の猶予
+const TOTAL_TIMEOUT = 30_000;
+
+/**
+ * ハイドレーションが終わるまで押し続ける。
+ *
+ * SSR された DOM はハイドレーション完了前でもクリックできるように見えるが、
+ * まだ React のハンドラが付いていないためクリックは握り潰される。
+ * 「手動で仕訳を作成」を押してもダイアログが開かない、「この月を登録」を押しても
+ * 「登録済み」にならない、といったランダムな失敗はこれが原因なので、
+ * `expectation` が満たされるまでクリックを再試行する。
+ *
+ * `expectation` にはアサーションのオプション（タイムアウト）が渡される。
+ * 1 回の試行を短く切ることで、効かなかったクリックを素早く押し直せる。
+ *
+ * ```ts
+ * await clickUntil(january.getByRole("button", { name: "この月を登録" }), (options) =>
+ *   expect(january).toContainText("登録済み", options),
+ * );
+ * ```
+ */
+export async function clickUntil(
+  target: Locator,
+  expectation: (options: { timeout: number }) => Promise<unknown>,
+): Promise<void> {
+  let attempt = 0;
+  await expect(async () => {
+    // 直前のクリックが遅れて効いていることがあるので、2 回目以降は押す前に確かめる
+    // （押した結果ボタン自体が消える「この月を登録」のような導線で二重クリックしない）
+    if (attempt++ > 0 && (await satisfied(expectation))) return;
+    await target.click({ timeout: ATTEMPT_TIMEOUT });
+    await expectation({ timeout: ATTEMPT_TIMEOUT });
+  }).toPass({ timeout: TOTAL_TIMEOUT });
+}
+
+async function satisfied(
+  expectation: (options: { timeout: number }) => Promise<unknown>,
+): Promise<boolean> {
+  try {
+    await expectation({ timeout: ATTEMPT_TIMEOUT });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/admin/e2e/tests/grants.spec.ts
+++ b/admin/e2e/tests/grants.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { clickUntil } from "../helpers/interactions";
 
 test("支給をテンプレートから1クリックで確認済登録し、二重生成を拒み、仕訳一覧に並べる", async ({ page }) => {
   const year = new Date().getFullYear();
@@ -28,8 +29,9 @@ test("支給をテンプレートから1クリックで確認済登録し、二�
 
   const january = page.getByRole("listitem").filter({ hasText: "1月" }).first();
   await expect(january).toContainText("¥1,000,000");
-  await january.getByRole("button", { name: "この月を登録" }).click();
-  await expect(january).toContainText("登録済み");
+  await clickUntil(january.getByRole("button", { name: "この月を登録" }), (options) =>
+    expect(january).toContainText("登録済み", options),
+  );
   // 同月の二重生成は拒否される（登録済みの月にボタンは出ない）
   await expect(january.getByRole("button", { name: "この月を登録" })).toHaveCount(0);
   await page.reload();

--- a/admin/e2e/tests/journal-review.spec.ts
+++ b/admin/e2e/tests/journal-review.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { clickUntil } from "../helpers/interactions";
 
 test("手動作成→一覧選択→編集→確認済、月絞り込みと破棄", async ({ page }) => {
   const name = `e2e-journal-${Date.now()}`;
@@ -21,8 +22,10 @@ test("手動作成→一覧選択→編集→確認済、月絞り込みと破�
   await page.getByRole("link", { name: "仕訳の確認・編集" }).click();
   await expect(page.getByRole("heading", { name: "仕訳の確認・編集" })).toBeVisible();
   for (const [description, date] of [["視察先への移動", "2026-08-01"], ["会議への移動", "2026-09-01"]]) {
-    await page.getByRole("button", { name: "手動で仕訳を作成" }).click();
     const dialog = page.getByRole("dialog");
+    await clickUntil(page.getByRole("button", { name: "手動で仕訳を作成" }), (options) =>
+      expect(dialog.getByLabel("日付", { exact: true })).toBeVisible(options),
+    );
     await dialog.getByLabel("日付", { exact: true }).fill(date);
     await dialog.getByLabel("金額", { exact: true }).fill("1200");
     await dialog.getByLabel("項目名", { exact: true }).fill(description);

--- a/admin/e2e/tests/prompts.spec.ts
+++ b/admin/e2e/tests/prompts.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { clickUntil } from "../helpers/interactions";
 
 test("デフォルトから初版を保存し、編集して版を重ね、巻き戻す", async ({ page }) => {
   const name = `e2e-prompt-${Date.now()}`;
@@ -31,8 +32,9 @@ test("デフォルトから初版を保存し、編集して版を重ね、巻�
   await expect(details).toBeVisible();
   await expect(page.getByText("領収書の抽出結果を次のJSONスキーマに従って")).toBeVisible();
 
-  await page.getByRole("button", { name: "保存して v1 にする" }).click();
-  await expect(page.getByText("v1 有効")).toBeVisible();
+  await clickUntil(page.getByRole("button", { name: "保存して v1 にする" }), (options) =>
+    expect(page.getByText("v1 有効")).toBeVisible(options),
+  );
   const history = page.locator('[data-slot="card"]').filter({ has: page.getByRole("heading", { name: "版履歴" }) }).getByRole("listitem");
   await expect(history).toHaveCount(1);
   await expect(history.first()).toContainText("初版");

--- a/admin/e2e/tests/publish.spec.ts
+++ b/admin/e2e/tests/publish.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { clickUntil } from "../helpers/interactions";
 
 test("確認済の仕訳を選んでbefore/afterを見比べ、公開して公開範囲を更新する", async ({ page }) => {
   const year = new Date().getFullYear();
@@ -23,12 +24,16 @@ test("確認済の仕訳を選んでbefore/afterを見比べ、公開して公�
   // 公開できる材料をつくる: 支給1件（確認済）と、確認済にした支出1件
   await page.getByRole("link", { name: "支給の登録" }).click();
   await expect(page.getByRole("heading", { name: "支給の登録" })).toBeVisible();
-  await page.getByRole("listitem").filter({ hasText: "1月" }).first().getByRole("button", { name: "この月を登録" }).click();
-  await expect(page.getByRole("listitem").filter({ hasText: "1月" }).first()).toContainText("登録済み");
+  const january = page.getByRole("listitem").filter({ hasText: "1月" }).first();
+  await clickUntil(january.getByRole("button", { name: "この月を登録" }), (options) =>
+    expect(january).toContainText("登録済み", options),
+  );
   await page.getByRole("link", { name: "仕訳の確認・編集" }).click();
   await expect(page.getByRole("heading", { name: "仕訳の確認・編集" })).toBeVisible();
-  await page.getByRole("button", { name: "手動で仕訳を作成" }).click();
   const dialog = page.getByRole("dialog");
+  await clickUntil(page.getByRole("button", { name: "手動で仕訳を作成" }), (options) =>
+    expect(dialog.getByLabel("日付", { exact: true })).toBeVisible(options),
+  );
   await dialog.getByLabel("日付", { exact: true }).fill(`${year}-03-15`);
   await dialog.getByLabel("金額", { exact: true }).fill("1500");
   await dialog.getByLabel("項目名", { exact: true }).fill("視察先への移動");


### PR DESCRIPTION
## 目的（Why）

admin の e2e をローカルで通しで回すと、議員室（調研費）系の spec が実行ごとに違う箇所でランダムに落ちていた。
CI は `retries: 2` で隠れているだけで、リトライのぶんループの CI 待ち時間が伸びる。
**ループを回す人が、e2e のランダムな失敗とリトライ待ちに足を取られない状態にするため。**

落ち方はいずれも「SSR された DOM はクリックできるように見えるが、ハイドレーションが終わるまで
React のハンドラが付いておらずクリックが握り潰される」症状:

- `journal-review.spec.ts`: 「手動で仕訳を作成」を押してもダイアログが開かない
- `grants.spec.ts`: 「この月を登録」を押しても「登録済み」にならない

## 変更内容

- `admin/e2e/helpers/interactions.ts` に `clickUntil(target, expectation)` を追加。
  期待する状態が満たされるまでクリックを再試行する（`expect(...).toPass()`）。
  1 回の試行を 5s で切って素早く押し直し、全体 30s で諦める。
  押した結果ボタン自体が消える導線（「この月を登録」）で二重クリックしないよう、
  **2 回目以降の試行は押す前に期待状態を確かめる**。
- 各 spec の「ナビゲーション直後にある最初のハイドレーション依存クリック」に適用:
  - `journal-review.spec.ts` — 「手動で仕訳を作成」
  - `grants.spec.ts` — 「この月を登録」
  - `publish.spec.ts` — 「この月を登録」「手動で仕訳を作成」（上記 2 つと同一の導線）
  - `prompts.spec.ts` — 「保存して v1 にする」（このページで最初のハイドレーション依存クリック。
    直前の `<details>`/`<summary>` は native なのでハイドレーション前でも動く）

Issue の「やらないこと」どおり、Playwright の設定（retries / workers）とアプリ側のハイドレーションには触れていない。

## ローカル CI の実行結果

- `pnpm verify` ✅（test / typecheck / lint / knip / depcruise すべて green）
- `node scripts/supabase-env.mjs pnpm --filter admin exec playwright test --workers=1 --repeat-each=3` ✅
  **139 passed (2.2m)** — 失敗・リトライなし

## スコープアウトして起票した Issue

なし

Closes #1408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * SSR後の画面でクリックが反映されない場合に、操作と状態確認を自動で再試行するよう改善しました。
  * 支給登録、仕訳作成、プロンプト保存、公開フローのE2Eテストを安定化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->