### PR TITLE
ci: 本番デプロイ成功時に自動命名の release tag を付ける

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,10 @@ name: Deploy Production
 on:
   workflow_dispatch:
 
+# デプロイ成功時に release tag を push するため contents: write が必要
+permissions:
+  contents: write
+
 concurrency:
   group: deploy-production
   cancel-in-progress: false
@@ -56,3 +60,15 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ADMIN }}
+
+      # webapp / admin の両方のデプロイが成功したときだけタグを付ける
+      # （途中のステップが失敗するとこのステップは実行されない）
+      #
+      # タグ名は JST の日時から自動生成する。名前順に並べるとデプロイ順になり、
+      # 名前だけでいつのデプロイか分かる
+      - name: Create release tag
+        run: |
+          TAG="release-$(TZ=Asia/Tokyo date '+%Y%m%d-%H%M%S')"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "$TAG"
+          echo "Created release tag: $TAG ($GITHUB_SHA)" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ marumie/
 
 ローカル開発環境のセットアップ手順は [開発環境セットアップガイド](docs/getting-started.md) を参照してください。
 
+## 本番デプロイとリリースタグ
+
+本番デプロイは GitHub Actions の **Deploy Production** ワークフローを `main` から手動実行して行います。
+webapp / admin の両方のデプロイが成功すると、デプロイしたコミットに release tag が自動で作成・push されます（どちらかが失敗した場合はタグは付きません）。
+
+- タグ名の形式: `release-YYYYMMDD-HHMMSS`（日本時間。例: `release-20260911-153012`）
+- 名前順に並べるとデプロイ順になります
+
+現在本番に出ているコミットは、最新の release tag で確認できます。
+
+```bash
+git fetch --tags
+git log -1 "$(git tag -l 'release-*' --sort=-refname | head -n 1)"
+```
+
 ## ライセンス
 
 このプロジェクトは [GNU Affero General Public License v3.0](LICENSE) の下でライセンスされています。


### PR DESCRIPTION
## 目的（Why）

本番デプロイは Deploy Production ワークフローの手動実行で行っているが、デプロイ後にタグが残らないため、
**メンテナが「いつ・どのコミットが本番に出たか」を git 上で後から追えない**状態を解消するため。
タグ名を毎回人間が考えなくて済むよう、自動命名にする。

## 変更内容

- `.github/workflows/deploy-production.yml`
  - workflow に `permissions: contents: write` を明示（タグの push に必要）
  - webapp / admin のデプロイステップの後に `Create release tag` ステップを追加。
    どちらかのデプロイが失敗すると以降のステップは実行されないため、**両方成功したときだけ**タグが付く
  - タグ名は `release-YYYYMMDD-HHMMSS`（JST）。自動生成・一意・名前順＝デプロイ順
  - 付与先は `$GITHUB_SHA`（= デプロイ対象のコミット）。作成したタグ名は job summary にも出力する
- `README.md`
  - 「本番デプロイとリリースタグ」節を追加。タグの形式と、
    現在本番に出ているコミットをタグから確認する方法（`git tag -l 'release-*' --sort=-refname | head -n 1`）を記載

## ローカル CI

`pnpm verify` パス（test / typecheck / lint / knip / depcruise）。

- webapp: Test Suites 122 passed (1 skipped) / Tests 1431 passed
- admin: Test Suites 17 passed / Tests 139 passed
- depcruise: 違反なし

アプリコードの変更がないため E2E は未実行。
README に載せたタグ確認コマンドはローカルでダミータグを作って動作確認済み。

## スコープアウト

なし（GitHub Release の作成、デプロイの push トリガー化、既存タグ `v.1.0.0` の整理は Issue の Out of scope のまま）。

Closes #1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)