### PR TITLE
test(e2e): webapp の E2E をシード済みの政治団体に固定して admin の E2E と分離する

### DIFF
--- a/webapp/e2e/tests/organization.spec.ts
+++ b/webapp/e2e/tests/organization.spec.ts
@@ -2,9 +2,21 @@ import { test, expect } from "@playwright/test";
 
 test.describe("政治団体ページ", () => {
 	test.describe("読み込み", () => {
+		// ルートのリダイレクト先はDB上の政治団体一覧の先頭（表示名の降順）で決まるため、
+		// admin の E2E が作った団体が遷移先になることがある。
+		// ここではリダイレクトが起きることだけを検証し、ページの中身の検証は
+		// シードで作られた sample-party を明示的に指定するテストで行う。
 		test("ルートにアクセスすると政治団体ページにリダイレクトされる", async ({
 			page,
 		}) => {
+			await page.goto("/");
+
+			// /o/{slug}/{year} にリダイレクトされることを確認
+			await expect(page).toHaveURL(/\/o\/[\w-]+\/\d{4}$/);
+			await expect(page).toHaveTitle(/みらいまる見え政治資金/);
+		});
+
+		test("政治団体ページが正常に表示される", async ({ page }) => {
 			const errors: string[] = [];
 
 			// ページ内で発生する未キャッチ例外を収集
@@ -14,11 +26,10 @@ test.describe("政治団体ページ", () => {
 				);
 			});
 
-			await page.goto("/");
+			const response = await page.goto("/o/sample-party/2026");
 
-			// /o/{slug}/{year} にリダイレクトされることを確認
-			await expect(page).toHaveURL(/\/o\/[\w-]+\/\d{4}$/);
-			await expect(page).toHaveTitle(/みらいまる見え政治資金/);
+			expect(response?.status()).toBe(200);
+			await expect(page).toHaveTitle(/サンプル党.*みらいまる見え政治資金/);
 
 			// 収支の流れセクションが描画されるまで待機（networkidle依存を避ける）
 			await expect(
@@ -34,13 +45,6 @@ test.describe("政治団体ページ", () => {
 				errors,
 				`以下のエラーが発生しました:\n${errors.join("\n")}`,
 			).toHaveLength(0);
-		});
-
-		test("政治団体ページが正常に表示される", async ({ page }) => {
-			const response = await page.goto("/o/sample-party/2026");
-
-			expect(response?.status()).toBe(200);
-			await expect(page).toHaveTitle(/サンプル党.*みらいまる見え政治資金/);
 		});
 
 		test("年度なしのURLはデフォルト年度にリダイレクトされる", async ({


### PR DESCRIPTION
## 目的（Why）

**開発者が、ローカルで E2E を 2 回以上回すたびに webapp の E2E が落ち、原因の切り分けに時間を取られる状態を解消するため。**

`pnpm test:e2e` は webapp → admin の順に回すが、admin の E2E（政治団体管理など）が作ったレコードが DB に残る。
ルートのリダイレクト先は政治団体一覧の先頭（表示名の降順）で決まるため、admin が作った団体が遷移先になり、
収支フロー図（サンキー）の無いページに飛んで `organization.spec.ts` の
「ルートにアクセスすると政治団体ページにリダイレクトされる」が失敗していた。

CI は毎回まっさらな DB から始まるので CI では顕在化しないが、ローカル（およびループのセッション）では毎回踏む罠になっていた。

## 変更内容

Issue の完了条件のうち「webapp の E2E がシードで作られた特定の政治団体を明示的に指定して検証する」方針を採った。

- 「ルートにアクセスすると政治団体ページにリダイレクトされる」は、**リダイレクトが起きること**（URL 形式とタイトル）だけを検証する。
  どの団体に飛ぶかは DB の内容に依存するため、ページの中身は検証しない。
- ページの中身（収支の流れセクション・サンキーチャートの描画・実行時エラーが無いこと）の検証は、
  既存の「政治団体ページが正常に表示される」に統合し、シードで作られる `sample-party` を明示的に指定して行う。

アサーションは減らしていない（リダイレクト検証と内容検証を 2 つのテストに分けただけ）。

## ローカル CI の実行結果

`pnpm verify`: ✅ green
- webapp/admin jest: `122 passed` / `17 passed`（Tests: 1431 + 139）
- typecheck / lint / knip / depcruise すべて green

E2E（`pnpm db:reset` 後に `pnpm test:e2e` を連続実行）:

| 実行 | webapp | admin |
|------|--------|-------|
| 1 回目 | ✅ 14 passed | ✅ 47 passed |
| 2 回目 | ✅ 14 passed | ❌ 8 failed（下記の別問題） |
| 3 回目 | ✅ 14 passed | ✅ 47 passed |

**修正前**は、admin の E2E が作ったデータが残った DB に対して webapp が `1 failed / 13 passed`（サンキーが描画されない）だった。
修正後は 3 回とも webapp が green で、本 Issue の症状は解消している。

2 回目の admin の失敗は本 PR の変更とは無関係で、supabase の auth コンテナ（GoTrue）→ postgres の接続枯渇が原因だった
（GoTrue のログに `cannot assign requested address`）。データ起因ではなく、同じ DB に対する 3 回目は green。
別 Issue として切り出している。

## スコープアウトして起票した Issue

- #1413 fix(e2e): ローカルで admin の E2E がまれに GoTrue の接続枯渇で大量に落ちる（`loop:human`）

Closes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - ルートアクセス時に、政治団体ページへのリダイレクトとページタイトルを検証するE2Eテストを追加。
  - 政治団体ページで、HTTPステータス、タイトル、収支フロー表示、実行時エラーを検証するテストを更新。
  - 重複していた検証処理を整理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->