### PR TITLE
test(e2e): webapp の E2E をローカルでも本番ビルドに当てる

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -228,7 +228,7 @@ pnpm run typecheck     # 型チェック
 pnpm run test          # テスト実行
 ```
 
-### E2Eテスト（admin）
+### E2Eテスト（webapp / admin）
 
 E2E はローカルの Supabase（認証）とシードデータに依存するため、プロジェクトルートから以下の順で実行します：
 
@@ -236,17 +236,20 @@ E2E はローカルの Supabase（認証）とシードデータに依存する�
 pnpm supabase:start && pnpm db:reset && pnpm test:e2e
 ```
 
-- `pnpm test:e2e` は webapp → admin の順に実行します。admin だけ回すなら `pnpm test:e2e:admin`
+- `pnpm test:e2e` は webapp → admin の順に実行します。片方だけ回すなら `pnpm test:e2e:webapp` / `pnpm test:e2e:admin`
 - `pnpm test:e2e:admin` / `pnpm test:e2e:ui` は起動中の Supabase から接続情報を自動取得するため、
   `admin/.env.local` のキー設定は不要です（`pnpm --filter admin test:e2e` と直接呼ぶ場合は自動取得されません）
-- admin の E2E は CI と同じ本番ビルド（`next build` → `next start --port 3001`）を自動で起動します。
-  ポート 3001 で開発サーバーが動いていると起動できないので、先に止めてください
-  （dev サーバーは並行実行中に Fast Refresh で RSC ストリームが切れ、
-  ハイドレーション前のクリックが握り潰されて E2E が不安定になるため使いません）
-- デバッグ目的で dev サーバーに当てたいときは `E2E_DEV_SERVER=1 pnpm test:e2e:admin`。
-  この場合は起動中の開発サーバーを再利用します（結果は CI と一致しないことがあります）
+- webapp / admin とも、E2E は CI と同じ本番ビルド（`next build` → `next start`）を自動で起動します
+  （webapp はポート 3000、admin はポート 3001）。該当ポートで開発サーバーが動いていると起動できないので、
+  先に止めてください（dev サーバーは並行実行中に Fast Refresh で RSC ストリームが切れ、
+  ハイドレーション前のクリックが握り潰されて E2E が不安定になるため使いません）。
+  ビルドから走るので初回は数分かかります
+- デバッグ目的で dev サーバーに当てたいときは `E2E_DEV_SERVER=1 pnpm test:e2e:webapp` /
+  `E2E_DEV_SERVER=1 pnpm test:e2e:admin`。この場合は起動中の開発サーバーを再利用します
+  （結果は CI と一致しないことがあります）
 
 ```bash
+pnpm test:e2e:webapp                   # webapp の E2E（ヘッドレス）
 pnpm test:e2e:admin                    # admin の E2E（ヘッドレス）
 pnpm test:e2e:ui                       # UIモードで実行（デバッグ用）
 pnpm --filter admin test:e2e:headed    # ブラウザを表示して実行（キーは admin/.env.local から）

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// E2E は CI と同じ本番ビルド（next build → next start）に対して回す。
+// dev サーバー（Turbopack）だと並行実行中もルートの都度ビルドで Fast Refresh が走り、
+// 配信中の RSC ストリームが中断されることがある
+// （サーバー側 `Error: aborted / ECONNRESET`、ブラウザ側 `Error: Connection closed.`）。
+// ページはハードリロードで復帰するものの、その間はハイドレーション前の SSR された DOM が
+// クリック可能に見えるため、Playwright のクリックがハンドラの付く前に落ちて握り潰される。
+// デバッグで dev サーバーに当てたいときだけ E2E_DEV_SERVER=1 を付ける。
+const useDevServer = process.env.E2E_DEV_SERVER === "1";
+
 export default defineConfig({
   testDir: "./e2e/tests",
   outputDir: "./e2e/.output/test-results",
@@ -19,9 +28,17 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? "pnpm start --port 3000" : "pnpm dev",
+    // CI は前段のステップでビルド済みなのでビルドし直さない。
+    command: process.env.CI
+      ? "pnpm start --port 3000"
+      : useDevServer
+        ? "pnpm dev"
+        : "pnpm build && pnpm start --port 3000",
     url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    // 既存のサーバーは dev サーバー指定のときだけ再利用する。
+    // 本番ビルドで回す既定では、3000 で動いている dev サーバーを拾って
+    // 上記の不安定さに逆戻りしないよう、明示的に止めてもらう。
+    reuseExistingServer: useDevServer,
+    timeout: 300 * 1000,
   },
 });


### PR DESCRIPTION
## 目的（Why）

開発者が、ローカルの webapp E2E で「実装は正しいのにクリックが握り潰されて落ちる」偽陽性に振り回される状態を解消するため。

`admin/playwright.config.ts` は #1405 の対応で、ローカルでも CI と同じ本番ビルド（`next build` → `next start`）に E2E を当てるようにした。
dev サーバー（Turbopack）だと並行実行中のルート都度ビルドで Fast Refresh が走り、配信中の RSC ストリームが中断される
（サーバー側 `Error: aborted / ECONNRESET`、ブラウザ側 `Error: Connection closed.`）。ページはハードリロードで復帰するが、
その隙にハイドレーション前の DOM へクリックが落ちて握り潰されるのが原因だった。

`webapp/playwright.config.ts` は同じ構成が残っており（現状 E2E が 14 件と少なく顕在化していないだけ）、
ローカルと CI で走る成果物が違う状態もローカル検証の信頼性を下げていた。

## 変更内容

### `webapp/playwright.config.ts`

`webServer` を admin と同じ方針に揃えた。

- 既定（ローカル）: `pnpm build && pnpm start --port 3000`、`reuseExistingServer: false`
  - ポート 3000 で動いている dev サーバーを拾って不安定さに逆戻りしないよう、明示的に止めてもらう
- CI: 既存どおり `pnpm start --port 3000`（前段のジョブでビルド済みなのでビルドし直さない）
- `E2E_DEV_SERVER=1` のときだけ `pnpm dev` を使い、起動中のサーバーを再利用する
- `timeout` をビルド込みで足りる 300 秒に伸ばした

理由は admin と同じコメントとして残している。

### `docs/getting-started.md`

E2E 節が admin 専用の書き方だったので、webapp / admin の両方を指すよう追従させた。

- 見出しを「E2Eテスト（webapp / admin）」に変更
- 本番ビルド起動・ポート占有時の注意・`E2E_DEV_SERVER=1` の説明を両アプリ向けに記載
- コマンド一覧に `pnpm test:e2e:webapp` を追加

## ローカル CI の実行結果

`pnpm verify` — 全て pass

```
admin  Test Suites: 1 skipped, 122 passed, 122 of 123 total / Tests: 1 skipped, 1431 passed, 1432 total
webapp Test Suites: 17 passed, 17 total / Tests: 139 passed, 139 total
typecheck / lint(biome) / knip / depcruise すべて violation なし
```

`pnpm supabase:start && pnpm db:reset && pnpm test:e2e` — 全て pass

```
webapp: 14 passed (22.3s)
admin:  47 passed (37.1s)
```

`webapp/.next/BUILD_ID` が実行時刻で更新されており、ローカル実行で実際に `pnpm build` が走って本番ビルドに当たっていることを確認した。

## スコープアウトして起票した Issue

なし。

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)