### PR TITLE
fix(loop): CodeRabbit のレート制限で未レビューのままの PR に再レビューを促す

### DIFF
--- a/docs/loop-engineering.md
+++ b/docs/loop-engineering.md
@@ -20,8 +20,9 @@ AIエージェント（Claude Code / Codex）に実装を自律的に回して�
 
 1. **main の CI が赤** → `loop-fix-main`
 2. **いま動かせる loop PR がある** → 必須チェック失敗・コンフリクトなら `loop-fix-ci`、
-   CodeRabbit が最新コミットをレビュー済みで未解決スレッドが残っていれば `loop-resolve-coderabbit`。
-   人間のレビュースレッドがある PR と修正ラウンドの予算を超えた PR は、セッションを起動せずランナーが `loop:human` に付け替える
+   CodeRabbit が最新コミットをレビュー済み（またはレート制限で止まっている）で未解決スレッドが残っていれば `loop-resolve-coderabbit`。
+   人間のレビュースレッドがある PR と修正ラウンドの予算を超えた PR は、セッションを起動せずランナーが `loop:human` に付け替える。
+   レート制限で最新コミットが未レビューのままの PR には、ランナーが `@coderabbitai review` を投げる
 3. **いま着手できる Issue がある** → `loop-implement`（`loop:unblock` 優先、次に番号最小。依存待ちの Issue は読み飛ばすだけで状態を変えない）
 4. **in-flight の PR（CI 実行中・レビュー中・承認済みでマージ待ち）か依存待ちの Issue しか無い** → `WAITING`。
    ランナーが状態だけを取り直し、変化した時点で次の tick を回す
@@ -112,6 +113,11 @@ docsのみの変更などで個別ジョブがスキップされても必ず報�
   `@coderabbitai resolve` での一括 resolve、レビュー自体の dismiss は禁止（人間が後から監査できなくなる）
 - 修正 push は **2 ラウンドまで**（`LOOP_MAX_FIX_ROUNDS`）。ランナーが `fix: CodeRabbit` で始まるコミット数で数え、
   超えてもまだ未解決の指摘があれば、セッションを起動せずに PR を open のまま Issue を `loop:human` に付け替える
+- **CodeRabbit にはプランごとに 1 時間あたりのレビュー回数の上限がある**（push ごとの増分レビューも 1 回に数える）。
+  上限に当たると head のコミットステータスは `success` のまま説明文が「Review rate limited」になり、そのコミットは**未レビュー**なので
+  承認は永遠に来ない。`state.sh` はこれを `RATE_LIMITED` として区別し、未解決スレッドが無ければランナーが `@coderabbitai review` を
+  投げて再レビューを促す（head ごとに 1 回、`LOOP_NUDGE_INTERVAL_MINUTES`（既定 20 分）経っても未レビューなら再送）。
+  1 Issue で「PR 作成 + 修正 push」の 2 回を使うので、上限がループのスループットの上限にもなる
 - ループが自動処理するのは `coderabbitai` のスレッドだけ。人間のレビュースレッドがある PR はランナーが即 `loop:human` に付け替える
 - エスカレーション済みの PR（Issue が `loop:human` / `loop:blocked`）は、メンテナが `loop:ready` に戻すまでランナーの対象外
 - 判定基準の実体は [loop-resolve-coderabbit.md](../.claude/commands/loop-resolve-coderabbit.md)

--- a/docs/loop-engineering.md
+++ b/docs/loop-engineering.md
@@ -117,7 +117,9 @@ docsのみの変更などで個別ジョブがスキップされても必ず報�
   上限に当たると head のコミットステータスは `success` のまま説明文が「Review rate limited」になり、そのコミットは**未レビュー**なので
   承認は永遠に来ない。`state.sh` はこれを `RATE_LIMITED` として区別し、未解決スレッドが無ければランナーが `@coderabbitai review` を
   投げて再レビューを促す（head ごとに 1 回、`LOOP_NUDGE_INTERVAL_MINUTES`（既定 20 分）経っても未レビューなら再送）。
-  1 Issue で「PR 作成 + 修正 push」の 2 回を使うので、上限がループのスループットの上限にもなる
+  1 Issue で「PR 作成時の 1 回 + 修正 push の最大 2 ラウンド」の最大 3 回を使う。上限を超えたレビューを
+  usage-based add-on で継続できない構成（このリポジトリはこれに当たる）では、この最大 3 回が上限に制約されるため、
+  上限がループのスループットの上限にもなる
 - ループが自動処理するのは `coderabbitai` のスレッドだけ。人間のレビュースレッドがある PR はランナーが即 `loop:human` に付け替える
 - エスカレーション済みの PR（Issue が `loop:human` / `loop:blocked`）は、メンテナが `loop:ready` に戻すまでランナーの対象外
 - 判定基準の実体は [loop-resolve-coderabbit.md](../.claude/commands/loop-resolve-coderabbit.md)

--- a/scripts/loop-once.sh
+++ b/scripts/loop-once.sh
@@ -108,7 +108,8 @@ main() {
     exit 1
   }
   local escalated_any=false
-  [[ "$esc_summary" != "escalated=0 flagged=0" ]] && escalated_any=true
+  [[ "$esc_summary" != escalated=0\ flagged=0* ]] && escalated_any=true
+  [[ "$esc_summary" == *nudged=[1-9]* ]] && echo "[loop-once] $esc_summary"
 
   # --- セッションを起動しない結果 ---
   case "$action" in

--- a/scripts/loop/decide.sh
+++ b/scripts/loop/decide.sh
@@ -12,21 +12,26 @@
 # セッションを起動せずにランナーが行うラベル操作は escalations / flags に列挙する:
 #   escalations: 人間のレビュースレッドがある PR、修正ラウンドの予算を超えた PR → 紐づく Issue を loop:human に
 #   flags:       起票者が信頼境界の外の Issue、依存先が未マージのまま閉じた Issue → loop:human に
+#   nudges:      CodeRabbit がレート制限で head を未レビューのままの PR → `@coderabbitai review` を投げて再レビューを促す
+#                （head ごとに 1 回。LOOP_NUDGE_INTERVAL_MINUTES 経っても未レビューなら再度）
 #
 # 出力の形:
 # { "action": "fix-main|fix-ci|resolve-coderabbit|implement|wait|none", "target": <番号|null>, "reason": "...",
 #   "escalations": [ { "pr", "issue", "reason": "human-review|budget-exceeded" } ],
 #   "flags":       [ { "issue", "reason": "untrusted-author|dead-dependency" } ],
+#   "nudges":      [ <PR番号> ],
 #   "waiting_on":  { "prs": [...], "issues": [...] } }
 #
 # 環境変数:
-#   LOOP_MAX_FIX_ROUNDS  CodeRabbit 対応の修正 push を何ラウンドまで許すか（デフォルト 2）
+#   LOOP_MAX_FIX_ROUNDS           CodeRabbit 対応の修正 push を何ラウンドまで許すか（デフォルト 2）
+#   LOOP_NUDGE_INTERVAL_MINUTES   レート制限中の PR に再レビューを促す間隔（デフォルト 20）
 
 set -euo pipefail
 
 max_rounds="${LOOP_MAX_FIX_ROUNDS:-2}"
+nudge_interval="${LOOP_NUDGE_INTERVAL_MINUTES:-20}"
 
-jq --argjson max_rounds "$max_rounds" '
+jq --argjson max_rounds "$max_rounds" --argjson nudge_interval "$nudge_interval" '
   # エスカレーション済み（Issue が loop:human / loop:blocked）の PR はループの対象外
   (.prs | map(select(.issue == null or (.issue.escalated | not)))) as $prs
 
@@ -46,7 +51,7 @@ jq --argjson max_rounds "$max_rounds" '
         | {action: "fix-ci", target: .number,
            reason: (if .merge_state == "DIRTY" then "conflict with main" else "ci-complete failed" end)} ]
       + [ $live[] | select(.ci_complete != "FAILURE" and .merge_state != "DIRTY"
-                           and (.coderabbit | IN("SUCCESS", "FAILURE", "ERROR"))
+                           and (.coderabbit | IN("SUCCESS", "FAILURE", "ERROR", "RATE_LIMITED"))
                            and .threads.coderabbit_unresolved > 0)
         | {action: "resolve-coderabbit", target: .number,
            reason: "\(.threads.coderabbit_unresolved) unresolved CodeRabbit thread(s) on reviewed head"} ]
@@ -54,6 +59,11 @@ jq --argjson max_rounds "$max_rounds" '
     ) as $pr_actions
   | ($pr_actions | map(.target)) as $action_prs
   | ($live | map(select(.number as $n | ($action_prs | index($n)) == null)) | map(.number)) as $inflight
+
+  # レート制限で head が未レビューのままの PR: 再レビューを促す（head ごとに 1 回、間隔を空けて再送）
+  | ([ $live[] | select(.coderabbit == "RATE_LIMITED" and .threads.coderabbit_unresolved == 0
+                        and (.nudged_at == null or ((now - (.nudged_at | fromdateiso8601)) / 60) >= $nudge_interval))
+        | .number ]) as $nudges
 
   | (
       [ .issues[] | select(.trusted | not) | {issue: .number, reason: "untrusted-author"} ]
@@ -80,6 +90,7 @@ jq --argjson max_rounds "$max_rounds" '
   | $decision + {
       escalations: $escalations,
       flags: $flags,
+      nudges: $nudges,
       waiting_on: {prs: $inflight, issues: $waiting_issues}
     }
 '

--- a/scripts/loop/escalate.sh
+++ b/scripts/loop/escalate.sh
@@ -5,14 +5,16 @@
 #
 #   escalations: PR にコメントし、紐づく Issue を loop:wip → loop:human に付け替える
 #   flags:       Issue を loop:ready → loop:human に付け替えて理由をコメントする
+#   nudges:      レート制限で未レビューのままの PR に `@coderabbitai review` を投げる
 #
-# 標準出力に反映した件数を "escalated=<n> flagged=<m>" の形で 1 行出力する。
+# 標準出力に反映した件数を "escalated=<n> flagged=<m> nudged=<k>" の形で 1 行出力する。
 
 set -euo pipefail
 
 decision="$(cat)"
 escalated=0
 flagged=0
+nudged=0
 
 while IFS=$'\t' read -r pr issue reason; do
   [[ -z "$pr" ]] && continue
@@ -49,4 +51,11 @@ while IFS=$'\t' read -r issue reason; do
   flagged=$((flagged + 1))
 done < <(jq -r '.flags[]? | [.issue, .reason] | @tsv' <<<"$decision")
 
-echo "escalated=$escalated flagged=$flagged"
+while read -r pr; do
+  [[ -z "$pr" ]] && continue
+  gh pr comment "$pr" --body "@coderabbitai review" >/dev/null
+  echo "[escalate] PR #$pr → @coderabbitai review（レート制限で head が未レビューのため再レビューを依頼）" >&2
+  nudged=$((nudged + 1))
+done < <(jq -r '.nudges[]?' <<<"$decision")
+
+echo "escalated=$escalated flagged=$flagged nudged=$nudged"

--- a/scripts/loop/state.sh
+++ b/scripts/loop/state.sh
@@ -14,7 +14,11 @@
 #       "review_decision": "|APPROVED|CHANGES_REQUESTED|REVIEW_REQUIRED",
 #       "auto_merge": true|false,
 #       "ci_complete": "SUCCESS|FAILURE|PENDING|MISSING|...",   # 必須チェック（CheckRun）
-#       "coderabbit":  "SUCCESS|FAILURE|ERROR|PENDING|MISSING", # 必須チェック（head のコミットステータス）
+#       "coderabbit":  "SUCCESS|FAILURE|ERROR|PENDING|RATE_LIMITED|MISSING", # head のコミットステータス。
+#                      # state が success でも説明が "rate limited" なら未レビューなので RATE_LIMITED にする
+#       "coderabbit_note": "<コミットステータスの説明文>",
+#       "head_committed_at": "<ISO8601>",
+#       "nudged_at": "<head 以降に @coderabbitai review を投げた最新時刻>" | null,
 #       "fix_rounds": <"fix: CodeRabbit" で始まるコミット数>,
 #       "issue": { "number", "labels": [...], "escalated": true|false } | null,   # Closes で紐づく Issue
 #       "threads": { "coderabbit_unresolved": n, "human_unresolved": n }
@@ -60,14 +64,24 @@ if [[ -n "$pr_numbers" ]]; then
     q+=" pr$n: pullRequest(number: $n) {"
     q+="   closingIssuesReferences(first: 5) { nodes { number labels(first: 30) { nodes { name } } } }"
     q+="   reviewThreads(first: 100) { nodes { isResolved comments(first: 1) { nodes { author { login } } } } }"
-    q+="   commits(last: 100) { nodes { commit { messageHeadline } } }"
+    q+="   commits(last: 100) { nodes { commit { messageHeadline committedDate } } }"
+    q+="   comments(last: 30) { nodes { body createdAt } }"
     q+=" }"
   done
   q+=" } }"
   pr_extra="$(gh api graphql -f query="$q" --jq '.data.repository')"
 fi
 
-prs_json="$(jq --argjson extra "$pr_extra" '
+# head の CodeRabbit コミットステータス（説明文が要る。レート制限時も state は success になる）
+cr_status='{}'
+for n in $pr_numbers; do
+  head="$(jq -r --argjson n "$n" '.[] | select(.number == $n) | .headRefOid' <<<"$prs_raw")"
+  st="$(gh api "repos/$repo/commits/$head/status" \
+    --jq '[.statuses[] | select(.context == "CodeRabbit")] | first // {} | {state, description, updated_at}' 2>/dev/null || echo '{}')"
+  cr_status="$(jq --argjson n "$n" --argjson st "$st" '. + {("pr\($n)"): $st}' <<<"$cr_status")"
+done
+
+prs_json="$(jq --argjson extra "$pr_extra" --argjson cr "$cr_status" '
   def check(nm):
     ([.statusCheckRollup[]? | select((.name // .context) == nm)] | first) as $c
     | if $c == null then "MISSING"
@@ -76,8 +90,11 @@ prs_json="$(jq --argjson extra "$pr_extra" '
       else ($c.state // "MISSING") end;
   map(
     ($extra["pr\(.number)"] // {}) as $x
+    | ($cr["pr\(.number)"] // {}) as $st
     | ($x.closingIssuesReferences.nodes // [] | first) as $iss
     | ($x.reviewThreads.nodes // [] | map(select(.isResolved == false))) as $open
+    | ($x.commits.nodes // [] | last | .commit.committedDate // null) as $head_at
+    | ([$x.comments.nodes[]? | select((.body | test("@coderabbitai review")) and $head_at != null and .createdAt > $head_at) | .createdAt] | max) as $nudged
     | {
         number, title,
         branch: .headRefName,
@@ -87,7 +104,12 @@ prs_json="$(jq --argjson extra "$pr_extra" '
         review_decision: .reviewDecision,
         auto_merge: (.autoMergeRequest != null),
         ci_complete: check("ci-complete"),
-        coderabbit: check("CodeRabbit"),
+        coderabbit: (if ($st.description // "" | test("rate limit"; "i")) then "RATE_LIMITED"
+                     elif ($st.state // "") != "" then ($st.state | ascii_upcase)
+                     else check("CodeRabbit") end),
+        coderabbit_note: ($st.description // ""),
+        head_committed_at: $head_at,
+        nudged_at: $nudged,
         fix_rounds: ([$x.commits.nodes[]? | select(.commit.messageHeadline | startswith("fix: CodeRabbit"))] | length),
         issue: (if $iss == null then null else {
           number: $iss.number,


### PR DESCRIPTION
## 目的（Why）

PR #1410 は未解決スレッド 0 件・CI green なのに 40 分以上 `CHANGES_REQUESTED` のまま止まり、ランナーは `WAITING` で待ち続けていた。
原因は CodeRabbit の 1 時間あたりのレビュー回数上限。上限に当たると head のコミットステータスが `success` のまま説明文「Review rate limited」になり、修正コミットは未レビューなので承認が来ない。ランナーは `success` を「レビュー済み」と読んで in-flight 扱いにしていた。

## 変更内容

- `state.sh`: head の CodeRabbit コミットステータスの説明文を REST で取り、rate limited なら `coderabbit: RATE_LIMITED` にする。head 以降に投げた `@coderabbitai review` の最新時刻（`nudged_at`）と head の `committedDate` も持つ
- `decide.sh`: `RATE_LIMITED` かつ未解決スレッド 0 の PR を `nudges` に列挙（head ごとに 1 回、`LOOP_NUDGE_INTERVAL_MINUTES` 既定 20 分経っても未レビューなら再送）。未解決スレッドがあれば `RATE_LIMITED` でも `loop-resolve-coderabbit` の対象にする
- `escalate.sh`: `nudges` に `@coderabbitai review` を投げる（セッション不要のランナー側書き込み）
- `docs/loop-engineering.md`: レート制限の挙動と、1 Issue で 2 回消費するためスループット上限になることを追記

## 検証

- 実リポジトリで `state.sh | decide.sh`（#1410 は手動 nudge 後に `PENDING / Review in progress` として取得できる）
- フィクスチャで: 未 nudge → nudge、5 分前に nudge 済み → 再送しない、30 分前 → 再送、未解決スレッドあり → `resolve-coderabbit`
- `bash -n`。TS 変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - CodeRabbitのレビュー回数について、1件あたりプルリクエスト作成時に1回、修正プッシュ後に最大2ラウンドの合計最大3回であることを明記しました。
  - usage-based add-onを利用できない構成では、この上限によりループ処理のスループットが制約されることを説明しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->