### PR TITLE
feat(webapp): 調研費 議員ページ（B-1〜B-5）

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       '@prisma/client':
         specifier: ^6.19.1
         version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      '@supabase/supabase-js':
+        specifier: ^2.89.0
+        version: 2.99.3
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(next@16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.63.0)(@types/node@25.5.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -10,6 +10,7 @@ import { reportProfilesSeeder } from './seeds/reportProfiles';
 import { researchFundAccountsSeeder } from './seeds/researchFundAccounts';
 import { researchFundJournalEntriesSeeder } from '@/prisma/seeds/researchFundJournalEntries';
 import { researchFundBooksSeeder } from './seeds/researchFundBooks';
+import { researchFundExpenditureGroupsSeeder } from './seeds/researchFundExpenditureGroups';
 import { tenantsSeeder } from './seeds/tenants';
 import { transactionsSeeder } from './seeds/transactions';
 import { usersSeeder } from './seeds/users';
@@ -32,6 +33,7 @@ const seeders: Seeder[] = [
   politiciansSeeder,
   researchFundBooksSeeder,
   researchFundJournalEntriesSeeder,
+  researchFundExpenditureGroupsSeeder,
 ];
 
 async function main() {

--- a/prisma/seeds/researchFundBooks.ts
+++ b/prisma/seeds/researchFundBooks.ts
@@ -5,10 +5,30 @@ interface ResearchFundBookSeedData {
   politicianSlug: string;
   financialYear: number;
   status: ResearchFundBookStatus;
+  /** 公開ページの「◯◯時点」 */
+  asOfDate?: string;
+  /** 公開ページの「次回更新◯◯の予定」 */
+  nextUpdateNote?: string;
+  /** 公開ページ B-3 の活用方針 */
+  policyComment?: string;
+  /** 公開ページ B-5「調査研究費のデータについて」の本文 */
+  details?: { dataNote: string };
 }
 
 const data: ResearchFundBookSeedData[] = [
-  { politicianSlug: 'sample-taro', financialYear: 2026, status: 'active' },
+  {
+    politicianSlug: 'sample-taro',
+    financialYear: 2026,
+    status: 'active',
+    asOfDate: '2026-08-20',
+    nextUpdateNote: '11月ごろ',
+    policyComment:
+      '2026年2月の当選後、まずは議員事務所の立ち上げに使っています。今後は調査活動や広報の比重を増やしていく予定です。',
+    details: {
+      dataNote:
+        '2026年2月の当選以降、仕訳が完了した支出を掲載しています。費目はチームみらい独自の詳細区分にマッピングし、使途等報告書で定められた法律上の区分にも切り替えて表示できます。',
+    },
+  },
   { politicianSlug: 'sample-hanako', financialYear: 2026, status: 'preparing' },
   { politicianSlug: 'e2e-politician', financialYear: 2026, status: 'active' },
 ];
@@ -43,6 +63,10 @@ export const researchFundBooksSeeder: Seeder = {
           politicianId: politician.id,
           financialYear: item.financialYear,
           status: item.status,
+          asOfDate: item.asOfDate ? new Date(item.asOfDate) : null,
+          nextUpdateNote: item.nextUpdateNote ?? null,
+          policyComment: item.policyComment ?? null,
+          details: item.details ?? undefined,
         },
       });
       console.log(`✅ Created: ${item.politicianSlug} (${item.financialYear})`);

--- a/prisma/seeds/researchFundExpenditureGroups.ts
+++ b/prisma/seeds/researchFundExpenditureGroups.ts
@@ -1,0 +1,91 @@
+import type { PrismaClient } from "@prisma/client";
+import type { Seeder } from "./lib/types";
+
+interface ExpenditureGroupSeedData {
+  title: string;
+  description: string;
+  displayOrder: number;
+  /** 紐づける仕訳の項目名（公開済みのものだけが成果カードに集計される） */
+  entryDescriptions: string[];
+  outcomes: { label: string; url: string | null }[];
+}
+
+// 公開ページ B-3「活用方針と主要な成果」の確認用。
+// 金額・件数・期間は紐づけた仕訳から自動集計するため、ここには書かない。
+const data: ExpenditureGroupSeedData[] = [
+  {
+    title: "意見受付窓口の開設",
+    description:
+      "有権者からの意見や陳情を受け付ける窓口として導入しました。初期費用および利用料です。",
+    displayOrder: 1,
+    entryDescriptions: ["ボネクタ利用料"],
+    outcomes: [{ label: "受付窓口を見る", url: "https://example.com/madoguchi" }],
+  },
+  {
+    title: "タウンミーティングの開催",
+    description: "有権者と直接意見交換する場として、貸会議室を借りました。",
+    displayOrder: 2,
+    entryDescriptions: ["会場費", "会議室利用料"],
+    // URL が無い成果物は公開側で「報告は準備中」と表示される。
+    outcomes: [{ label: "開催報告", url: null }],
+  },
+];
+
+export const researchFundExpenditureGroupsSeeder: Seeder = {
+  name: "Research Fund Expenditure Groups",
+  async seed(prisma: PrismaClient) {
+    const politician = await prisma.politician.findUnique({ where: { slug: "sample-taro" } });
+    if (!politician) {
+      console.log("⚠️  Politician not found: sample-taro, skipping");
+      return;
+    }
+    const book = await prisma.researchFundBook.findUnique({
+      where: { politicianId_financialYear: { politicianId: politician.id, financialYear: 2026 } },
+    });
+    if (!book) {
+      console.log("⚠️  Research fund book not found: sample-taro (2026), skipping");
+      return;
+    }
+
+    for (const item of data) {
+      const existing = await prisma.researchFundExpenditureGroup.findFirst({
+        where: { bookId: book.id, title: item.title },
+      });
+      if (existing) {
+        console.log(`⏭️  Already exists: ${item.title}`);
+        continue;
+      }
+
+      const entries = await prisma.researchFundJournalEntry.findMany({
+        where: {
+          bookId: book.id,
+          status: "published",
+          description: { in: item.entryDescriptions },
+        },
+        select: { id: true },
+      });
+      if (entries.length === 0) {
+        console.log(`⚠️  No published entries for ${item.title}, skipping`);
+        continue;
+      }
+
+      await prisma.researchFundExpenditureGroup.create({
+        data: {
+          bookId: book.id,
+          title: item.title,
+          description: item.description,
+          displayOrder: item.displayOrder,
+          outcomes: {
+            create: item.outcomes.map((outcome, index) => ({
+              label: outcome.label,
+              url: outcome.url,
+              displayOrder: index + 1,
+            })),
+          },
+          items: { create: entries.map((entry) => ({ entryId: entry.id })) },
+        },
+      });
+      console.log(`✅ Created: ${item.title} (${entries.length} entries)`);
+    }
+  },
+};

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -8,6 +8,11 @@ WEBAPP_URL=https://marumie.team-mir.ai
 DATA_REFRESH_TOKEN=your-secret-refresh-token
 
 # === 任意 ===
+# 調研費の領収書（非公開バケット）。未設定の場合、領収書は配信しない
+# SUPABASE_URL=http://127.0.0.1:54331
+# SUPABASE_SERVICE_ROLE_KEY=
+# RESEARCH_FUND_DOCUMENT_BUCKET=research-fund-documents
+
 # NEXT_PUBLIC_GA_TRACKING_ID=your-ga-tracking-id
 # USE_MOCK_DATA=true
 # MAINTENANCE_MODE=true

--- a/webapp/e2e/tests/research-fund.spec.ts
+++ b/webapp/e2e/tests/research-fund.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, type Locator } from "@playwright/test";
+
+// シードで公開済みの調研費データを持つ議員（prisma/seeds/researchFundJournalEntries.ts）。
+const PAGE_URL = "/p/sample-taro/2026";
+
+test.describe("調査研究費 議員ページ", () => {
+	test("B-1〜B-5 が表示され、実行時エラーが発生しないこと", async ({ page }) => {
+		const errors: string[] = [];
+		page.on("pageerror", (error) => {
+			errors.push(`${error.name}: ${error.message}`);
+		});
+
+		const response = await page.goto(PAGE_URL);
+
+		expect(response?.status()).toBe(200);
+		await expect(page).toHaveTitle(
+			/サンプル 太郎の調査研究費.*みらいまる見え政治資金/,
+		);
+
+		// B-1 使いみちの流れ（KPI2枚＋サンキー）
+		await expect(page.locator("#cash-flow").getByText("支給された")).toBeVisible();
+		await expect(
+			page.locator("#cash-flow").getByText("議員活動に使った"),
+		).toBeVisible();
+		await expect(
+			page.locator('[role="img"][aria-label="調査研究費の使いみちの流れ図"]'),
+		).toBeVisible();
+
+		// B-2 1年間の推移
+		await expect(
+			page.locator('#monthly-trends [role="img"][aria-label="月ごとの調査研究費の支給と支出"]'),
+		).toBeVisible();
+
+		// B-3 活用方針と主要な成果
+		await expect(
+			page.locator("#highlights").getByText("サンプル 太郎の調査研究費の活用方針"),
+		).toBeVisible();
+		await expect(page.getByText("タウンミーティングの開催")).toBeVisible();
+		// URL の無い成果物は「報告は準備中」と出す
+		await expect(page.getByText("開催報告：報告は準備中")).toBeVisible();
+
+		// B-4 すべての支出
+		await expect(
+			page.locator("#transactions").getByRole("heading", { name: /すべての支出/ }),
+		).toBeVisible();
+
+		// B-5 データについて
+		await expect(page.getByText("調査研究費のデータについて")).toBeVisible();
+		await expect(page.getByText(/余った分：.*は使っていません/)).toBeVisible();
+
+		expect(errors, `以下のエラーが発生しました:\n${errors.join("\n")}`).toHaveLength(0);
+	});
+
+	test("未公開（下書き・確認済）の仕訳は表示されない", async ({ page }) => {
+		await page.goto(PAGE_URL);
+
+		await selectMonth(page.locator("#transactions"), "8月");
+
+		// シードでは 8/10 以降が未公開（確認済・下書き）。8月を開いても出てこない。
+		await expect(
+			page.locator("#transactions").getByText(/^2026\.08\.(1|2|3)\d$/),
+		).toHaveCount(0);
+		await expect(
+			page.locator("#transactions").getByText("2026.08.02").first(),
+		).toBeVisible();
+	});
+
+	test("月を切り替えるとその月の支出だけが表示される", async ({ page }) => {
+		await page.goto(PAGE_URL);
+		const section = page.locator("#transactions");
+
+		await selectMonth(section, "4月");
+		await expect(section.getByText(/^4月の支出 \d+件・合計/)).toBeVisible();
+		await expect(section.getByText(/^2026\.05\./)).toHaveCount(0);
+	});
+
+	test("区分トグルで法律上の区分に切り替えられる", async ({ page }) => {
+		await page.goto(PAGE_URL);
+		const section = page.locator("#transactions");
+		const legalTab = section.getByRole("button", { name: "法律上の区分" });
+
+		await expect(async () => {
+			await legalTab.click();
+			await expect(legalTab).toHaveAttribute("aria-pressed", "true");
+		}).toPass();
+
+		await expect(section.getByText(/^[①-⑩]\s/).first()).toBeVisible();
+	});
+
+	test("特記事項のⓘを押すと注記が開く", async ({ page }) => {
+		await page.goto(PAGE_URL);
+		const section = page.locator("#transactions");
+
+		await selectMonth(section, "5月");
+		const infoButton = section
+			.getByRole("button", { name: /の特記事項$/ })
+			.first();
+		await expect(infoButton).toBeVisible();
+
+		await expect(async () => {
+			if ((await infoButton.getAttribute("aria-expanded")) !== "true") {
+				await infoButton.click();
+			}
+			await expect(infoButton).toHaveAttribute("aria-expanded", "true");
+		}).toPass();
+	});
+
+	test("存在しない議員のページは政治団体ページに寄せられる", async ({ page }) => {
+		await page.goto("/p/no-such-politician/2026");
+
+		await expect(page).toHaveURL(/\/o\/[\w-]+/);
+	});
+});
+
+/** ハイドレーション前のクリックを取りこぼさないよう、選択が反映されるまで押す。 */
+async function selectMonth(section: Locator, label: string) {
+	const button = section.getByRole("button", { name: label, exact: true });
+	await expect(button).toBeVisible();
+	await expect(async () => {
+		await button.click();
+		await expect(button).toHaveAttribute("aria-pressed", "true");
+	}).toPass();
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,6 +6,7 @@
     "@next/third-parties": "^16.1.1",
     "@nivo/sankey": "^0.99.0",
     "@prisma/client": "^6.19.1",
+    "@supabase/supabase-js": "^2.89.0",
     "@vercel/speed-insights": "^1.3.1",
     "apexcharts": "^5.3.6",
     "critters": "^0.0.25",

--- a/webapp/src/app/api/research-fund/receipts/[entryId]/route.ts
+++ b/webapp/src/app/api/research-fund/receipts/[entryId]/route.ts
@@ -1,0 +1,22 @@
+import "server-only";
+import { NextResponse } from "next/server";
+import { loadResearchFundReceiptUrl } from "@/server/contexts/research-fund/presentation/loaders/load-research-fund-receipt";
+
+// 署名URLは短時間で失効するため、レスポンスをキャッシュさせない。
+export const dynamic = "force-dynamic";
+
+/**
+ * 領収書の原本を配信する。非公開バケットの署名URLへリダイレクトするだけで、
+ * 公開済み（published）の仕訳に紐づくものしか返さない。
+ */
+export async function GET(_request: Request, { params }: { params: Promise<{ entryId: string }> }) {
+  const { entryId } = await params;
+  const signedUrl = await loadResearchFundReceiptUrl(entryId);
+  if (!signedUrl) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return new NextResponse(null, {
+    status: 307,
+    headers: { Location: signedUrl, "Cache-Control": "no-store" },
+  });
+}

--- a/webapp/src/app/p/[slug]/[year]/page.tsx
+++ b/webapp/src/app/p/[slug]/[year]/page.tsx
@@ -1,0 +1,59 @@
+import "server-only";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import AboutSection from "@/client/components/common/AboutSection";
+import LinkCardsSection from "@/client/components/common/LinkCardsSection";
+import MainColumn from "@/client/components/layout/MainColumn";
+import ResearchFundAboutSection from "@/client/components/research-fund/ResearchFundAboutSection";
+import ResearchFundExpensesSection from "@/client/components/research-fund/ResearchFundExpensesSection";
+import ResearchFundFlowSection from "@/client/components/research-fund/ResearchFundFlowSection";
+import ResearchFundHighlightsSection from "@/client/components/research-fund/ResearchFundHighlightsSection";
+import ResearchFundMonthlySection from "@/client/components/research-fund/ResearchFundMonthlySection";
+import { formatUpdatedAt } from "@/client/lib/format-date";
+import { loadResearchFundPage } from "@/server/contexts/research-fund/presentation/loaders/load-research-fund-page";
+
+export const revalidate = 300; // 5 minutes
+
+interface PoliticianPageProps {
+  params: Promise<{ slug: string; year: string }>;
+}
+
+/** 年度が数字でない URL では DB を引かずに 404 にする。 */
+function parseYear(year: string): number | null {
+  return /^\d{4}$/.test(year) ? Number(year) : null;
+}
+
+export async function generateMetadata({ params }: PoliticianPageProps): Promise<Metadata> {
+  const { slug, year } = await params;
+  const financialYear = parseYear(year);
+  const data = financialYear ? await loadResearchFundPage({ slug, financialYear }) : null;
+
+  return {
+    title: data
+      ? `${data.politician.name}の調査研究費 - みらいまる見え政治資金`
+      : "みらいまる見え政治資金",
+  };
+}
+
+export default async function PoliticianPage({ params }: PoliticianPageProps) {
+  const { slug, year } = await params;
+  const financialYear = parseYear(year);
+  const data = financialYear ? await loadResearchFundPage({ slug, financialYear }) : null;
+  if (!data) notFound();
+
+  // 「2026.8.20時点」。未設定なら公開範囲の最終日で代用する。
+  const updatedAt = formatUpdatedAt(data.asOfDate ?? null);
+  const hasHighlights = data.policyComment !== null || data.groups.length > 0;
+
+  return (
+    <MainColumn>
+      <ResearchFundFlowSection data={data} updatedAt={updatedAt} />
+      {hasHighlights && <ResearchFundHighlightsSection data={data} updatedAt={updatedAt} />}
+      <ResearchFundMonthlySection data={data} updatedAt={updatedAt} />
+      <ResearchFundExpensesSection data={data} updatedAt={updatedAt} />
+      <ResearchFundAboutSection data={data} />
+      <AboutSection />
+      <LinkCardsSection />
+    </MainColumn>
+  );
+}

--- a/webapp/src/app/p/[slug]/page.tsx
+++ b/webapp/src/app/p/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import "server-only";
+import { redirect } from "next/navigation";
+
+const DEFAULT_YEAR = 2026;
+
+/** 年度なしの URL は既定の年度へ寄せる（/o/[slug] と同じ挙動）。 */
+export default async function PoliticianYearRedirect({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  redirect(`/p/${encodeURIComponent(slug)}/${DEFAULT_YEAR}`);
+}

--- a/webapp/src/client/components/research-fund/CategoryModeTabs.tsx
+++ b/webapp/src/client/components/research-fund/CategoryModeTabs.tsx
@@ -1,0 +1,37 @@
+"use client";
+import "client-only";
+import type { ResearchFundCategoryMode } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+const TABS: { mode: ResearchFundCategoryMode; label: string }[] = [
+  { mode: "detailed", label: "詳細の区分" },
+  { mode: "legal", label: "法律上の区分" },
+];
+
+/** 区分トグル。文言・見た目とも既存の「収支の流れ」のタブに合わせる。 */
+export default function CategoryModeTabs({
+  value,
+  onChange,
+}: {
+  value: ResearchFundCategoryMode;
+  onChange: (mode: ResearchFundCategoryMode) => void;
+}) {
+  return (
+    <div className="flex gap-7 border-b border-gray-300 mb-4">
+      {TABS.map((tab) => (
+        <button
+          key={tab.mode}
+          type="button"
+          onClick={() => onChange(tab.mode)}
+          aria-pressed={value === tab.mode}
+          className={`pb-2 font-bold text-base border-b-2 transition-colors leading-tight cursor-pointer ${
+            value === tab.mode
+              ? "border-[#238778] text-[#238778]"
+              : "border-transparent text-[#9CA3AF] hover:text-gray-600"
+          }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/webapp/src/client/components/research-fund/ReceiptModal.tsx
+++ b/webapp/src/client/components/research-fund/ReceiptModal.tsx
@@ -1,0 +1,79 @@
+"use client";
+import "client-only";
+import { useEffect } from "react";
+import ResearchFundCategoryPill from "@/client/components/research-fund/ResearchFundCategoryPill";
+import type {
+  ResearchFundCategoryView,
+  ResearchFundExpenseView,
+} from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+interface Props {
+  expense: ResearchFundExpenseView;
+  category: ResearchFundCategoryView;
+  onClose: () => void;
+}
+
+/** 領収書の原本。署名URLはリクエストのたびに発行するので、画像はこのエンドポイント経由で読む。 */
+function receiptUrl(entryId: string): string {
+  return `/api/research-fund/receipts/${encodeURIComponent(entryId)}`;
+}
+
+export default function ReceiptModal({ expense, category, onClose }: Props) {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+      <button
+        type="button"
+        aria-label="閉じる"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default bg-black/40"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="領収書"
+        className="relative flex max-h-[88vh] w-full max-w-[520px] flex-col gap-6 overflow-auto rounded-3xl bg-white p-8"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-xl font-bold text-gray-800">領収書</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="cursor-pointer text-[15px] font-bold text-[#238778]"
+          >
+            閉じる
+          </button>
+        </div>
+
+        <dl className="grid grid-cols-[96px_1fr] gap-x-4 gap-y-3 text-sm text-gray-800">
+          <dt className="font-bold text-[#6B7280]">日付</dt>
+          <dd className="font-bold">{expense.date.replace(/-/g, ".")}</dd>
+          <dt className="font-bold text-[#6B7280]">カテゴリー</dt>
+          <dd>
+            <ResearchFundCategoryPill category={category} />
+          </dd>
+          <dt className="font-bold text-[#6B7280]">項目</dt>
+          <dd className="font-bold">{expense.description}</dd>
+          <dt className="font-bold text-[#6B7280]">金額</dt>
+          <dd className="font-bold text-[#DC2626]">-{expense.amount.toLocaleString("ja-JP")} 円</dd>
+          <dt className="font-bold text-[#6B7280]">特記事項</dt>
+          <dd className="leading-[1.7]">{expense.note ?? "特記事項はありません"}</dd>
+        </dl>
+
+        {/* 署名URLへのリダイレクトを返すエンドポイントなので、next/image の最適化は使えない */}
+        <img
+          src={receiptUrl(expense.entryId)}
+          alt={`${expense.description}の領収書`}
+          className="w-full rounded-2xl border border-[#E5E7EB] bg-[#F9FAFB]"
+        />
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundAboutSection.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundAboutSection.tsx
@@ -1,0 +1,89 @@
+import "server-only";
+import MainColumnCard from "@/client/components/layout/MainColumnCard";
+import MainButton from "@/client/components/ui/MainButton";
+import type { ResearchFundPageData } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+const BODY_CLASS =
+  "text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium sm:font-normal font-japanese";
+const HEADING_CLASS = "text-base sm:text-lg font-bold text-gray-800 mb-3 font-japanese";
+
+function formatMan(amount: number): string {
+  return `${Math.round(amount / 10000).toLocaleString("ja-JP")}万円`;
+}
+
+/**
+ * 未使用分の説明。返還額を成績のように見せないため、数字を出すのは
+ * サンキーの最終帯とこの文の2箇所だけにする（デザイン仕様 §5）。
+ */
+function unusedSentence(data: ResearchFundPageData): string {
+  const grantedMonths = data.monthly.filter((month) => month.granted > 0).length;
+  const period = grantedMonths > 0 ? `${grantedMonths}ヶ月分・` : "";
+  return `余った分：${formatMan(data.kpi.spent)}を使い、${formatMan(
+    data.unused,
+  )}は使っていません（${period}年末時点で確定します）。`;
+}
+
+/** B-5 データについて。既存の「データについて」と同構成に、調研費の記載を足す。 */
+export default function ResearchFundAboutSection({ data }: { data: ResearchFundPageData }) {
+  const updateNote = data.nextUpdateNote
+    ? `更新は不定期で、次回は${data.nextUpdateNote}の予定です。`
+    : "更新は不定期です。";
+
+  return (
+    <MainColumnCard id="explanation">
+      <div className="space-y-9">
+        <div>
+          <h3 className={HEADING_CLASS}>みらい まる見え政治資金について</h3>
+          <p className={BODY_CLASS}>
+            本プロジェクトは、チームみらいによって政治資金の透明化を目的に開発されたオープンソースソフトウェアです。すでにオープンソースで
+            <a
+              href="https://github.com/team-mirai-volunteer/marumie"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-bold text-[#238778] underline hover:no-underline"
+            >
+              こちらのGitHub
+            </a>
+            にて無償公開中であり、政党や所属を問わず利用可能な形で提供しております。開発コミュニティにご興味のある方は
+            <a
+              href="https://action.team-mir.ai/missions/join-slack"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-bold text-[#238778] underline hover:no-underline"
+            >
+              アクションボード
+            </a>
+            からSlackにご参加ください。
+          </p>
+        </div>
+
+        <div>
+          <h3 className={HEADING_CLASS}>調査研究費のデータについて</h3>
+          <p className={BODY_CLASS}>
+            {data.dataNote ??
+              `${data.financialYear}年に${data.politician.name}に支給された調査研究費のうち、仕訳が完了し公開した支出を1件ずつ掲載しています。費目はチームみらい独自の詳細区分にマッピングし、使途等報告書で定められた法律上の区分にも切り替えて表示できます。`}
+            {updateNote}
+            {unusedSentence(data)}
+          </p>
+        </div>
+
+        <div>
+          <h3 className={HEADING_CLASS}>免責事項</h3>
+          <p className={BODY_CLASS}>
+            本サイトで公開するデータは、可能な限り正確かつ最新の情報を反映するよう努めていますが、現時点においてはその正確性・完全性・即時性について保証するものではありません。最終的な使途は、別途公開される「調査研究広報滞在費の使途等報告書」をご確認ください。
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-center">
+        <a
+          href="https://team-mirai.notion.site/FAQ-27ef6f56bae180c085e9f97d05a5d59c"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <MainButton>よくあるご質問</MainButton>
+        </a>
+      </div>
+    </MainColumnCard>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundCategoryPill.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundCategoryPill.tsx
@@ -1,0 +1,25 @@
+import type { ResearchFundCategoryView } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+/**
+ * 費目のピル。既存の支出カテゴリと同じ「白背景・カテゴリ色の枠と文字」の形式。
+ * 「住居費（議員宿舎・宿泊費）」のように括弧書きのある費目は、括弧部分を一回り小さくする。
+ */
+export default function ResearchFundCategoryPill({
+  category,
+}: {
+  category: ResearchFundCategoryView;
+}) {
+  const parenIndex = category.label.indexOf("（");
+  const main = parenIndex < 0 ? category.label : category.label.slice(0, parenIndex);
+  const sub = parenIndex < 0 ? "" : category.label.slice(parenIndex);
+
+  return (
+    <span
+      className="inline-flex items-center whitespace-nowrap rounded-full border bg-white px-3 py-px text-xs font-medium leading-5"
+      style={{ borderColor: category.color, color: category.color }}
+    >
+      {main}
+      {sub && <span className="text-[10px]">{sub}</span>}
+    </span>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundExpensesSection.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundExpensesSection.tsx
@@ -1,0 +1,155 @@
+"use client";
+import "client-only";
+import Image from "next/image";
+import { useMemo, useState } from "react";
+import CardHeader from "@/client/components/layout/CardHeader";
+import MainColumnCard from "@/client/components/layout/MainColumnCard";
+import CategoryModeTabs from "@/client/components/research-fund/CategoryModeTabs";
+import ReceiptModal from "@/client/components/research-fund/ReceiptModal";
+import ResearchFundCategoryPill from "@/client/components/research-fund/ResearchFundCategoryPill";
+import type {
+  ResearchFundCategoryMode,
+  ResearchFundExpenseView,
+  ResearchFundPageData,
+} from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+interface Props {
+  data: ResearchFundPageData;
+  updatedAt: string;
+}
+
+const ROW_GRID = "md:grid-cols-[140px_200px_1fr_180px]";
+
+/**
+ * B-4 すべての支出。
+ *
+ * 4月だけで99件になる月があるため、月切り替えを必須にしている。
+ */
+export default function ResearchFundExpensesSection({ data, updatedAt }: Props) {
+  const months = useMemo(
+    () => [...new Set(data.expenses.map((expense) => expense.month))].sort(),
+    [data.expenses],
+  );
+  const [month, setMonth] = useState(() => months[months.length - 1] ?? "");
+  const [mode, setMode] = useState<ResearchFundCategoryMode>("detailed");
+  const [openNoteId, setOpenNoteId] = useState<string | null>(null);
+  const [receipt, setReceipt] = useState<ResearchFundExpenseView | null>(null);
+
+  const rows = useMemo(
+    () => data.expenses.filter((expense) => expense.month === month),
+    [data.expenses, month],
+  );
+  const total = rows.reduce((sum, row) => sum + row.amount, 0);
+
+  return (
+    <MainColumnCard id="transactions">
+      <CardHeader
+        icon={<Image src="/icons/icon-cashback.svg" alt="Cash move icon" width={30} height={30} />}
+        organizationName={data.politician.name}
+        title="すべての支出"
+        updatedAt={updatedAt}
+        subtitle="金額にかかわらず、すべての支出を1件ずつ、領収書つきで公開しています"
+      />
+
+      {months.length === 0 ? (
+        <p className="text-gray-500">公開中の支出はまだありません</p>
+      ) : (
+        <>
+          <fieldset className="flex flex-wrap gap-2">
+            <legend className="sr-only">月の切り替え</legend>
+            {months.map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => {
+                  setMonth(value);
+                  setOpenNoteId(null);
+                }}
+                aria-pressed={value === month}
+                className={`cursor-pointer rounded-full border px-4 py-1 text-sm font-bold transition-colors ${
+                  value === month
+                    ? "border-[#238778] bg-[#238778] text-white"
+                    : "border-[#D1D5DB] bg-white text-[#4B5563] hover:bg-[#F9FAFB]"
+                }`}
+              >
+                {Number(value.slice(5, 7))}月
+              </button>
+            ))}
+          </fieldset>
+
+          <div>
+            <CategoryModeTabs value={mode} onChange={setMode} />
+
+            <div
+              className={`hidden border-b border-[#D5DBE1] pb-3 text-sm font-bold text-gray-800 md:grid ${ROW_GRID}`}
+            >
+              <div className="px-4">日付</div>
+              <div className="pl-4">カテゴリー</div>
+              <div>項目</div>
+              <div className="pr-6 text-right">金額</div>
+            </div>
+
+            {rows.map((row) => {
+              const category = row[mode];
+              return (
+                <div key={row.id} className="border-b border-[#D5DBE1] py-3 md:py-0">
+                  <div className={`grid grid-cols-1 gap-1 md:items-center md:gap-0 ${ROW_GRID}`}>
+                    <div className="text-xs font-bold text-[#4B5563] md:px-4 md:py-5 md:text-base md:text-gray-800">
+                      {row.date.replace(/-/g, ".")}
+                    </div>
+                    <div className="md:pl-4">
+                      <ResearchFundCategoryPill category={category} />
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-bold text-gray-800 md:text-base">
+                        {row.description}
+                      </span>
+                      {row.note && (
+                        <button
+                          type="button"
+                          onClick={() => setOpenNoteId(openNoteId === row.id ? null : row.id)}
+                          aria-expanded={openNoteId === row.id}
+                          aria-label={`${row.description}の特記事項`}
+                          className="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border border-[#9CA3AF] text-[11px] font-bold text-[#6B7280] hover:bg-[#F3F4F6]"
+                        >
+                          i
+                        </button>
+                      )}
+                      {row.hasReceipt && (
+                        <button
+                          type="button"
+                          onClick={() => setReceipt(row)}
+                          className="inline-flex h-[22px] cursor-pointer items-center rounded-full border border-[#238778] px-2.5 text-xs font-bold text-[#238778] hover:bg-[#E2F6F3]"
+                        >
+                          領収書
+                        </button>
+                      )}
+                    </div>
+                    <div className="whitespace-nowrap text-base font-bold text-[#DC2626] md:pr-6 md:text-right md:text-xl">
+                      -{row.amount.toLocaleString("ja-JP")}
+                      <span className="text-xs font-normal text-[#4B5563]"> 円</span>
+                    </div>
+                  </div>
+                  {openNoteId === row.id && row.note && (
+                    <p className="pb-3 text-xs leading-relaxed text-[#6B7280] md:pb-4">
+                      {row.note}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+
+            <p className="mt-5 text-center text-sm font-medium text-[#6A7383]">
+              {Number(month.slice(5, 7))}月の支出 {rows.length}件・合計{" "}
+              {total.toLocaleString("ja-JP")}円
+            </p>
+          </div>
+        </>
+      )}
+
+      {receipt && (
+        <ReceiptModal expense={receipt} category={receipt[mode]} onClose={() => setReceipt(null)} />
+      )}
+    </MainColumnCard>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundFlowChart.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundFlowChart.tsx
@@ -1,0 +1,32 @@
+"use client";
+import "client-only";
+import { useState } from "react";
+import CategoryModeTabs from "@/client/components/research-fund/CategoryModeTabs";
+import SankeyChart from "@/client/components/top-page/features/charts/SankeyChart";
+import type {
+  ResearchFundCategoryMode,
+  ResearchFundPageData,
+} from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+/** B-1 のサンキー。区分トグルで詳細／法律上を切り替える。 */
+export default function ResearchFundFlowChart({
+  sankey,
+}: {
+  sankey: ResearchFundPageData["sankey"];
+}) {
+  const [mode, setMode] = useState<ResearchFundCategoryMode>("detailed");
+  const data = sankey[mode];
+
+  return (
+    <div>
+      <CategoryModeTabs value={mode} onChange={setMode} />
+      <div className="md:mx-0 -mx-3 mb-0">
+        {data.nodes.length > 0 ? (
+          <SankeyChart data={data} ariaLabel="調査研究費の使いみちの流れ図" />
+        ) : (
+          <div className="mx-4 text-gray-500">公開中の調査研究費のデータがありません</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundFlowChart.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundFlowChart.tsx
@@ -22,7 +22,11 @@ export default function ResearchFundFlowChart({
       <CategoryModeTabs value={mode} onChange={setMode} />
       <div className="md:mx-0 -mx-3 mb-0">
         {data.nodes.length > 0 ? (
-          <SankeyChart data={data} ariaLabel="調査研究費の使いみちの流れ図" />
+          <SankeyChart
+            data={data}
+            ariaLabel="調査研究費の使いみちの流れ図"
+            ariaDescription="調査研究費の支給から使いみちへのお金の流れを示すサンキーダイアグラムです。"
+          />
         ) : (
           <div className="mx-4 text-gray-500">公開中の調査研究費のデータがありません</div>
         )}

--- a/webapp/src/client/components/research-fund/ResearchFundFlowSection.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundFlowSection.tsx
@@ -1,0 +1,64 @@
+import "server-only";
+import Image from "next/image";
+import CardHeader from "@/client/components/layout/CardHeader";
+import MainColumnCard from "@/client/components/layout/MainColumnCard";
+import ResearchFundFlowChart from "@/client/components/research-fund/ResearchFundFlowChart";
+import FinancialSummaryCard from "@/client/components/top-page/features/financial-summary/FinancialSummaryCard";
+import { formatAmount } from "@/client/lib/financial-calculator";
+import type { ResearchFundPageData } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+interface Props {
+  data: ResearchFundPageData;
+  updatedAt: string;
+}
+
+/** B-1 使いみちの流れ。KPI2枚（支給された／議員活動に使った）＋区分トグル＋サンキー。 */
+export default function ResearchFundFlowSection({ data, updatedAt }: Props) {
+  return (
+    <MainColumnCard id="cash-flow">
+      <CardHeader
+        icon={<Image src="/icons/icon-cashflow.svg" alt="Cash flow icon" width={30} height={31} />}
+        organizationName={data.politician.name}
+        title="調査研究費の使いみち"
+        updatedAt={updatedAt}
+        subtitle="議員に毎月100万円支給される公費を、何に使ったか"
+      />
+
+      <details className="-mt-4">
+        <summary className="inline-flex cursor-pointer items-center gap-1.5 py-1 text-sm font-bold text-[#238778] hover:underline">
+          調査研究費とは
+        </summary>
+        <p className="mt-3 rounded-xl bg-gradient-to-br from-[#E2F6F3] to-[#EEF6E2] px-5 py-5 text-[15px] leading-[1.87] tracking-[0.01em] text-gray-800">
+          <strong className="mb-3 block text-lg font-bold leading-relaxed">
+            調査研究費は、政党を通らず国から議員に対して毎月直接支給される公費です。
+          </strong>
+          政党を経由しないため、政党の収支とは別のお金として公開しています。全額が税金で、議員活動にのみ使えます。選挙運動には使えません。余った分は国庫に返します。（正式名称：調査研究広報滞在費）
+        </p>
+      </details>
+
+      {/* KPI は2枚だけ。未使用分はカードにしない（デザイン仕様 §5） */}
+      <div className="flex flex-col gap-2 md:flex-row">
+        <FinancialSummaryCard
+          className="w-full md:flex-1"
+          title="支給された"
+          amount={formatAmount(data.kpi.granted)}
+          titleColor="#238778"
+          amountColor="#1F2937"
+        />
+        <FinancialSummaryCard
+          className="w-full md:flex-1"
+          title="議員活動に使った"
+          amount={formatAmount(data.kpi.spent)}
+          titleColor="#DC2626"
+          amountColor="#1F2937"
+        />
+      </div>
+
+      <ResearchFundFlowChart sankey={data.sankey} />
+
+      <div className="text-right md:hidden">
+        <span className="text-xs font-normal leading-[1.33] text-[#9CA3AF]">{updatedAt}</span>
+      </div>
+    </MainColumnCard>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundHighlightsSection.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundHighlightsSection.tsx
@@ -1,0 +1,112 @@
+import "server-only";
+import Image from "next/image";
+import CardHeader from "@/client/components/layout/CardHeader";
+import MainColumnCard from "@/client/components/layout/MainColumnCard";
+import ResearchFundCategoryPill from "@/client/components/research-fund/ResearchFundCategoryPill";
+import type {
+  ResearchFundGroupView,
+  ResearchFundPageData,
+} from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+interface Props {
+  data: ResearchFundPageData;
+  updatedAt: string;
+}
+
+function formatDate(date: string): string {
+  const [year, month, day] = date.split("-");
+  return `${year}.${Number(month)}.${Number(day)}`;
+}
+
+function formatPeriod(period: ResearchFundGroupView["period"]): string {
+  if (!period) return "";
+  return period.start === period.end
+    ? formatDate(period.start)
+    : `${formatDate(period.start)}〜${formatDate(period.end)}`;
+}
+
+/** B-3 主要な支出の成果。活用方針と、支出群ごとの成果カード。 */
+export default function ResearchFundHighlightsSection({ data, updatedAt }: Props) {
+  return (
+    <MainColumnCard id="highlights">
+      <CardHeader
+        icon={<Image src="/icons/icon-heart-handshake.svg" alt="" width={30} height={30} />}
+        organizationName={data.politician.name}
+        title="活用方針と主要な成果"
+        updatedAt={updatedAt}
+        subtitle="調査研究費の使用方針と、主要な支出に対する成果"
+      />
+
+      {data.policyComment && (
+        <div className="border-l-4 border-[#9CA3AF] bg-[#F3F4F6] px-6 py-5">
+          <div className="text-base font-bold text-gray-800">
+            {data.politician.name}の調査研究費の活用方針
+          </div>
+          <p className="mt-2 text-[15px] leading-[1.87] tracking-[0.01em] text-gray-800">
+            {data.policyComment}
+          </p>
+        </div>
+      )}
+
+      {data.groups.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {data.groups.map((group, index) => (
+            <div
+              key={group.id}
+              id={`highlight-${group.id}`}
+              className="flex flex-col gap-3 rounded-2xl border border-[#E5E7EB] p-5"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="inline-flex h-5 items-center rounded-full bg-[#E2F6F3] px-2 text-[11px] font-bold text-[#238778]">
+                  成果{index + 1}
+                </span>
+                <span className="text-xs text-[#4B5563]">
+                  {formatPeriod(group.period)}
+                  {group.count > 0 && `　${group.count}件`}
+                </span>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <span className="text-lg font-bold text-gray-800">{group.title}</span>
+                <span className="whitespace-nowrap text-xl font-bold tracking-[0.01em] text-[#DC2626]">
+                  -{group.amount.toLocaleString("ja-JP")}
+                  <span className="text-xs font-normal text-[#4B5563]"> 円</span>
+                </span>
+              </div>
+
+              {group.categories.length > 0 && (
+                <div className="flex flex-wrap gap-1.5">
+                  {group.categories.map((category) => (
+                    <ResearchFundCategoryPill key={category.label} category={category} />
+                  ))}
+                </div>
+              )}
+
+              <p className="text-sm leading-[1.87] text-gray-800">{group.description}</p>
+
+              {group.outcomes.map((outcome) =>
+                outcome.url ? (
+                  <a
+                    key={outcome.label}
+                    href={outcome.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 self-start text-sm font-bold text-[#238778] underline hover:no-underline"
+                  >
+                    {outcome.label}
+                    <Image src="/icons/icon-outerlink.svg" alt="" width={14} height={14} />
+                  </a>
+                ) : (
+                  // 成果物の公開が間に合っていない支出群も隠さず、準備中と明示する。
+                  <span key={outcome.label} className="text-sm text-[#9CA3AF]">
+                    {outcome.label}：報告は準備中
+                  </span>
+                ),
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </MainColumnCard>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundMonthlyChart.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundMonthlyChart.tsx
@@ -51,6 +51,7 @@ export default function ResearchFundMonthlyChart({
       aria-label="月ごとの調査研究費の支給と支出"
     >
       <title>月ごとの調査研究費の支給と支出</title>
+      {/* ticks はゼロ線の下側を負の座標で持つが、支出額そのものは非負なのでラベルに符号は出さない。 */}
       {ticks.map((value) => (
         <text
           key={`tick-${value}`}
@@ -62,7 +63,7 @@ export default function ResearchFundMonthlyChart({
           fontWeight={500}
           fill={LABEL_COLOR}
         >
-          {formatMan(value)}
+          {formatMan(Math.abs(value))}
         </text>
       ))}
       <line

--- a/webapp/src/client/components/research-fund/ResearchFundMonthlyChart.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundMonthlyChart.tsx
@@ -1,0 +1,131 @@
+import type { ResearchFundMonthView } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+const WIDTH = 936;
+const HEIGHT = 420;
+const MARGIN = { top: 20, right: 24, bottom: 44, left: 88 };
+const PLOT_HEIGHT = HEIGHT - MARGIN.top - MARGIN.bottom;
+const ZERO_Y = MARGIN.top + PLOT_HEIGHT / 2;
+const BAR_WIDTH = 40;
+
+const GRANT_COLOR = "#2AA693";
+const SPEND_COLOR = "#DC2626";
+const AXIS_COLOR = "#E2E8F0";
+const LABEL_COLOR = "#4B5563";
+
+/** 目盛りの候補。ラベルが6本を超えない一番細かい刻みを選ぶ。 */
+const TICK_CANDIDATES = [100_000, 500_000, 1_000_000, 5_000_000, 10_000_000, 50_000_000];
+
+function formatMan(amount: number): string {
+  return `${Math.round(amount / 10000).toLocaleString("ja-JP")}万円`;
+}
+
+function scaleOf(monthly: readonly ResearchFundMonthView[]) {
+  const maxAbs = Math.max(1, ...monthly.map((month) => Math.max(month.granted, month.spent)));
+  const target = maxAbs * 1.2;
+  const tick =
+    TICK_CANDIDATES.find((candidate) => target / candidate <= 6) ??
+    TICK_CANDIDATES[TICK_CANDIDATES.length - 1];
+  const yMax = Math.max(tick, Math.ceil(target / tick) * tick);
+  return { tick, yMax, pixelsPerYen: PLOT_HEIGHT / 2 / yMax };
+}
+
+/**
+ * B-2 1年間の推移。中央のゼロ線から上が支給、下が支出の上下対向の棒グラフ。
+ * まだ公開していない月は、データが無いのではないことが伝わるよう点線の空枠で描く。
+ */
+export default function ResearchFundMonthlyChart({
+  monthly,
+}: {
+  monthly: ResearchFundMonthView[];
+}) {
+  const { tick, yMax, pixelsPerYen } = scaleOf(monthly);
+  const step = (WIDTH - MARGIN.left - MARGIN.right) / Math.max(monthly.length, 1);
+  const ticks: number[] = [];
+  for (let value = -yMax; value <= yMax; value += tick) ticks.push(value);
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width="100%"
+      role="img"
+      aria-label="月ごとの調査研究費の支給と支出"
+    >
+      <title>月ごとの調査研究費の支給と支出</title>
+      {ticks.map((value) => (
+        <text
+          key={`tick-${value}`}
+          x={MARGIN.left - 12}
+          y={ZERO_Y - value * pixelsPerYen}
+          textAnchor="end"
+          dominantBaseline="middle"
+          fontSize={14}
+          fontWeight={500}
+          fill={LABEL_COLOR}
+        >
+          {formatMan(value)}
+        </text>
+      ))}
+      <line
+        x1={MARGIN.left}
+        y1={MARGIN.top}
+        x2={MARGIN.left}
+        y2={MARGIN.top + PLOT_HEIGHT}
+        stroke={AXIS_COLOR}
+      />
+      {monthly.map((month, index) => {
+        const centerX = MARGIN.left + step * index + step / 2;
+        const x = centerX - BAR_WIDTH / 2;
+        const monthLabel = `${Number(month.month.slice(5, 7))}月`;
+        return (
+          <g key={month.month}>
+            {month.published ? (
+              <>
+                <rect
+                  x={x}
+                  y={ZERO_Y - month.granted * pixelsPerYen}
+                  width={BAR_WIDTH}
+                  height={month.granted * pixelsPerYen}
+                  fill={GRANT_COLOR}
+                />
+                <rect
+                  x={x}
+                  y={ZERO_Y}
+                  width={BAR_WIDTH}
+                  height={month.spent * pixelsPerYen}
+                  fill={SPEND_COLOR}
+                />
+              </>
+            ) : (
+              <rect
+                x={x}
+                y={ZERO_Y - tick * pixelsPerYen}
+                width={BAR_WIDTH}
+                height={tick * pixelsPerYen}
+                fill="none"
+                stroke="#C3C8D0"
+                strokeDasharray="4 4"
+              />
+            )}
+            <text
+              x={centerX}
+              y={MARGIN.top + PLOT_HEIGHT + 24}
+              textAnchor="middle"
+              fontSize={14}
+              fontWeight={500}
+              fill={month.published ? LABEL_COLOR : "#9CA3AF"}
+            >
+              {monthLabel}
+            </text>
+          </g>
+        );
+      })}
+      <line
+        x1={MARGIN.left}
+        y1={ZERO_Y}
+        x2={WIDTH - MARGIN.right}
+        y2={ZERO_Y}
+        stroke={LABEL_COLOR}
+      />
+    </svg>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundMonthlySection.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundMonthlySection.tsx
@@ -1,0 +1,58 @@
+import "server-only";
+import Image from "next/image";
+import CardHeader from "@/client/components/layout/CardHeader";
+import MainColumnCard from "@/client/components/layout/MainColumnCard";
+import ResearchFundMonthlyChart from "@/client/components/research-fund/ResearchFundMonthlyChart";
+import type { ResearchFundPageData } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+interface Props {
+  data: ResearchFundPageData;
+  updatedAt: string;
+}
+
+const LEGEND = [
+  { label: "支給", color: "#2AA693" },
+  { label: "支出", color: "#DC2626" },
+  { label: "未公開", color: null },
+];
+
+/** B-2 1年間の推移。 */
+export default function ResearchFundMonthlySection({ data, updatedAt }: Props) {
+  return (
+    <MainColumnCard id="monthly-trends">
+      <CardHeader
+        icon={<Image src="/icons/icon-barchart.svg" alt="Bar chart icon" width={30} height={30} />}
+        organizationName={data.politician.name}
+        title="月ごとの支出の推移"
+        updatedAt={updatedAt}
+        subtitle="今年の月ごとの支給と支出"
+      />
+
+      <div className="-mr-[18px] overflow-x-auto sm:mr-0">
+        <div className="min-w-[640px]">
+          <ResearchFundMonthlyChart monthly={data.monthly} />
+        </div>
+      </div>
+
+      <div className="-mt-4 flex flex-wrap justify-end gap-3 text-sm font-bold text-[#4B5563]">
+        {LEGEND.map((item) => (
+          <span key={item.label} className="flex items-center gap-1.5">
+            <span
+              className="inline-block h-3 w-3"
+              style={
+                item.color
+                  ? { background: item.color }
+                  : { border: "1px dashed #C3C8D0", background: "transparent" }
+              }
+            />
+            {item.label}
+          </span>
+        ))}
+      </div>
+
+      <div className="text-right md:hidden">
+        <span className="text-xs font-normal leading-[1.33] text-[#9CA3AF]">{updatedAt}</span>
+      </div>
+    </MainColumnCard>
+  );
+}

--- a/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
@@ -88,6 +88,8 @@ interface SankeyNodeWithPosition {
 
 interface SankeyChartProps {
   data: SankeyData;
+  /** 図の内容を説明する読み上げ用のラベル。政治資金以外の図でも使えるように差し替えられる。 */
+  ariaLabel?: string;
 }
 
 const getNodeWidth = (nodeType: string | undefined, isMobile: boolean) => {
@@ -489,7 +491,10 @@ const CustomLabelsLayer = ({ nodes }: { nodes: readonly SankeyNodeWithPosition[]
   );
 };
 
-export default function SankeyChart({ data }: SankeyChartProps) {
+export default function SankeyChart({
+  data,
+  ariaLabel = "政治資金の収支フロー図",
+}: SankeyChartProps) {
   const isMobile = useMobileDetection();
   const { getNodeColor } = useNodeColors();
 
@@ -535,7 +540,7 @@ export default function SankeyChart({ data }: SankeyChartProps) {
       }}
       className="sankey-container !mb-0"
       role="img"
-      aria-label="政治資金の収支フロー図"
+      aria-label={ariaLabel}
       aria-describedby="sankey-chart-description"
     >
       <div id="sankey-chart-description" className="sr-only">

--- a/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
@@ -90,6 +90,8 @@ interface SankeyChartProps {
   data: SankeyData;
   /** 図の内容を説明する読み上げ用のラベル。政治資金以外の図でも使えるように差し替えられる。 */
   ariaLabel?: string;
+  /** 図の詳細を説明する読み上げ用テキスト。ariaLabel と食い違わないよう合わせて差し替える。 */
+  ariaDescription?: string;
 }
 
 const getNodeWidth = (nodeType: string | undefined, isMobile: boolean) => {
@@ -494,6 +496,7 @@ const CustomLabelsLayer = ({ nodes }: { nodes: readonly SankeyNodeWithPosition[]
 export default function SankeyChart({
   data,
   ariaLabel = "政治資金の収支フロー図",
+  ariaDescription = "政治資金の収入から支出へのお金の流れを示すサンキーダイアグラムです。",
 }: SankeyChartProps) {
   const isMobile = useMobileDetection();
   const { getNodeColor } = useNodeColors();
@@ -544,7 +547,7 @@ export default function SankeyChart({
       aria-describedby="sankey-chart-description"
     >
       <div id="sankey-chart-description" className="sr-only">
-        政治資金の収入から支出へのお金の流れを示すサンキーダイアグラムです。
+        {ariaDescription}
       </div>
       <style jsx global>{`
         .sankey-container svg path:hover {

--- a/webapp/src/client/components/top-page/features/charts/useSankeyHelpers.ts
+++ b/webapp/src/client/components/top-page/features/charts/useSankeyHelpers.ts
@@ -21,7 +21,15 @@ const COLORS = {
   PROCESSING_ERROR: "#F87171", // (仕訳中)のエラー色
   PROCESSING_LIGHT: "#FFF2F2", // (仕訳中)の薄い色
   PERCENTAGE_DARK: "#111827", // パーセンテージ表記の濃い色（収支・昨年残高用）
+  UNUSED_BOX: "#6B7280", // 調研費の未使用分（他の帯より後退させる）
+  UNUSED_LIGHT: "#E5E7EB", // 調研費の未使用分の薄い色
 } as const;
+
+/**
+ * 調研費の未使用分。支出の費目と同じ右端に並ぶが、使った額と同列に見せないよう
+ * 淡色にして末尾に固定する。年度途中は返還額が確定しないため「国庫へ返還」とは呼ばない。
+ */
+const UNUSED_LABEL = "未使用";
 
 // モバイル検知のカスタムフック
 export function useMobileDetection() {
@@ -65,6 +73,10 @@ export function useNodeColors() {
 
       if (nodeLabel === "未払費用") {
         return variant === "light" ? COLORS.PROCESSING_LIGHT : COLORS.PROCESSING_ERROR;
+      }
+
+      if (nodeLabel === UNUSED_LABEL) {
+        return variant === "light" ? COLORS.UNUSED_LIGHT : COLORS.UNUSED_BOX;
       }
 
       // 通常のノードタイプ判定
@@ -200,8 +212,9 @@ export function useSankeySorting(data: SankeyData) {
         const aValue = calculateNodeValue(a.id, data.links);
         const bValue = calculateNodeValue(b.id, data.links);
 
-        const aIsCarryover = a.label === "現金残高";
-        const bIsCarryover = b.label === "現金残高";
+        // 現金残高（政治資金）と未使用（調研費）はどちらも末尾に置く。
+        const aIsCarryover = a.label === "現金残高" || a.label === UNUSED_LABEL;
+        const bIsCarryover = b.label === "現金残高" || b.label === UNUSED_LABEL;
         const aIsProcessing = a.label === "(仕訳中)";
         const bIsProcessing = b.label === "(仕訳中)";
 

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-sankey-aggregation-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-sankey-aggregation-usecase.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import type { SankeyData } from "@/server/contexts/public-finance/domain/models/sankey-data";
+import type { SankeyData } from "@/server/contexts/shared/domain/models/sankey-data";
 import type { IPoliticalOrganizationRepository } from "@/server/contexts/public-finance/domain/repositories/political-organization-repository.interface";
 import type { IBalanceSheetRepository } from "@/server/contexts/public-finance/domain/repositories/balance-sheet-repository.interface";
 import type { ITransactionRepository } from "@/server/contexts/public-finance/domain/repositories/transaction-repository.interface";

--- a/webapp/src/server/contexts/public-finance/domain/services/sankey-data-builder.ts
+++ b/webapp/src/server/contexts/public-finance/domain/services/sankey-data-builder.ts
@@ -13,7 +13,7 @@ import type {
   SankeyData,
   SankeyLink,
   SankeyNode,
-} from "@/server/contexts/public-finance/domain/models/sankey-data";
+} from "@/server/contexts/shared/domain/models/sankey-data";
 
 /**
  * SankeyDataを構築するビルダークラス

--- a/webapp/src/server/contexts/public-finance/infrastructure/prisma.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/prisma.ts
@@ -1,17 +1,5 @@
 import "server-only";
 
-import { PrismaClient } from "@prisma/client";
-
-const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
-};
-
-export const prisma =
-  globalForPrisma.prisma ??
-  new PrismaClient({
-    log: ["query"],
-  });
-
-if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
-}
+// Prisma クライアントは全コンテキストで1つを共有する。
+// 既存の参照パスを維持するため、ここでは shared の実体を再輸出するだけにしている。
+export { prisma } from "@/server/contexts/shared/infrastructure/prisma";

--- a/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase.ts
+++ b/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase.ts
@@ -1,0 +1,103 @@
+import "server-only";
+import type {
+  PublishedAccount,
+  PublishedExpenditureGroup,
+} from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type {
+  ResearchFundCategoryView,
+  ResearchFundGroupView,
+  ResearchFundPageData,
+} from "@/server/contexts/research-fund/domain/models/research-fund-page";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+import { researchFundCategoryColor } from "@/server/contexts/research-fund/domain/services/research-fund-category-color";
+import { parseResearchFundDetails } from "@/server/contexts/research-fund/domain/services/research-fund-details";
+import { buildExpenseViews } from "@/server/contexts/research-fund/domain/services/research-fund-expense-list";
+import { buildMonthlyViews } from "@/server/contexts/research-fund/domain/services/research-fund-monthly";
+import { buildResearchFundSankey } from "@/server/contexts/research-fund/domain/services/research-fund-sankey-builder";
+import {
+  aggregateResearchFund,
+  type ResearchFundAggregation,
+  type ResearchFundRow,
+} from "@/shared/research-fund/aggregation";
+import { aggregateLinkedEntries } from "@/shared/research-fund/expenditure-group";
+
+export interface GetResearchFundPageParams {
+  slug: string;
+  financialYear: number;
+}
+
+export class GetResearchFundPageUsecase {
+  constructor(private repository: ResearchFundRepository) {}
+
+  /** 議員ページ（B-1〜B-5）のデータ。帳簿が無ければ null を返し、呼び出し側が 404 にする。 */
+  async execute(params: GetResearchFundPageParams): Promise<ResearchFundPageData | null> {
+    const published = await this.repository.findPublished(params.slug, params.financialYear);
+    if (!published) return null;
+
+    const detailed = aggregate(published.rows, published.accounts, "detailed");
+    const legal = aggregate(published.rows, published.accounts, "legal");
+    const details = parseResearchFundDetails(published.details);
+
+    return {
+      politician: published.politician,
+      financialYear: published.financialYear,
+      asOfDate: published.asOfDate,
+      nextUpdateNote: published.nextUpdateNote,
+      policyComment: published.policyComment,
+      dataNote: details.dataNote,
+      kpi: detailed.kpi,
+      unused: detailed.unused,
+      sankey: {
+        detailed: buildResearchFundSankey(detailed),
+        legal: buildResearchFundSankey(legal),
+      },
+      monthly: buildMonthlyViews(
+        detailed.monthly,
+        published.financialYear,
+        published.publishedThrough,
+      ),
+      expenses: buildExpenseViews(published.expenses, published.accounts),
+      groups: published.groups.map((group) => buildGroupView(group, published.accounts)),
+    };
+  }
+}
+
+function aggregate(
+  rows: readonly ResearchFundRow[],
+  accounts: Readonly<Record<string, PublishedAccount>>,
+  mode: "detailed" | "legal",
+): ResearchFundAggregation {
+  const result = aggregateResearchFund(rows, accounts, mode);
+  if (result.status === "invalid")
+    throw new Error(
+      `調研費の集計に失敗しました: ${result.errors.map((error) => `${error.path} ${error.message}`).join(", ")}`,
+    );
+  return result.value;
+}
+
+function buildGroupView(
+  group: PublishedExpenditureGroup,
+  accounts: Readonly<Record<string, PublishedAccount>>,
+): ResearchFundGroupView {
+  // 金額・件数・期間は紐づいた仕訳から自動集計する（admin の編集画面と同じ値になる）。
+  const summary = aggregateLinkedEntries(group.entries);
+  const categories = new Map<string, ResearchFundCategoryView>();
+  for (const entry of group.entries) {
+    const account = accounts[entry.accountKey];
+    if (!account || categories.has(entry.accountKey)) continue;
+    categories.set(entry.accountKey, {
+      label: account.label,
+      color: researchFundCategoryColor(account.legalCategoryKey),
+    });
+  }
+  return {
+    id: group.id,
+    title: group.title,
+    description: group.description,
+    amount: summary.amount,
+    count: summary.count,
+    period: summary.period,
+    categories: [...categories.values()],
+    outcomes: group.outcomes,
+  };
+}

--- a/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase.ts
+++ b/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import type { ReceiptStorage } from "@/server/contexts/research-fund/domain/repositories/receipt-storage.interface";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+/** 署名URLの有効期限（秒）。開いてすぐ表示する用途なので短くする。 */
+const SIGNED_URL_EXPIRES_IN = 300;
+
+export class GetResearchFundReceiptUsecase {
+  constructor(
+    private repository: ResearchFundRepository,
+    private storage: ReceiptStorage,
+  ) {}
+
+  /**
+   * published の仕訳に紐づく領収書の署名URL。
+   * 未公開の仕訳・存在しない仕訳は null を返し、公開前の領収書が漏れないようにする。
+   */
+  async execute(entryId: string): Promise<string | null> {
+    if (!/^[1-9]\d*$/.test(entryId)) return null;
+    const receipt = await this.repository.findPublishedReceipt(entryId);
+    if (!receipt) return null;
+    return await this.storage.createSignedUrl(receipt.storageKey, SIGNED_URL_EXPIRES_IN);
+  }
+}

--- a/webapp/src/server/contexts/research-fund/domain/models/published-research-fund.ts
+++ b/webapp/src/server/contexts/research-fund/domain/models/published-research-fund.ts
@@ -1,0 +1,73 @@
+/**
+ * 公開ページが読む調研費データ。
+ *
+ * published の仕訳だけを射影したものであり、draft / approved の仕訳と
+ * 公開されない備考（memo）はこの型に入らない（= 画面に出ない）。
+ */
+import type { ResearchFundCategory, ResearchFundRow } from "@/shared/research-fund/aggregation";
+
+/** 費目（科目マスタ）。法定区分のキーはカテゴリーピルの色に使う。 */
+export interface PublishedAccount extends ResearchFundCategory {
+  legalCategoryKey: string;
+}
+
+/**
+ * 公開された支出1行（仕訳の借方・費用行1つ）。
+ * 同一注文の分割行は splitGroup が同じになる。
+ */
+export interface PublishedExpense {
+  /** 行の一意キー（仕訳明細のID） */
+  id: string;
+  /** 領収書の取得に使う仕訳のID */
+  entryId: string;
+  /** 帳簿上の日付（YYYY-MM-DD）。タイムゾーンによる月のずれを避ける。 */
+  date: string;
+  accountKey: string;
+  description: string;
+  amount: number;
+  /** 特記事項（公開される）。備考（memo）は含まない。 */
+  note: string | null;
+  splitGroup: string | null;
+  hasReceipt: boolean;
+}
+
+/** 成果物。url が無ければ公開側は「報告は準備中」と表示する。 */
+export interface PublishedOutcome {
+  label: string;
+  url: string | null;
+}
+
+/** 支出群（主要な支出の成果）。金額・件数・期間は紐づいた仕訳から集計する。 */
+export interface PublishedExpenditureGroup {
+  id: string;
+  title: string;
+  description: string;
+  outcomes: PublishedOutcome[];
+  /** 紐づいた published の仕訳。未公開の仕訳は含めない。 */
+  entries: { entryDate: string; amount: number; accountKey: string }[];
+}
+
+export interface PublishedResearchFund {
+  politician: { name: string; slug: string };
+  financialYear: number;
+  /** 「2026.8.20時点」。未設定なら null */
+  asOfDate: string | null;
+  /** 「次回更新 11月ごろ」。未設定なら null */
+  nextUpdateNote: string | null;
+  /** 活用方針（議員本人が書く1〜2行）。未設定なら null */
+  policyComment: string | null;
+  /** B-5「データについて」の説明文。未設定なら null */
+  details: unknown;
+  /** 何月分まで公開したか（YYYY-MM-DD）。未設定なら null */
+  publishedThrough: string | null;
+  /** 集計に渡す行（支給と支出）。 */
+  rows: ResearchFundRow[];
+  accounts: Record<string, PublishedAccount>;
+  expenses: PublishedExpense[];
+  groups: PublishedExpenditureGroup[];
+}
+
+/** 公開された領収書。published の仕訳に紐づくものだけを配信する。 */
+export interface PublishedReceipt {
+  storageKey: string;
+}

--- a/webapp/src/server/contexts/research-fund/domain/models/research-fund-page.ts
+++ b/webapp/src/server/contexts/research-fund/domain/models/research-fund-page.ts
@@ -1,0 +1,75 @@
+/**
+ * 調研費 議員ページ（B-1〜B-5）が描くためのデータ。
+ *
+ * published の仕訳だけから作る。区分トグル（詳細／法律上）はクライアント側で
+ * 切り替えるだけで済むよう、両方の区分を先に組み立てて渡す。
+ */
+import type { SankeyData } from "@/types/sankey";
+
+/** 区分トグルの値。既存の収支の流れと同じ2択。 */
+export type ResearchFundCategoryMode = "detailed" | "legal";
+
+/** カテゴリーピル1つ分の表示情報。 */
+export interface ResearchFundCategoryView {
+  label: string;
+  /** 白背景・この色の枠と文字（既存の支出ピルと同じ形式） */
+  color: string;
+}
+
+/** B-4 の明細1行。区分トグルで detailed / legal を出し分ける。 */
+export interface ResearchFundExpenseView {
+  /** 行の一意キー */
+  id: string;
+  /** 領収書の取得に使う仕訳のID */
+  entryId: string;
+  /** 帳簿上の日付（YYYY-MM-DD） */
+  date: string;
+  /** 表示する月（YYYY-MM）。月切り替えの絞り込みに使う。 */
+  month: string;
+  description: string;
+  amount: number;
+  detailed: ResearchFundCategoryView;
+  legal: ResearchFundCategoryView;
+  /** 特記事項。同一注文の分割行はその説明もここに含む。無ければ null */
+  note: string | null;
+  hasReceipt: boolean;
+}
+
+/** B-2 の1か月分。未公開の月は published が false になり、点線の空枠で描く。 */
+export interface ResearchFundMonthView {
+  /** YYYY-MM */
+  month: string;
+  granted: number;
+  spent: number;
+  published: boolean;
+}
+
+/** B-3 の成果カード1枚。 */
+export interface ResearchFundGroupView {
+  id: string;
+  title: string;
+  description: string;
+  amount: number;
+  count: number;
+  /** 紐づいた仕訳の期間。紐づけが無ければ null */
+  period: { start: string; end: string } | null;
+  categories: ResearchFundCategoryView[];
+  outcomes: { label: string; url: string | null }[];
+}
+
+export interface ResearchFundPageData {
+  politician: { name: string; slug: string };
+  financialYear: number;
+  asOfDate: string | null;
+  nextUpdateNote: string | null;
+  policyComment: string | null;
+  /** B-5「調査研究費のデータについて」の本文。未設定なら null */
+  dataNote: string | null;
+  kpi: { granted: number; spent: number };
+  /** 支給されて、まだ使っていない額。「国庫へ返還」とは呼ばない。 */
+  unused: number;
+  sankey: Record<ResearchFundCategoryMode, SankeyData>;
+  monthly: ResearchFundMonthView[];
+  expenses: ResearchFundExpenseView[];
+  groups: ResearchFundGroupView[];
+}

--- a/webapp/src/server/contexts/research-fund/domain/repositories/receipt-storage.interface.ts
+++ b/webapp/src/server/contexts/research-fund/domain/repositories/receipt-storage.interface.ts
@@ -1,0 +1,4 @@
+export interface ReceiptStorage {
+  /** 非公開バケットの領収書を、期限つきの署名URLで配信する。 */
+  createSignedUrl(storageKey: string, expiresIn: number): Promise<string>;
+}

--- a/webapp/src/server/contexts/research-fund/domain/repositories/research-fund-repository.interface.ts
+++ b/webapp/src/server/contexts/research-fund/domain/repositories/research-fund-repository.interface.ts
@@ -1,0 +1,12 @@
+import type {
+  PublishedReceipt,
+  PublishedResearchFund,
+} from "@/server/contexts/research-fund/domain/models/published-research-fund";
+
+export interface ResearchFundRepository {
+  /** 議員の slug と年度から、published の仕訳だけを射影して返す。帳簿が無ければ null */
+  findPublished(slug: string, financialYear: number): Promise<PublishedResearchFund | null>;
+
+  /** published の仕訳に紐づく領収書だけを返す。未公開の仕訳の領収書は返さない。 */
+  findPublishedReceipt(entryId: string): Promise<PublishedReceipt | null>;
+}

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-category-color.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-category-color.ts
@@ -1,0 +1,25 @@
+/**
+ * カテゴリーピルの色。
+ *
+ * 調研費だけ別物の見た目にしないため（デザイン仕様 §5）、既存の支出カテゴリと同じ
+ * 色域を使う。法定区分ごとに1色を決め、詳細の21分類はその法定区分の色を継承する。
+ */
+const LEGAL_CATEGORY_COLORS: Record<string, string> = {
+  personnel: "#0369A1", // ① 人件費
+  utilities: "#126C81", // ② 光熱水費
+  "equipment-supplies": "#4D7C0F", // ③ 備品・消耗品費
+  office: "#047857", // ④ 事務所費
+  exchange: "#C2410C", // ⑤ 交流費
+  publicity: "#A16207", // ⑥ 広報紙誌の発行その他の事業費
+  research: "#047857", // ⑦ 調査研究費
+  donation: "#BE185D", // ⑧ 寄附
+  stay: "#0369A1", // ⑨ 滞在費
+  "other-expenses": "#334155", // ⑩ その他の経費
+};
+
+/** 法定区分に色が無い科目（要確認など）のフォールバック。 */
+const FALLBACK_COLOR = "#334155";
+
+export function researchFundCategoryColor(legalCategoryKey: string): string {
+  return LEGAL_CATEGORY_COLORS[legalCategoryKey] ?? FALLBACK_COLOR;
+}

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-details.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-details.ts
@@ -1,0 +1,17 @@
+/**
+ * 帳簿の details（B-5「データについて」の説明文）を読む。
+ *
+ * DB では Json 型で、書き込み側の画面はまだ無い（年度クローズと details の編集UIは別途）。
+ * 公開側は壊れた値でページを落とさないよう、読めた分だけを使う。
+ */
+interface ResearchFundDetails {
+  /** 「調査研究費のデータについて」の本文。未設定なら null */
+  dataNote: string | null;
+}
+
+export function parseResearchFundDetails(details: unknown): ResearchFundDetails {
+  if (typeof details !== "object" || details === null || Array.isArray(details))
+    return { dataNote: null };
+  const dataNote = (details as Record<string, unknown>).dataNote;
+  return { dataNote: typeof dataNote === "string" && dataNote.trim() ? dataNote : null };
+}

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-expense-list.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-expense-list.ts
@@ -45,7 +45,7 @@ export function buildExpenseViews(
       (a, b) =>
         compare(b.date, a.date) ||
         // 同一注文の行が他の支出に割り込まれないよう、日付の中では注文ごとにまとめる。
-        compare(a.splitGroup ?? a.id, b.splitGroup ?? b.id) ||
+        compare(a.splitGroup ?? "", b.splitGroup ?? "") ||
         compareIds(a.id, b.id),
     )
     .map((expense) => {

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-expense-list.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-expense-list.ts
@@ -1,0 +1,78 @@
+import type {
+  PublishedAccount,
+  PublishedExpense,
+} from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type { ResearchFundExpenseView } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+import { researchFundCategoryColor } from "@/server/contexts/research-fund/domain/services/research-fund-category-color";
+
+/** 科目マスタに無い科目のラベル（要確認の仕訳は公開されない想定だが、表示は落とさない）。 */
+const UNKNOWN_CATEGORY_LABEL = "その他";
+
+/**
+ * 同一注文の分割行につける説明。
+ *
+ * Amazon の明細を1品目ずつ起こしているため、同じ品を何度も買ったように読まれる。
+ * 束ねて並べたうえで、何件で1注文なのかを特記事項として添える。
+ */
+export function splitGroupNote(count: number): string {
+  return `同一注文で${count}点購入。1点ずつ行を分けて計上しています`;
+}
+
+function mergeNotes(note: string | null, splitNote: string | null): string | null {
+  if (!splitNote) return note?.trim() ? note : null;
+  return note?.trim() ? `${note}／${splitNote}` : splitNote;
+}
+
+/**
+ * B-4 の明細行を組み立てる。
+ *
+ * 並びは日付の新しい順。同一注文（split_group）の行は必ず隣り合わせにし、
+ * 何点で1注文かを特記事項に添えることで「同じものを何度も買っている」と
+ * 読まれないようにする。
+ */
+export function buildExpenseViews(
+  expenses: readonly PublishedExpense[],
+  accounts: Readonly<Record<string, PublishedAccount>>,
+): ResearchFundExpenseView[] {
+  const splitCounts = new Map<string, number>();
+  for (const expense of expenses) {
+    if (!expense.splitGroup) continue;
+    splitCounts.set(expense.splitGroup, (splitCounts.get(expense.splitGroup) ?? 0) + 1);
+  }
+
+  return [...expenses]
+    .sort(
+      (a, b) =>
+        compare(b.date, a.date) ||
+        // 同一注文の行が他の支出に割り込まれないよう、日付の中では注文ごとにまとめる。
+        compare(a.splitGroup ?? a.id, b.splitGroup ?? b.id) ||
+        compareIds(a.id, b.id),
+    )
+    .map((expense) => {
+      const account = accounts[expense.accountKey];
+      const color = researchFundCategoryColor(account?.legalCategoryKey ?? "");
+      const splitCount = expense.splitGroup ? (splitCounts.get(expense.splitGroup) ?? 1) : 1;
+      return {
+        id: expense.id,
+        entryId: expense.entryId,
+        date: expense.date,
+        month: expense.date.slice(0, 7),
+        description: expense.description,
+        amount: expense.amount,
+        detailed: { label: account?.label || UNKNOWN_CATEGORY_LABEL, color },
+        legal: { label: account?.legalLabel || UNKNOWN_CATEGORY_LABEL, color },
+        note: mergeNotes(expense.note, splitCount > 1 ? splitGroupNote(splitCount) : null),
+        hasReceipt: expense.hasReceipt,
+      };
+    });
+}
+
+function compare(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** 仕訳IDは連番なので、文字列比較（"10" < "9"）にならないよう数値で比べる。 */
+function compareIds(a: string, b: string): number {
+  const diff = Number(a) - Number(b);
+  return Number.isFinite(diff) ? diff : compare(a, b);
+}

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-monthly.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-monthly.ts
@@ -1,0 +1,30 @@
+import type { ResearchFundMonthView } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+import type { ResearchFundAggregation } from "@/shared/research-fund/aggregation";
+
+/**
+ * B-2 の1年分（1月〜12月）を組み立てる。
+ *
+ * 公開範囲（published_through）より後の月は「まだ公開していない」ことが伝わるよう
+ * 空欄にし、描画側が点線の空枠で描く。公開範囲の中にある月は、支出が無くても
+ * 0円として実線で描く（データが無いのではなく、使っていないという意味）。
+ */
+export function buildMonthlyViews(
+  monthly: ResearchFundAggregation["monthly"],
+  financialYear: number,
+  publishedThrough: string | null,
+): ResearchFundMonthView[] {
+  const totals = new Map(monthly.map((total) => [total.month, total]));
+  const publishedThroughMonth = publishedThrough?.slice(0, 7) ?? null;
+
+  return Array.from({ length: 12 }, (_, index) => {
+    const month = `${financialYear}-${String(index + 1).padStart(2, "0")}`;
+    const total = totals.get(month);
+    const published = publishedThroughMonth !== null && month <= publishedThroughMonth;
+    return {
+      month,
+      granted: published ? (total?.granted ?? 0) : 0,
+      spent: published ? (total?.spent ?? 0) : 0,
+      published,
+    };
+  });
+}

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-sankey-builder.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-sankey-builder.ts
@@ -1,0 +1,47 @@
+import type { SankeyData } from "@/types/sankey";
+import type { ResearchFundAggregation } from "@/shared/research-fund/aggregation";
+
+/** サンキーの左端。調研費は政党を通らず国から議員へ直接支給される。 */
+const GRANT_NODE_LABEL = "公費から支給";
+/**
+ * サンキーの末尾に固定する未使用分のラベル。
+ * 年度途中は返還額が確定しないため「国庫へ返還」とは呼ばない（デザイン仕様 §5）。
+ */
+const UNUSED_NODE_LABEL = "未使用";
+
+const GRANT_NODE_ID = "income-grant";
+const TOTAL_NODE_ID = "total";
+
+/**
+ * 集計結果から B-1 のサンキーを組み立てる。
+ *
+ * ノードIDは Safari 対策で英数字のみにするため、費目は並び順の連番で採番する
+ * （法律上の区分ではキーが日本語になるため、キーをそのままIDに使えない）。
+ * 未使用は費目と同じ右端に置き、描画側で淡色・末尾固定にする。
+ */
+export function buildResearchFundSankey(aggregation: ResearchFundAggregation): SankeyData {
+  const granted = aggregation.kpi.granted;
+  // 0円・マイナスの帯は描けないので落とす（支給前で未使用がマイナスになる場合を含む）。
+  const categories = aggregation.categories.filter((category) => category.totalAmount > 0);
+  if (granted <= 0 || categories.length === 0) return { nodes: [], links: [] };
+
+  return {
+    nodes: [
+      { id: GRANT_NODE_ID, label: GRANT_NODE_LABEL, nodeType: "income" },
+      { id: TOTAL_NODE_ID, label: "合計", nodeType: "total" },
+      ...categories.map((category, index) => ({
+        id: `expense-${index}`,
+        label: category.kind === "unused" ? UNUSED_NODE_LABEL : category.label,
+        nodeType: "expense" as const,
+      })),
+    ],
+    links: [
+      { source: GRANT_NODE_ID, target: TOTAL_NODE_ID, value: granted },
+      ...categories.map((category, index) => ({
+        source: TOTAL_NODE_ID,
+        target: `expense-${index}`,
+        value: category.totalAmount,
+      })),
+    ],
+  };
+}

--- a/webapp/src/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository.ts
+++ b/webapp/src/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository.ts
@@ -1,0 +1,179 @@
+import "server-only";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type {
+  PublishedAccount,
+  PublishedExpenditureGroup,
+  PublishedExpense,
+  PublishedResearchFund,
+} from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+import type { ResearchFundRow } from "@/shared/research-fund/aggregation";
+
+/**
+ * 公開ページに出す仕訳の取り出し方。
+ *
+ * 備考（memo）は公開されない事務所内メモなので、select に含めない
+ * （サーバー側にすら読み出さないことで、取り違えて出力する余地を無くす）。
+ */
+const entrySelect = {
+  id: true,
+  entryDate: true,
+  description: true,
+  note: true,
+  splitGroup: true,
+  documentId: true,
+  lines: {
+    select: {
+      id: true,
+      side: true,
+      accountKey: true,
+      amount: true,
+      account: {
+        select: { type: true, label: true, legalLabel: true, legalCategoryKey: true },
+      },
+    },
+    orderBy: { id: "asc" as const },
+  },
+} satisfies Prisma.ResearchFundJournalEntrySelect;
+
+type Entry = Prisma.ResearchFundJournalEntryGetPayload<{ select: typeof entrySelect }>;
+type Line = Entry["lines"][number];
+
+/** 公開の集計に使うのは「借方の費用」と「貸方の調査研究費収入」だけ。相手勘定の普通預金は数えない。 */
+const isExpenseLine = (line: Line) => line.side === "debit" && line.account.type === "expense";
+const isGrantLine = (line: Line) => line.side === "credit" && line.accountKey === "grant-income";
+
+function dateOf(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export class PrismaResearchFundRepository implements ResearchFundRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async findPublished(slug: string, financialYear: number): Promise<PublishedResearchFund | null> {
+    const book = await this.prisma.researchFundBook.findFirst({
+      where: { financialYear, politician: { slug } },
+      select: {
+        financialYear: true,
+        publishedThrough: true,
+        asOfDate: true,
+        nextUpdateNote: true,
+        policyComment: true,
+        details: true,
+        politician: { select: { name: true, slug: true } },
+        journalEntries: {
+          where: { status: "published" },
+          select: entrySelect,
+          orderBy: [{ entryDate: "desc" }, { id: "asc" }],
+        },
+        expenditureGroups: {
+          orderBy: [{ displayOrder: "asc" }, { id: "asc" }],
+          select: {
+            id: true,
+            title: true,
+            description: true,
+            outcomes: {
+              orderBy: [{ displayOrder: "asc" }, { id: "asc" }],
+              select: { label: true, url: true },
+            },
+            items: {
+              // 未公開の仕訳を成果カードの集計に混ぜない。
+              where: { entry: { status: "published" } },
+              select: { entry: { select: entrySelect } },
+            },
+          },
+        },
+      },
+    });
+    if (!book) return null;
+
+    const rows: ResearchFundRow[] = [];
+    const expenses: PublishedExpense[] = [];
+    const accounts: Record<string, PublishedAccount> = {};
+
+    for (const entry of book.journalEntries) {
+      const date = dateOf(entry.entryDate);
+      for (const line of entry.lines) {
+        if (isGrantLine(line)) {
+          rows.push({
+            date,
+            accountKey: line.accountKey,
+            amount: line.amount.toNumber(),
+            type: "grant",
+          });
+          continue;
+        }
+        if (!isExpenseLine(line)) continue;
+        accounts[line.accountKey] = accountOf(line);
+        rows.push({
+          date,
+          accountKey: line.accountKey,
+          amount: line.amount.toNumber(),
+          type: "expense",
+        });
+        expenses.push({
+          id: String(line.id),
+          entryId: String(entry.id),
+          date,
+          accountKey: line.accountKey,
+          description: entry.description,
+          amount: line.amount.toNumber(),
+          note: entry.note,
+          splitGroup: entry.splitGroup,
+          hasReceipt: entry.documentId !== null,
+        });
+      }
+    }
+
+    const groups: PublishedExpenditureGroup[] = book.expenditureGroups.map((group) => ({
+      id: String(group.id),
+      title: group.title,
+      description: group.description,
+      outcomes: group.outcomes.map((outcome) => ({ label: outcome.label, url: outcome.url })),
+      entries: group.items.flatMap(({ entry }) =>
+        entry.lines.filter(isExpenseLine).map((line) => {
+          accounts[line.accountKey] = accountOf(line);
+          return {
+            entryDate: dateOf(entry.entryDate),
+            amount: line.amount.toNumber(),
+            accountKey: line.accountKey,
+          };
+        }),
+      ),
+    }));
+
+    return {
+      politician: book.politician,
+      financialYear: book.financialYear,
+      asOfDate: book.asOfDate ? dateOf(book.asOfDate) : null,
+      nextUpdateNote: book.nextUpdateNote,
+      policyComment: book.policyComment,
+      details: book.details,
+      publishedThrough: book.publishedThrough ? dateOf(book.publishedThrough) : null,
+      rows,
+      accounts,
+      expenses,
+      groups,
+    };
+  }
+
+  async findPublishedReceipt(entryId: string) {
+    const entry = await this.prisma.researchFundJournalEntry.findFirst({
+      where: { id: BigInt(entryId), status: "published" },
+      select: { document: { select: { storageKey: true } } },
+    });
+    return entry?.document ? { storageKey: entry.document.storageKey } : null;
+  }
+}
+
+/**
+ * 法定区分が未設定の科目（下書き用の「要確認」など）でも法律上の区分に切り替えられるよう、
+ * 法定ラベルが空なら科目名で代用する。公開前に21分類へ直す運用なので通常は発生しない。
+ */
+function accountOf(line: Line): PublishedAccount {
+  return {
+    label: line.account.label,
+    legalLabel: line.account.legalLabel || line.account.label,
+    legalCategoryKey: line.account.legalCategoryKey ?? "",
+  };
+}

--- a/webapp/src/server/contexts/research-fund/infrastructure/storage/supabase-receipt-storage.ts
+++ b/webapp/src/server/contexts/research-fund/infrastructure/storage/supabase-receipt-storage.ts
@@ -1,0 +1,34 @@
+import "server-only";
+import { createClient } from "@supabase/supabase-js";
+import type { ReceiptStorage } from "@/server/contexts/research-fund/domain/repositories/receipt-storage.interface";
+
+/**
+ * 領収書の原本は非公開バケットに置き、署名URLで配信する（admin と同じバケット）。
+ * 当面はマスキングなしで原本を公開する運用のため、masked_key は使わない。
+ */
+export class SupabaseReceiptStorage implements ReceiptStorage {
+  constructor(
+    private client: ReturnType<typeof createClient>,
+    private bucket: string,
+  ) {}
+
+  static fromEnv(): SupabaseReceiptStorage | null {
+    const url = process.env.SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const bucket = process.env.RESEARCH_FUND_DOCUMENT_BUCKET;
+    if (!url || !key || !bucket) return null;
+    return new SupabaseReceiptStorage(
+      createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } }),
+      bucket,
+    );
+  }
+
+  async createSignedUrl(storageKey: string, expiresIn: number): Promise<string> {
+    const { data, error } = await this.client.storage
+      .from(this.bucket)
+      .createSignedUrl(storageKey, expiresIn);
+    if (error || !data?.signedUrl)
+      throw new Error("領収書の署名URLの取得に失敗しました", { cause: error });
+    return data.signedUrl;
+  }
+}

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/constants.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/constants.ts
@@ -1,0 +1,8 @@
+/** 公開ページのキャッシュ保持時間（秒）。本番以外は短くして確認しやすくする。 */
+export const CACHE_REVALIDATE_SECONDS = process.env.VERCEL_ENV === "production" ? 3600 : 10;
+
+/**
+ * 調研費の公開ページのキャッシュタグ。
+ * admin の公開アクションが webapp の /api/refresh を叩き、このタグを無効化する。
+ */
+export const RESEARCH_FUND_CACHE_TAG = "research-fund-page-data";

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-page.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-page.ts
@@ -7,7 +7,10 @@ import {
 } from "@/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase";
 import { PrismaResearchFundRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
-import { CACHE_REVALIDATE_SECONDS, RESEARCH_FUND_CACHE_TAG } from "./constants";
+import {
+  CACHE_REVALIDATE_SECONDS,
+  RESEARCH_FUND_CACHE_TAG,
+} from "@/server/contexts/research-fund/presentation/loaders/constants";
 
 export const loadResearchFundPage = unstable_cache(
   async (params: GetResearchFundPageParams) => {

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-page.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-page.ts
@@ -1,0 +1,19 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import {
+  GetResearchFundPageUsecase,
+  type GetResearchFundPageParams,
+} from "@/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase";
+import { PrismaResearchFundRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+import { CACHE_REVALIDATE_SECONDS, RESEARCH_FUND_CACHE_TAG } from "./constants";
+
+export const loadResearchFundPage = unstable_cache(
+  async (params: GetResearchFundPageParams) => {
+    const usecase = new GetResearchFundPageUsecase(new PrismaResearchFundRepository(prisma));
+    return await usecase.execute(params);
+  },
+  [RESEARCH_FUND_CACHE_TAG],
+  { revalidate: CACHE_REVALIDATE_SECONDS, tags: [RESEARCH_FUND_CACHE_TAG] },
+);

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-receipt.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-receipt.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+import { GetResearchFundReceiptUsecase } from "@/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase";
+import { PrismaResearchFundRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository";
+import { SupabaseReceiptStorage } from "@/server/contexts/research-fund/infrastructure/storage/supabase-receipt-storage";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+/**
+ * 領収書の署名URL。署名URLは短時間で失効するのでキャッシュしない。
+ * ストレージが未設定の環境（領収書を使わないローカルなど）では null を返す。
+ */
+export async function loadResearchFundReceiptUrl(entryId: string): Promise<string | null> {
+  const storage = SupabaseReceiptStorage.fromEnv();
+  if (!storage) return null;
+  const usecase = new GetResearchFundReceiptUsecase(
+    new PrismaResearchFundRepository(prisma),
+    storage,
+  );
+  return await usecase.execute(entryId);
+}

--- a/webapp/src/server/contexts/shared/domain/models/sankey-data.ts
+++ b/webapp/src/server/contexts/shared/domain/models/sankey-data.ts
@@ -1,6 +1,7 @@
 /**
  * Sankeyダイアグラムの最終出力を表現するドメインモデル
  *
+ * public-finance と research-fund の双方が使うため shared に置く（コンテキスト間の直接依存を避ける）。
  * UIコンポーネントからも参照されるため、server-onlyは含めない
  */
 

--- a/webapp/src/server/contexts/shared/infrastructure/prisma.ts
+++ b/webapp/src/server/contexts/shared/infrastructure/prisma.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+/**
+ * 全コンテキストで共有する Prisma クライアント。
+ *
+ * コンテキストごとにクライアントを作るとコネクションプールが分かれ、
+ * サーバーレス環境で接続上限に当たりやすくなるため、1つに集約する。
+ */
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ["query"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/webapp/src/types/sankey.ts
+++ b/webapp/src/types/sankey.ts
@@ -1,10 +1,10 @@
 /**
  * Sankeyダイアグラムの型定義
  *
- * 実装はドメインモデルに移動。UIコンポーネントからの参照パスを維持するためにre-export
+ * 実装は shared のドメインモデルに移動。UIコンポーネントからの参照パスを維持するためにre-export
  */
 export type {
   SankeyData,
   SankeyNode,
   SankeyLink,
-} from "@/server/contexts/public-finance/domain/models/sankey-data";
+} from "@/server/contexts/shared/domain/models/sankey-data";

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase.test.ts
@@ -1,0 +1,170 @@
+import { GetResearchFundPageUsecase } from "@/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase";
+import type { PublishedResearchFund } from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+const accounts: PublishedResearchFund["accounts"] = {
+  taxi: { label: "タクシー代", legalLabel: "⑨ 滞在費", legalCategoryKey: "stay" },
+  "public-transport": {
+    label: "電車・バス代",
+    legalLabel: "⑨ 滞在費",
+    legalCategoryKey: "stay",
+  },
+  "printing-pr": {
+    label: "印刷・広報費",
+    legalLabel: "⑥ 広報紙誌の発行その他の事業費",
+    legalCategoryKey: "publicity",
+  },
+};
+
+function published(overrides: Partial<PublishedResearchFund> = {}): PublishedResearchFund {
+  return {
+    politician: { name: "サンプル 太郎", slug: "sample-taro" },
+    financialYear: 2026,
+    asOfDate: "2026-08-20",
+    nextUpdateNote: "11月ごろ",
+    policyComment: "事務所の立ち上げに使っています",
+    details: { dataNote: "仕訳が完了した支出を掲載しています" },
+    publishedThrough: "2026-08-31",
+    rows: [
+      { date: "2026-02-01", accountKey: "grant-income", amount: 1_000_000, type: "grant" },
+      { date: "2026-03-01", accountKey: "grant-income", amount: 1_000_000, type: "grant" },
+      { date: "2026-02-10", accountKey: "taxi", amount: 3_000, type: "expense" },
+      { date: "2026-03-10", accountKey: "public-transport", amount: 2_000, type: "expense" },
+      { date: "2026-03-11", accountKey: "printing-pr", amount: 99_000, type: "expense" },
+    ],
+    accounts,
+    expenses: [
+      {
+        id: "1",
+        entryId: "1",
+        date: "2026-02-10",
+        accountKey: "taxi",
+        description: "タクシー代",
+        amount: 3_000,
+        note: null,
+        splitGroup: null,
+        hasReceipt: true,
+      },
+      {
+        id: "2",
+        entryId: "2",
+        date: "2026-03-10",
+        accountKey: "public-transport",
+        description: "電車代",
+        amount: 2_000,
+        note: null,
+        splitGroup: null,
+        hasReceipt: false,
+      },
+      {
+        id: "3",
+        entryId: "3",
+        date: "2026-03-11",
+        accountKey: "printing-pr",
+        description: "チラシ印刷費",
+        amount: 99_000,
+        note: null,
+        splitGroup: null,
+        hasReceipt: false,
+      },
+    ],
+    groups: [
+      {
+        id: "7",
+        title: "広報活動",
+        description: "チラシを配りました",
+        outcomes: [{ label: "配布報告", url: null }],
+        entries: [{ entryDate: "2026-03-11", amount: 99_000, accountKey: "printing-pr" }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function usecaseWith(value: PublishedResearchFund | null) {
+  const repository: ResearchFundRepository = {
+    findPublished: jest.fn().mockResolvedValue(value),
+    findPublishedReceipt: jest.fn().mockResolvedValue(null),
+  };
+  return { usecase: new GetResearchFundPageUsecase(repository), repository };
+}
+
+describe("GetResearchFundPageUsecase", () => {
+  it("帳簿が無ければ null を返す", async () => {
+    const { usecase } = usecaseWith(null);
+
+    expect(await usecase.execute({ slug: "unknown", financialYear: 2026 })).toBeNull();
+  });
+
+  it("支給・支出の合計と未使用を集計する", async () => {
+    const { usecase } = usecaseWith(published());
+
+    const data = await usecase.execute({ slug: "sample-taro", financialYear: 2026 });
+
+    expect(data?.kpi).toEqual({ granted: 2_000_000, spent: 104_000 });
+    expect(data?.unused).toBe(1_896_000);
+  });
+
+  it("詳細の区分と法律上の区分でサンキーを作り分け、未使用を末尾に置く", async () => {
+    const { usecase } = usecaseWith(published());
+
+    const data = await usecase.execute({ slug: "sample-taro", financialYear: 2026 });
+
+    expect(data?.sankey.detailed.nodes.map((node) => node.label)).toEqual([
+      "公費から支給",
+      "合計",
+      "印刷・広報費",
+      "電車・バス代",
+      "タクシー代",
+      "未使用",
+    ]);
+    // 法律上の区分では ⑨ 滞在費 にタクシー代と電車・バス代が統合される
+    expect(data?.sankey.legal.nodes.map((node) => node.label)).toEqual([
+      "公費から支給",
+      "合計",
+      "⑥ 広報紙誌の発行その他の事業費",
+      "⑨ 滞在費",
+      "未使用",
+    ]);
+  });
+
+  it("成果カードの金額・件数・期間を紐づいた仕訳から集計する", async () => {
+    const { usecase } = usecaseWith(published());
+
+    const data = await usecase.execute({ slug: "sample-taro", financialYear: 2026 });
+
+    expect(data?.groups[0]).toEqual({
+      id: "7",
+      title: "広報活動",
+      description: "チラシを配りました",
+      amount: 99_000,
+      count: 1,
+      period: { start: "2026-03-11", end: "2026-03-11" },
+      categories: [{ label: "印刷・広報費", color: "#A16207" }],
+      outcomes: [{ label: "配布報告", url: null }],
+    });
+  });
+
+  it("帳簿の公開用メタ情報をそのまま渡す", async () => {
+    const { usecase } = usecaseWith(published());
+
+    const data = await usecase.execute({ slug: "sample-taro", financialYear: 2026 });
+
+    expect(data?.asOfDate).toBe("2026-08-20");
+    expect(data?.nextUpdateNote).toBe("11月ごろ");
+    expect(data?.policyComment).toBe("事務所の立ち上げに使っています");
+    expect(data?.dataNote).toBe("仕訳が完了した支出を掲載しています");
+  });
+
+  it("集計できない行があれば黙って表示せず失敗させる", async () => {
+    const { usecase } = usecaseWith(
+      published({
+        rows: [{ date: "2026-13-99", accountKey: "taxi", amount: 1, type: "expense" }],
+      }),
+    );
+
+    await expect(usecase.execute({ slug: "sample-taro", financialYear: 2026 })).rejects.toThrow(
+      /調研費の集計に失敗しました/,
+    );
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase.test.ts
@@ -1,0 +1,38 @@
+import { GetResearchFundReceiptUsecase } from "@/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase";
+import type { ReceiptStorage } from "@/server/contexts/research-fund/domain/repositories/receipt-storage.interface";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+function build(receipt: { storageKey: string } | null) {
+  const repository: ResearchFundRepository = {
+    findPublished: jest.fn().mockResolvedValue(null),
+    findPublishedReceipt: jest.fn().mockResolvedValue(receipt),
+  };
+  const storage: ReceiptStorage = {
+    createSignedUrl: jest.fn().mockResolvedValue("https://storage.example/signed"),
+  };
+  return { usecase: new GetResearchFundReceiptUsecase(repository, storage), repository, storage };
+}
+
+describe("GetResearchFundReceiptUsecase", () => {
+  it("公開済みの仕訳に紐づく領収書は署名URLを返す", async () => {
+    const { usecase, storage } = build({ storageKey: "key-1" });
+
+    expect(await usecase.execute("12")).toBe("https://storage.example/signed");
+    expect(storage.createSignedUrl).toHaveBeenCalledWith("key-1", 300);
+  });
+
+  it("公開されていない・存在しない仕訳の領収書は返さない", async () => {
+    const { usecase, storage } = build(null);
+
+    expect(await usecase.execute("12")).toBeNull();
+    expect(storage.createSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("仕訳IDでない入力ではストレージにも問い合わせない", async () => {
+    const { usecase, repository } = build({ storageKey: "key-1" });
+
+    expect(await usecase.execute("../secret")).toBeNull();
+    expect(await usecase.execute("0")).toBeNull();
+    expect(repository.findPublishedReceipt).not.toHaveBeenCalled();
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/domain/services/research-fund-details.test.ts
+++ b/webapp/tests/server/contexts/research-fund/domain/services/research-fund-details.test.ts
@@ -1,0 +1,18 @@
+import { parseResearchFundDetails } from "@/server/contexts/research-fund/domain/services/research-fund-details";
+
+describe("parseResearchFundDetails", () => {
+  it("dataNote を読む", () => {
+    expect(parseResearchFundDetails({ dataNote: "仕訳が完了した支出を掲載しています" })).toEqual({
+      dataNote: "仕訳が完了した支出を掲載しています",
+    });
+  });
+
+  it("未設定・空文字・型違いは null にしてページを落とさない", () => {
+    expect(parseResearchFundDetails(null).dataNote).toBeNull();
+    expect(parseResearchFundDetails(undefined).dataNote).toBeNull();
+    expect(parseResearchFundDetails("text").dataNote).toBeNull();
+    expect(parseResearchFundDetails([{ dataNote: "x" }]).dataNote).toBeNull();
+    expect(parseResearchFundDetails({ dataNote: "  " }).dataNote).toBeNull();
+    expect(parseResearchFundDetails({ dataNote: 1 }).dataNote).toBeNull();
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/domain/services/research-fund-expense-list.test.ts
+++ b/webapp/tests/server/contexts/research-fund/domain/services/research-fund-expense-list.test.ts
@@ -1,0 +1,105 @@
+import type {
+  PublishedAccount,
+  PublishedExpense,
+} from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import {
+  buildExpenseViews,
+  splitGroupNote,
+} from "@/server/contexts/research-fund/domain/services/research-fund-expense-list";
+
+const accounts: Record<string, PublishedAccount> = {
+  taxi: { label: "タクシー代", legalLabel: "⑨ 滞在費", legalCategoryKey: "stay" },
+  "stationery-supplies": {
+    label: "文房具・備品",
+    legalLabel: "③ 備品・消耗品費",
+    legalCategoryKey: "equipment-supplies",
+  },
+};
+
+function expense(overrides: Partial<PublishedExpense> = {}): PublishedExpense {
+  return {
+    id: "1",
+    entryId: "1",
+    date: "2026-04-23",
+    accountKey: "taxi",
+    description: "タクシー代",
+    amount: 1200,
+    note: null,
+    splitGroup: null,
+    hasReceipt: false,
+    ...overrides,
+  };
+}
+
+describe("buildExpenseViews", () => {
+  it("日付の新しい順に並べる", () => {
+    const views = buildExpenseViews(
+      [
+        expense({ id: "1", entryId: "1", date: "2026-04-01" }),
+        expense({ id: "2", entryId: "2", date: "2026-05-01" }),
+      ],
+      accounts,
+    );
+
+    expect(views.map((view) => view.date)).toEqual(["2026-05-01", "2026-04-01"]);
+    expect(views.map((view) => view.month)).toEqual(["2026-05", "2026-04"]);
+  });
+
+  it("同一注文の分割行を隣り合わせにし、何点で1注文かを特記事項に添える", () => {
+    const views = buildExpenseViews(
+      [
+        expense({ id: "10", entryId: "10", splitGroup: "order-1", description: "トナー代" }),
+        expense({ id: "11", entryId: "11", description: "電車代" }),
+        expense({ id: "12", entryId: "12", splitGroup: "order-1", description: "トナー代" }),
+      ],
+      accounts,
+    );
+
+    expect(views.map((view) => view.id)).toEqual(["11", "10", "12"]);
+    expect(views[1].note).toBe(splitGroupNote(2));
+    expect(views[2].note).toBe(splitGroupNote(2));
+  });
+
+  it("特記事項がある分割行は、元の特記事項と分割の説明を並べる", () => {
+    const views = buildExpenseViews(
+      [
+        expense({ id: "1", entryId: "1", splitGroup: "order-1", note: "会派で按分" }),
+        expense({ id: "2", entryId: "2", splitGroup: "order-1", note: "会派で按分" }),
+      ],
+      accounts,
+    );
+
+    expect(views[0].note).toBe(`会派で按分／${splitGroupNote(2)}`);
+  });
+
+  it("分割していない行の特記事項はそのまま、無ければ null", () => {
+    const views = buildExpenseViews(
+      [
+        expense({ id: "1", entryId: "1", note: "領収書の発行なし" }),
+        expense({ id: "2", entryId: "2", date: "2026-04-22", note: "   " }),
+      ],
+      accounts,
+    );
+
+    expect(views[0].note).toBe("領収書の発行なし");
+    expect(views[1].note).toBeNull();
+  });
+
+  it("詳細の区分と法律上の区分の両方のラベルを持たせる", () => {
+    const [view] = buildExpenseViews(
+      [expense({ accountKey: "stationery-supplies" })],
+      accounts,
+    );
+
+    expect(view.detailed.label).toBe("文房具・備品");
+    expect(view.legal.label).toBe("③ 備品・消耗品費");
+    expect(view.detailed.color).toBe(view.legal.color);
+  });
+
+  it("科目マスタに無い科目でも行を落とさない", () => {
+    const [view] = buildExpenseViews([expense({ accountKey: "unknown" })], accounts);
+
+    expect(view.detailed.label).toBe("その他");
+    expect(view.legal.label).toBe("その他");
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/domain/services/research-fund-monthly.test.ts
+++ b/webapp/tests/server/contexts/research-fund/domain/services/research-fund-monthly.test.ts
@@ -1,0 +1,37 @@
+import { buildMonthlyViews } from "@/server/contexts/research-fund/domain/services/research-fund-monthly";
+
+describe("buildMonthlyViews", () => {
+  const monthly = [
+    { month: "2026-02", granted: 1_000_000, spent: 126_860 },
+    { month: "2026-08", granted: 1_000_000, spent: 21_335 },
+  ];
+
+  it("1月から12月までを必ず返す", () => {
+    const views = buildMonthlyViews(monthly, 2026, "2026-08-31");
+
+    expect(views).toHaveLength(12);
+    expect(views[0].month).toBe("2026-01");
+    expect(views[11].month).toBe("2026-12");
+  });
+
+  it("公開範囲の中は集計値を、支出が無い月も0円として公開扱いにする", () => {
+    const views = buildMonthlyViews(monthly, 2026, "2026-08-31");
+
+    expect(views[1]).toEqual({ month: "2026-02", granted: 1_000_000, spent: 126_860, published: true });
+    expect(views[2]).toEqual({ month: "2026-03", granted: 0, spent: 0, published: true });
+  });
+
+  it("公開範囲より後の月は未公開にする（点線の空枠で描かれる）", () => {
+    const views = buildMonthlyViews(monthly, 2026, "2026-08-31");
+
+    expect(views[8].published).toBe(false);
+    expect(views[11].published).toBe(false);
+  });
+
+  it("まだ何も公開していなければ全ての月が未公開になる", () => {
+    const views = buildMonthlyViews(monthly, 2026, null);
+
+    expect(views.every((view) => !view.published)).toBe(true);
+    expect(views.every((view) => view.granted === 0 && view.spent === 0)).toBe(true);
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/domain/services/research-fund-sankey-builder.test.ts
+++ b/webapp/tests/server/contexts/research-fund/domain/services/research-fund-sankey-builder.test.ts
@@ -1,0 +1,66 @@
+import { buildResearchFundSankey } from "@/server/contexts/research-fund/domain/services/research-fund-sankey-builder";
+import type { ResearchFundAggregation } from "@/shared/research-fund/aggregation";
+
+function aggregation(overrides: Partial<ResearchFundAggregation> = {}): ResearchFundAggregation {
+  return {
+    categories: [
+      { key: "taxi", label: "タクシー代", kind: "expense", totalAmount: 300_000 },
+      { key: "unused", label: "未使用", kind: "unused", totalAmount: 700_000 },
+    ],
+    monthly: [],
+    kpi: { granted: 1_000_000, spent: 300_000 },
+    unused: 700_000,
+    ...overrides,
+  };
+}
+
+describe("buildResearchFundSankey", () => {
+  it("支給→合計→費目と未使用のリンクを作る", () => {
+    const sankey = buildResearchFundSankey(aggregation());
+
+    expect(sankey.nodes.map((node) => node.label)).toEqual([
+      "公費から支給",
+      "合計",
+      "タクシー代",
+      "未使用",
+    ]);
+    expect(sankey.links).toEqual([
+      { source: "income-grant", target: "total", value: 1_000_000 },
+      { source: "total", target: "expense-0", value: 300_000 },
+      { source: "total", target: "expense-1", value: 700_000 },
+    ]);
+  });
+
+  it("ノードIDは英数字だけで採番する（法律上の区分はキーが日本語になるため）", () => {
+    const sankey = buildResearchFundSankey(
+      aggregation({
+        categories: [
+          { key: "③ 備品・消耗品費", label: "③ 備品・消耗品費", kind: "expense", totalAmount: 10 },
+        ],
+      }),
+    );
+
+    for (const node of sankey.nodes) expect(node.id).toMatch(/^[a-zA-Z0-9_-]+$/);
+  });
+
+  it("0円・マイナスの費目は帯にしない", () => {
+    const sankey = buildResearchFundSankey(
+      aggregation({
+        categories: [
+          { key: "taxi", label: "タクシー代", kind: "expense", totalAmount: 300_000 },
+          { key: "unused", label: "未使用", kind: "unused", totalAmount: -1 },
+        ],
+      }),
+    );
+
+    expect(sankey.nodes.map((node) => node.label)).toEqual(["公費から支給", "合計", "タクシー代"]);
+  });
+
+  it("支給が無ければ空のデータを返す", () => {
+    expect(
+      buildResearchFundSankey(
+        aggregation({ kpi: { granted: 0, spent: 0 }, categories: [], unused: 0 }),
+      ),
+    ).toEqual({ nodes: [], links: [] });
+  });
+});


### PR DESCRIPTION
## 目的（Why）

制度が変わるのを待たずに「領収書が見られない・1万円以下が分からない・公開が年1回」を自分たちで解消して見せるため、議員単位で published の仕訳だけを1件ずつ公開するページを追加する。市民が「調研費が何に使われたか」を1件ずつ追えるようになる。

## 変更内容

### 公開ページ `/p/[slug]/[year]`（パスは既存 `/o/[slug]/[year]` の慣習に合わせた）

- **B-1 使いみちの流れ**: KPI2枚（支給された／議員活動に使った）＋区分トグル（詳細／法律上）＋サンキー。未使用は淡色で末尾固定にし、「国庫へ返還」とは呼ばない
- **B-2 1年間の推移**: 中央のゼロ線から上が支給・下が支出の上下対向の棒グラフ。公開範囲より後の月は点線の空枠
- **B-3 主要な支出の成果**: 活用方針（グレー帯・左太罫）＋成果カード（金額・日付・費目・件数・目的・成果物）。URL の無い成果物は「報告は準備中」
- **B-4 すべての支出**: 月切り替え（必須）・区分トグル・日付／カテゴリー／項目＋ⓘ＋領収書チップ／金額。ⓘで直下に注記行、領収書チップでモーダル表示
- **B-5 データについて**: 既存と同構成＋末尾の未使用の説明文（`as_of_date` / `next_update_note` / `details` を使用）

### サーバー側（webapp の `research-fund` コンテキストを新設・読み取り専用）

- リポジトリは `status: published` の仕訳だけを射影する。**備考（memo）は Prisma の select に含めない**ので、サーバー側にすら読み出されない
- 集計は #1350 の `shared/research-fund/aggregation.ts`、成果カードの金額・件数・期間は #1359 の `aggregateLinkedEntries` を使う
- loader は `unstable_cache` + tag `research-fund-page-data`。この tag は既に `webapp/src/app/api/refresh/route.ts` で無効化対象になっており、admin の公開アクションから反映される
- 領収書は `/api/research-fund/receipts/[entryId]` が #1355 のバケットの署名URLへリダイレクトする。published の仕訳に紐づくものしか返さない（署名URLは短命なのでキャッシュしない）

### 既存コードへの変更

- `SankeyChart` に `ariaLabel` の任意プロパティを追加（既定値は従来どおり）
- `useSankeyHelpers` に「未使用」ノードの淡色＋末尾固定を追加（政治資金側にこのラベルのノードは無いため既存表示に影響しない）
- Prisma クライアントを `contexts/shared/infrastructure/prisma.ts` に集約（コンテキストごとにクライアントを増やしてコネクションプールを分けないため）。`public-finance` 側は再輸出だけにして参照パスは維持
- シードに公開ページ用のメタ情報（`as_of_date` / `next_update_note` / `policy_comment` / `details`）と支出群2件を追加

### 「分割行をどう束ねるか」について

デザイン仕様 §7 の課題。Issue のヒントどおり hifi プロトタイプの見せ方に従い、**同一注文（`split_group`）の行は必ず隣り合わせに並べたうえで「同一注文でN点購入。1点ずつ行を分けて計上しています」を特記事項に添える**方式にした（行ごとに金額・領収書が違うため、1行に潰さない）。

## ローカル CI

- `pnpm verify` ✅（admin 1464 passed / webapp 164 passed、typecheck・lint・knip・depcruise いずれも green）
- `pnpm test:e2e:webapp` ✅（20 passed。うち新規7件が調研費 議員ページ）

## スコープアウトして起票した Issue

- #1418 feat(webapp): 調研費 議員ページをサイトマップとヘッダーナビに載せる

Closes #1360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 議員ごとの調査研究費ページを追加しました。
  * 支給額・使用額、資金フロー、月別推移、支出明細、成果を確認できます。
  * 月別絞り込みや、詳細区分・法律上の区分の切り替えに対応しました。
  * 特記事項の表示や、公開済み支出に紐づく領収書の閲覧が可能です。
  * 年度指定のない議員ページは既定年度へ自動的に移動します。

* **改善**
  * 未公開の支出・月は表示対象から除外し、公開状況を明確にしました。
  * 調査研究費ページの表示内容とデータ集計の安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->