### PR TITLE
feat(admin): 支出群の削除と並べ替え

### DIFF
--- a/admin/e2e/tests/expenditure-groups.spec.ts
+++ b/admin/e2e/tests/expenditure-groups.spec.ts
@@ -99,7 +99,34 @@ test("活用方針を保存し、仕訳を束ねた支出群を作って編集�
   await expect(edited).toContainText("1件");
   await expect(edited).toContainText("2026.03.01");
 
-  // 外した仕訳は別の支出群で選べるようになる
+  // 外した仕訳は別の支出群で選べるようになる。そのまま 2 つ目の支出群にする
+  await page.getByRole("link", { name: "支出群を作る" }).click();
+  const printed = page.getByRole("listitem").filter({ hasText: "資料の印刷" }).getByRole("checkbox");
+  await expect(printed).toBeEnabled();
+  await page.getByLabel("タイトル").fill("視察のまとめ");
+  await page.getByLabel("使った目的と、そこから生まれたもの").fill("視察の記録を残した。");
+  await printed.check();
+  await page.getByRole("button", { name: "作成する" }).click();
+  await expect(page).toHaveURL(/expenditure-groups$/);
+
+  // 並べ替えは display_order に保存され、再読み込みしても残る
+  const titles = page.locator('[data-slot="card"]:has(h2) h2');
+  await expect(titles).toHaveText(["議会質問づくりの相棒（改）", "視察のまとめ"]);
+  await page.getByRole("button", { name: "視察のまとめを前に移動" }).click();
+  await expect(titles).toHaveText(["視察のまとめ", "議会質問づくりの相棒（改）"]);
+  await page.reload();
+  await expect(titles).toHaveText(["視察のまとめ", "議会質問づくりの相棒（改）"]);
+
+  // 編集ページから削除すると、紐づいていた仕訳は他の支出群で選べるようになる
+  const doomed = page
+    .locator('[data-slot="card"]')
+    .filter({ has: page.getByRole("heading", { name: "視察のまとめ" }) });
+  await doomed.getByRole("link", { name: "編集" }).click();
+  await page.getByRole("button", { name: "この支出群を削除" }).click();
+  await page.getByRole("button", { name: "削除する", exact: true }).click();
+  await expect(page.getByText("支出群を削除しました")).toBeVisible();
+  await expect(page).toHaveURL(/expenditure-groups$/);
+  await expect(titles).toHaveText(["議会質問づくりの相棒（改）"]);
   await page.getByRole("link", { name: "支出群を作る" }).click();
   await expect(
     page.getByRole("listitem").filter({ hasText: "資料の印刷" }).getByRole("checkbox"),

--- a/admin/src/client/components/research-fund/DeleteExpenditureGroupButton.tsx
+++ b/admin/src/client/components/research-fund/DeleteExpenditureGroupButton.tsx
@@ -1,0 +1,83 @@
+"use client";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Trash } from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/client/components/ui";
+import { deleteExpenditureGroup } from "@/server/contexts/research-fund/presentation/actions/manage-expenditure-groups";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+
+/** 編集ページから支出群を消す。確認ダイアログを挟み、消したら一覧へ戻る */
+export function DeleteExpenditureGroupButton({
+  groupId,
+  title,
+  target,
+}: {
+  groupId: string;
+  title: string;
+  target: Extract<AdminTarget, { kind: "research-fund" }>;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  function remove() {
+    startTransition(async () => {
+      try {
+        const result = await deleteExpenditureGroup(target.politicianId, target.bookId, groupId);
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success("支出群を削除しました");
+        setOpen(false);
+        router.push(
+          `/politicians/${target.politicianId}/books/${target.bookId}/expenditure-groups`,
+        );
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+
+  return (
+    <>
+      <Button variant="destructive" className="ml-auto" onClick={() => setOpen(true)}>
+        <Trash size={13} />
+        この支出群を削除
+      </Button>
+      <Dialog
+        open={open}
+        onOpenChange={(value) => {
+          if (!pending) setOpen(value);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{title} を削除しますか？</DialogTitle>
+            <DialogDescription>
+              成果物と仕訳の紐づけも一緒に消えます。仕訳そのものは残り、他の支出群で選べるようになります。この操作は取り消せません。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" disabled={pending} onClick={() => setOpen(false)}>
+              キャンセル
+            </Button>
+            <Button variant="destructive" disabled={pending} onClick={remove}>
+              {pending ? "削除中..." : "削除する"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/admin/src/client/components/research-fund/ExpenditureGroupForm.tsx
+++ b/admin/src/client/components/research-fund/ExpenditureGroupForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { CaretLeft, Plus, X } from "@phosphor-icons/react/dist/ssr";
 import { toast } from "sonner";
 import { PageHeader } from "@/client/components/layout/PageHeader";
+import { DeleteExpenditureGroupButton } from "@/client/components/research-fund/DeleteExpenditureGroupButton";
 import {
   Button,
   Card,
@@ -205,6 +206,13 @@ export function ExpenditureGroupForm({
               <Button asChild variant="outline">
                 <Link href={listPath}>キャンセル</Link>
               </Button>
+              {group && (
+                <DeleteExpenditureGroupButton
+                  groupId={group.id}
+                  title={group.title}
+                  target={target}
+                />
+              )}
             </div>
           </CardContent>
         </Card>

--- a/admin/src/client/components/research-fund/ExpenditureGroupList.tsx
+++ b/admin/src/client/components/research-fund/ExpenditureGroupList.tsx
@@ -2,13 +2,16 @@
 import { useId, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Plus } from "@phosphor-icons/react/dist/ssr";
+import { CaretLeft, CaretRight, Plus } from "@phosphor-icons/react/dist/ssr";
 import { toast } from "sonner";
 import { PageHeader } from "@/client/components/layout/PageHeader";
 import { Button, Card, CardContent, Label, Textarea } from "@/client/components/ui";
 import { cn, formatCurrency, formatLinkedPeriod } from "@/client/lib";
 import type { ExpenditureGroupSummary } from "@/server/contexts/research-fund/domain/models/expenditure-group";
-import { saveUsagePolicy } from "@/server/contexts/research-fund/presentation/actions/manage-expenditure-groups";
+import {
+  reorderExpenditureGroups,
+  saveUsagePolicy,
+} from "@/server/contexts/research-fund/presentation/actions/manage-expenditure-groups";
 import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
 
 export function ExpenditureGroupList({
@@ -35,6 +38,30 @@ export function ExpenditureGroupList({
           return;
         }
         toast.success("活用方針を保存しました");
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+
+  /** index の支出群を offset だけ動かした並びを保存する。表示順は左上から右下へ数える */
+  function move(index: number, offset: number) {
+    const moved = [...groups];
+    const [group] = moved.splice(index, 1);
+    if (!group) return;
+    moved.splice(index + offset, 0, group);
+    startTransition(async () => {
+      try {
+        const result = await reorderExpenditureGroups(
+          target.politicianId,
+          target.bookId,
+          moved.map((item) => item.id),
+        );
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
         router.refresh();
       } catch {
         toast.error("通信に失敗しました。再度お試しください");
@@ -87,7 +114,7 @@ export function ExpenditureGroupList({
         </Card>
       ) : (
         <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(340px,420px))]">
-          {groups.map((group) => (
+          {groups.map((group, index) => (
             <Card key={group.id}>
               <CardContent className="p-5">
                 <h2 className="text-[15.5px] font-bold">{group.title}</h2>
@@ -113,10 +140,30 @@ export function ExpenditureGroupList({
                     ))}
                   </ul>
                 )}
-                <div className="mt-4">
+                <div className="mt-4 flex items-center gap-2">
                   <Button asChild variant="outline" size="xs">
                     <Link href={`${base}/${group.id}`}>編集</Link>
                   </Button>
+                  <div className="ml-auto flex gap-1.5">
+                    <Button
+                      variant="outline"
+                      size="icon-sm"
+                      disabled={pending || index === 0}
+                      aria-label={`${group.title}を前に移動`}
+                      onClick={() => move(index, -1)}
+                    >
+                      <CaretLeft size={12} />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="icon-sm"
+                      disabled={pending || index === groups.length - 1}
+                      aria-label={`${group.title}を後ろに移動`}
+                      onClick={() => move(index, 1)}
+                    >
+                      <CaretRight size={12} />
+                    </Button>
+                  </div>
                 </div>
               </CardContent>
             </Card>

--- a/admin/src/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase.ts
@@ -75,6 +75,22 @@ export class ManageExpenditureGroupsUsecase {
     return groupId;
   }
 
+  async remove(bookId: string, groupId: string) {
+    validateId(bookId);
+    validateId(groupId);
+    await this.repository.remove(bookId, groupId);
+  }
+
+  /** 一覧に出ている支出群を過不足なく、表示したい順に渡す */
+  async reorder(bookId: string, groupIds: readonly string[]) {
+    validateId(bookId);
+    for (const groupId of groupIds) validateId(groupId);
+    if (new Set(groupIds).size !== groupIds.length)
+      throw new ExpenditureGroupError("並び順の指定が重複しています");
+    if (groupIds.length === 0) return;
+    await this.repository.reorder(bookId, groupIds);
+  }
+
   private async prepare(
     bookId: string,
     groupId: string | null,

--- a/admin/src/server/contexts/research-fund/domain/repositories/expenditure-group-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/expenditure-group-repository.interface.ts
@@ -19,4 +19,11 @@ export interface ExpenditureGroupRepository {
   create(bookId: string, input: ExpenditureGroupWrite): Promise<string>;
   /** create と同じ保証で、既存の紐づけ・成果物を入れ替える */
   update(bookId: string, groupId: string, input: ExpenditureGroupWrite): Promise<void>;
+  /** 支出群を消す。紐づけと成果物は onDelete: Cascade で一緒に消える */
+  remove(bookId: string, groupId: string): Promise<void>;
+  /**
+   * 渡された順に displayOrder を 0 から振り直す。
+   * 帳簿の支出群と過不足があれば（一覧が古いなら）ExpenditureGroupError を投げ、何も変えない。
+   */
+  reorder(bookId: string, groupIds: readonly string[]): Promise<void>;
 }

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
@@ -141,6 +141,34 @@ export class PrismaExpenditureGroupRepository implements ExpenditureGroupReposit
     );
   }
 
+  async remove(bookId: string, groupId: string) {
+    // 紐づけ（research_fund_group_items）と成果物は onDelete: Cascade で一緒に消える。
+    const result = await this.prisma.researchFundExpenditureGroup.deleteMany({
+      where: { id: BigInt(groupId), bookId: BigInt(bookId) },
+    });
+    if (result.count !== 1) throw new ExpenditureGroupError("支出群が見つかりません");
+  }
+
+  async reorder(bookId: string, groupIds: readonly string[]) {
+    await this.prisma.$transaction(async (tx) => {
+      const rows = await tx.researchFundExpenditureGroup.findMany({
+        where: { bookId: BigInt(bookId) },
+        select: { id: true },
+      });
+      // 一覧を開いたまま他所で追加・削除されていたら、歯抜けの順序を書き込まずに諦めてもらう。
+      const current = new Set(rows.map((row) => String(row.id)));
+      if (current.size !== groupIds.length || groupIds.some((groupId) => !current.has(groupId)))
+        throw new ExpenditureGroupError(
+          "一覧が更新されています。再読み込みしてから並べ替えてください",
+        );
+      for (const [displayOrder, groupId] of groupIds.entries())
+        await tx.researchFundExpenditureGroup.update({
+          where: { id: BigInt(groupId) },
+          data: { displayOrder },
+        });
+    });
+  }
+
   /**
    * 紐づけと成果物を作り直す。トランザクション内で呼ぶ前提で、
    * 帳簿外・他の支出群の仕訳が混ざっていれば投げて丸ごと巻き戻す。

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
@@ -150,23 +150,27 @@ export class PrismaExpenditureGroupRepository implements ExpenditureGroupReposit
   }
 
   async reorder(bookId: string, groupIds: readonly string[]) {
-    await this.prisma.$transaction(async (tx) => {
-      const rows = await tx.researchFundExpenditureGroup.findMany({
-        where: { bookId: BigInt(bookId) },
-        select: { id: true },
-      });
-      // 一覧を開いたまま他所で追加・削除されていたら、歯抜けの順序を書き込まずに諦めてもらう。
-      const current = new Set(rows.map((row) => String(row.id)));
-      if (current.size !== groupIds.length || groupIds.some((groupId) => !current.has(groupId)))
-        throw new ExpenditureGroupError(
-          "一覧が更新されています。再読み込みしてから並べ替えてください",
-        );
-      for (const [displayOrder, groupId] of groupIds.entries())
-        await tx.researchFundExpenditureGroup.update({
-          where: { id: BigInt(groupId) },
-          data: { displayOrder },
+    // READ COMMITTED だと findMany の後に別トランザクションが追加・削除しても
+    // 古い current の検証を通ってしまうため、create / update と同じく直列化する。
+    await serializable(() =>
+      this.prisma.$transaction(async (tx) => {
+        const rows = await tx.researchFundExpenditureGroup.findMany({
+          where: { bookId: BigInt(bookId) },
+          select: { id: true },
         });
-    });
+        // 一覧を開いたまま他所で追加・削除されていたら、歯抜けの順序を書き込まずに諦めてもらう。
+        const current = new Set(rows.map((row) => String(row.id)));
+        if (current.size !== groupIds.length || groupIds.some((groupId) => !current.has(groupId)))
+          throw new ExpenditureGroupError(
+            "一覧が更新されています。再読み込みしてから並べ替えてください",
+          );
+        for (const [displayOrder, groupId] of groupIds.entries())
+          await tx.researchFundExpenditureGroup.update({
+            where: { id: BigInt(groupId) },
+            data: { displayOrder },
+          });
+      }, serializableOptions),
+    );
   }
 
   /**

--- a/admin/src/server/contexts/research-fund/presentation/actions/manage-expenditure-groups.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/manage-expenditure-groups.ts
@@ -52,3 +52,44 @@ export async function saveExpenditureGroup(
     return failure(error, "支出群の保存に失敗しました");
   }
 }
+
+export async function deleteExpenditureGroup(
+  politicianId: string,
+  bookId: string,
+  groupId: string,
+) {
+  await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    await new ManageExpenditureGroupsUsecase(new PrismaExpenditureGroupRepository(prisma)).remove(
+      bookId,
+      groupId,
+    );
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const };
+  } catch (error) {
+    return failure(error, "支出群の削除に失敗しました");
+  }
+}
+
+/** 一覧に出ている支出群の ID を、表示したい順に過不足なく渡す */
+export async function reorderExpenditureGroups(
+  politicianId: string,
+  bookId: string,
+  groupIds: string[],
+) {
+  await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    await new ManageExpenditureGroupsUsecase(new PrismaExpenditureGroupRepository(prisma)).reorder(
+      bookId,
+      groupIds,
+    );
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const };
+  } catch (error) {
+    return failure(error, "並べ替えに失敗しました");
+  }
+}

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-expenditure-groups-usecase.test.ts
@@ -14,6 +14,8 @@ function setup() {
     entries: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
+    remove: jest.fn(),
+    reorder: jest.fn(),
   };
   repository.book.mockResolvedValue({ policyComment: "方針" });
   repository.list.mockResolvedValue([]);
@@ -177,6 +179,30 @@ test.each(["example.com", "javascript:alert(1)", "ftp://example.com/a"])(
   },
 );
 
+test("削除は帳簿と支出群のIDをそのままリポジトリに渡す", async () => {
+  const { repository, usecase } = setup();
+  await usecase.remove("3", "1");
+  expect(repository.remove).toHaveBeenCalledWith("3", "1");
+});
+
+test("並べ替えは渡された順をそのままリポジトリに渡す", async () => {
+  const { repository, usecase } = setup();
+  await usecase.reorder("3", ["2", "1", "3"]);
+  expect(repository.reorder).toHaveBeenCalledWith("3", ["2", "1", "3"]);
+});
+
+test("空の並びではリポジトリを呼ばない", async () => {
+  const { repository, usecase } = setup();
+  await usecase.reorder("3", []);
+  expect(repository.reorder).not.toHaveBeenCalled();
+});
+
+test("同じ支出群が2回出てくる並びは保存しない", async () => {
+  const { repository, usecase } = setup();
+  await expect(usecase.reorder("3", ["1", "2", "1"])).rejects.toThrow("重複");
+  expect(repository.reorder).not.toHaveBeenCalled();
+});
+
 test.each(["", "0", "-1", "abc"])("不正なIDではリポジトリを呼ばない: %j", async (id) => {
   const { repository, usecase } = setup();
   await expect(usecase.list(id)).rejects.toThrow("ID");
@@ -185,7 +211,13 @@ test.each(["", "0", "-1", "abc"])("不正なIDではリポジトリを呼ばな�
   await expect(usecase.savePolicyComment(id, "方針")).rejects.toThrow("ID");
   await expect(usecase.save(id, null, edit)).rejects.toThrow("ID");
   await expect(usecase.save("3", id, edit)).rejects.toThrow("ID");
+  await expect(usecase.remove(id, "1")).rejects.toThrow("ID");
+  await expect(usecase.remove("3", id)).rejects.toThrow("ID");
+  await expect(usecase.reorder(id, ["1"])).rejects.toThrow("ID");
+  await expect(usecase.reorder("3", ["1", id])).rejects.toThrow("ID");
   expect(repository.create).not.toHaveBeenCalled();
   expect(repository.update).not.toHaveBeenCalled();
   expect(repository.savePolicyComment).not.toHaveBeenCalled();
+  expect(repository.remove).not.toHaveBeenCalled();
+  expect(repository.reorder).not.toHaveBeenCalled();
 });

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.test.ts
@@ -53,3 +53,14 @@ test("同時保存の直列化衝突は保存し直せるエラーに変換す�
     isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
   });
 });
+
+test("並べ替えも直列化トランザクションで行い、衝突は保存し直せるエラーに変換する", async () => {
+  const { $transaction, repository } = setup();
+  $transaction.mockRejectedValue(
+    new Prisma.PrismaClientKnownRequestError("write conflict", { code: "P2034", clientVersion: "test" }),
+  );
+  await expect(repository.reorder("3", ["2", "1"])).rejects.toThrow("他の操作と競合しました");
+  expect($transaction).toHaveBeenCalledWith(expect.any(Function), {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  });
+});


### PR DESCRIPTION
## 目的（Why）

議員室の担当者が、間違えて作った支出群を消せず、公開側に出るカードの並びも作成順に固定されたままだったのを解消するため。
DB は `research_fund_expenditure_groups.display_order` を既に持っているので、schema 変更なしで実装した。

## 変更内容

- **削除**: 支出群の編集ページに「この支出群を削除」を追加。確認ダイアログ（`DeleteExpenditureGroupButton`）を挟み、消したら一覧へ戻る。
  紐づけ `research_fund_group_items` と成果物 `research_fund_group_outcomes` は `onDelete: Cascade` で一緒に消え、仕訳そのものは残って他の支出群で選べるようになる
- **並べ替え**: 一覧のカードに前後へ動かすボタンを追加。一覧に出ている支出群の ID を表示順に丸ごと送り、`display_order` を 0 から振り直す
- リポジトリの `reorder` はトランザクション内で帳簿の支出群と過不足を突き合わせ、古い一覧からの保存は歯抜けの順序を書かずに弾く
- usecase に `remove` / `reorder` を追加（ID 形式・重複の検証）。サーバーアクションは既存同様 `requireAuth` → `requireJournalTarget` → `revalidatePath` の 1 セット

## ローカル CI

- `pnpm verify` ✅（admin 1468 passed / webapp 139 passed、typecheck・lint・knip・depcruise すべて green）
- `pnpm supabase:start && pnpm db:reset && pnpm test:e2e` ✅（webapp / admin 48 passed）
  E2E は `admin/e2e/tests/expenditure-groups.spec.ts` に 2 つ目の支出群の作成・並べ替え（リロード後も保持）・編集ページからの削除・削除後に仕訳が再び選べることを追加した

## スコープアウト

- 公開側の表示（#1360）
- Prisma schema の変更（不要）

Closes #1409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 支出群を編集画面から削除できるようになりました。
  * 支出群カードを前後に移動して並べ替えられるようになり、順序が保存されます。
  * 支出群の削除後、紐づいていた支出項目を他の支出群へ再選択できるようになりました。
  * 削除時の確認ダイアログ、成功・失敗通知を追加しました。

* **テスト**
  * 支出群の削除、並べ替え、順序の保持、項目の再選択に関するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->