### PR TITLE
chore: 本番環境で Prisma のクエリログを出さない

### DIFF
--- a/admin/src/server/contexts/shared/infrastructure/prisma.ts
+++ b/admin/src/server/contexts/shared/infrastructure/prisma.ts
@@ -1,15 +1,18 @@
 import "server-only";
 
-import { PrismaClient } from "@prisma/client";
+import { type Prisma, PrismaClient } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
+// 本番では公開ページのアクセスごとに実行 SQL が標準出力へ出てしまうため、クエリログは開発・テストだけで有効にする。
+const logLevels: Prisma.LogLevel[] = process.env.NODE_ENV === "production" ? [] : ["query"];
+
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log: ["query"],
+    log: logLevels,
   });
 
 if (process.env.NODE_ENV !== "production") {

--- a/admin/tests/server/contexts/shared/infrastructure/prisma.test.ts
+++ b/admin/tests/server/contexts/shared/infrastructure/prisma.test.ts
@@ -1,0 +1,45 @@
+const constructorMock = jest.fn();
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: class {
+    constructor(options: unknown) {
+      constructorMock(options);
+    }
+  },
+}));
+
+// NODE_ENV は型定義上 readonly なので、テストでの差し替えはキャスト経由で行う
+const setNodeEnv = (value: string | undefined) => {
+  (process.env as Record<string, string | undefined>).NODE_ENV = value;
+};
+
+const loadPrisma = (nodeEnv: string) => {
+  jest.resetModules();
+  constructorMock.mockClear();
+  setNodeEnv(nodeEnv);
+  // 前回のモジュール読み込みが残したグローバルキャッシュを持ち越さない
+  delete (globalThis as { prisma?: unknown }).prisma;
+  require("@/server/contexts/shared/infrastructure/prisma");
+  return constructorMock.mock.calls[0][0] as { log: string[] };
+};
+
+describe("prisma client", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv);
+    delete (globalThis as { prisma?: unknown }).prisma;
+  });
+
+  it("本番ではクエリログを出さない", () => {
+    expect(loadPrisma("production").log).toEqual([]);
+  });
+
+  it("開発ではクエリログを出す", () => {
+    expect(loadPrisma("development").log).toEqual(["query"]);
+  });
+
+  it("テストではクエリログを出す", () => {
+    expect(loadPrisma("test").log).toEqual(["query"]);
+  });
+});

--- a/webapp/src/server/contexts/public-finance/infrastructure/prisma.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/prisma.ts
@@ -1,15 +1,18 @@
 import "server-only";
 
-import { PrismaClient } from "@prisma/client";
+import { type Prisma, PrismaClient } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
+// 本番では公開ページのアクセスごとに実行 SQL が標準出力へ出てしまうため、クエリログは開発・テストだけで有効にする。
+const logLevels: Prisma.LogLevel[] = process.env.NODE_ENV === "production" ? [] : ["query"];
+
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log: ["query"],
+    log: logLevels,
   });
 
 if (process.env.NODE_ENV !== "production") {

--- a/webapp/tests/server/contexts/public-finance/infrastructure/prisma.test.ts
+++ b/webapp/tests/server/contexts/public-finance/infrastructure/prisma.test.ts
@@ -1,0 +1,45 @@
+const constructorMock = jest.fn();
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: class {
+    constructor(options: unknown) {
+      constructorMock(options);
+    }
+  },
+}));
+
+// NODE_ENV は型定義上 readonly なので、テストでの差し替えはキャスト経由で行う
+const setNodeEnv = (value: string | undefined) => {
+  (process.env as Record<string, string | undefined>).NODE_ENV = value;
+};
+
+const loadPrisma = (nodeEnv: string) => {
+  jest.resetModules();
+  constructorMock.mockClear();
+  setNodeEnv(nodeEnv);
+  // 前回のモジュール読み込みが残したグローバルキャッシュを持ち越さない
+  delete (globalThis as { prisma?: unknown }).prisma;
+  require("@/server/contexts/public-finance/infrastructure/prisma");
+  return constructorMock.mock.calls[0][0] as { log: string[] };
+};
+
+describe("prisma client", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv);
+    delete (globalThis as { prisma?: unknown }).prisma;
+  });
+
+  it("本番ではクエリログを出さない", () => {
+    expect(loadPrisma("production").log).toEqual([]);
+  });
+
+  it("開発ではクエリログを出す", () => {
+    expect(loadPrisma("development").log).toEqual(["query"]);
+  });
+
+  it("テストではクエリログを出す", () => {
+    expect(loadPrisma("test").log).toEqual(["query"]);
+  });
+});


### PR DESCRIPTION
## 目的（Why）

本番（Vercel）を運用するメンテナが、公開ページのアクセスごとに実行 SQL が標準出力へ流れてログが膨らみ、SQL の構造が運用ログに残り続ける状態を解消するため。
開発時のクエリ確認は引き続き必要なので、環境で切り替える。

## 変更内容

- `PrismaClient` の `log` を `NODE_ENV === "production"` のとき `[]`、それ以外（開発・テスト）は従来どおり `["query"]` にする
  - `webapp/src/server/contexts/public-finance/infrastructure/prisma.ts`
  - `admin/src/server/contexts/shared/infrastructure/prisma.ts`（Issue の「補足」に従い admin 側も同様に対応）
- 各アプリに `NODE_ENV` ごとの `log` 設定を検証するユニットテストを追加

> Issue 本文は webapp 側のパスを `contexts/shared/...` としていますが、その移設を行う #1419 が未マージのため、現行の `contexts/public-finance/...` に対して変更しています。

## ローカル CI

`pnpm verify` 通過（test / typecheck / lint / knip / depcruise）。

```
Test Suites: 1 skipped, 127 passed, 127 of 128 total   (admin)
Test Suites: 18 passed, 18 total                       (webapp)
✔ no dependency violations found
```

E2E は画面の導線・認証・フォーム・ルーティングに影響しない変更のため未実行。

## スコープアウトして起票した Issue

なし。

Closes #1421