### PR TITLE
fix(loop): bash 3.2 + 日本語ロケールで run-session.sh が unbound variable になるのを直す

### DIFF
--- a/scripts/loop/escalate.sh
+++ b/scripts/loop/escalate.sh
@@ -22,12 +22,12 @@ while IFS=$'\t' read -r pr issue reason; do
     budget-exceeded)
       body="🤖 CodeRabbit 対応の修正ラウンドが上限（LOOP_MAX_FIX_ROUNDS）に達しても未解決の指摘が残っているため、この PR はループの対象から外し人間に引き継ぎます。残った指摘の判断をお願いします。PR は open のまま、auto-merge の予約も残しています。" ;;
     *)
-      body="🤖 ループの対象から外し人間に引き継ぎます（reason=$reason）。" ;;
+      body="🤖 ループの対象から外し人間に引き継ぎます（reason=${reason}）。" ;;
   esac
   gh pr comment "$pr" --body "$body" >/dev/null
   if [[ -n "$issue" && "$issue" != "null" ]]; then
     gh issue edit "$issue" --remove-label "loop:wip" --add-label "loop:human" >/dev/null
-    gh issue comment "$issue" --body "🤖 PR #$pr を人間に引き継ぎました（reason=$reason）。詳細は PR のコメントを参照してください。" >/dev/null
+    gh issue comment "$issue" --body "🤖 PR #${pr} を人間に引き継ぎました（reason=${reason}）。詳細は PR のコメントを参照してください。" >/dev/null
   fi
   echo "[escalate] PR #$pr (issue #$issue) → loop:human reason=$reason" >&2
   escalated=$((escalated + 1))
@@ -41,7 +41,7 @@ while IFS=$'\t' read -r issue reason; do
     dead-dependency)
       body="🤖 本文の「#X のマージ後に着手」で指定された依存先が、main にマージされないまま閉じています。待っても成果物が来ないため \`loop:human\` に切り替えました。依存の記述を直すか、依存先を再度進めてから \`loop:ready\` に戻してください。" ;;
     *)
-      body="🤖 ループの対象から外しました（reason=$reason）。" ;;
+      body="🤖 ループの対象から外しました（reason=${reason}）。" ;;
   esac
   gh issue edit "$issue" --remove-label "loop:ready" --add-label "loop:human" >/dev/null
   gh issue comment "$issue" --body "$body" >/dev/null

--- a/scripts/loop/run-session.sh
+++ b/scripts/loop/run-session.sh
@@ -53,7 +53,7 @@ run_codex() {
   prompt="あなたはループエンジニアリングの 1 セッションを実行するエージェントです。
 まず docs/loop-session-rules.md を読み、次に .claude/commands/$command_name.md を読んで、その手順を実行してください。
 
-- 手順書中の \$ARGUMENTS は「$argument」に読み替えること
+- 手順書中の \$ARGUMENTS は「${argument}」に読み替えること
 - ファイル冒頭の frontmatter（allowed-tools 等）は Claude Code 用の設定なので無視してよい
 - 「現在の状況」セクションの !\`コマンド\` は自動展開されないので、各コマンドを自分で実行して状況を把握すること
 - 最後に必ず LOOP_RESULT 行を出力すること"


### PR DESCRIPTION
## 目的（Why）

ループのランナーが astra（Codex CLI）をモデルに指定するとセッションを 1 つも起動できず、ループが止まる状態を解消するため。

`scripts/loop/run-session.sh` が `argument?: unbound variable` で即死し、tick のログファイルすら作られないため、ランナーからは `no-result-line` の一過性失敗に見え、2 tick で中断されていた。

## 原因

macOS 標準の `/bin/bash`（3.2.57）は `LANG=ja_JP.UTF-8` のとき、`$var` の直後に続く全角文字の先頭バイト（例: `」` の 0xE3）を変数名の一部と誤判定する。`set -u` のため存在しない変数の参照となりスクリプトが終了する。

```
$ LANG=ja_JP.UTF-8 /bin/bash -uc 'a=1; x="「$a」"; echo "$x"'
/bin/bash: a?: unbound variable
```

`${var}` と波括弧で囲めば変数名の境界が確定するため再現しない。

## 変更内容

`scripts/loop-once.sh` / `scripts/loop.sh` / `scripts/loop/*.sh` 全体を走査し、**波括弧なしの変数展開の直後に非 ASCII 文字が続く箇所 4 件**をすべて `${var}` に修正した。

- `scripts/loop/run-session.sh:56` — `「$argument」` → `「${argument}」`（Issue で報告された astra 起動不能の直接原因）
- `scripts/loop/escalate.sh:25,30,44` — `$reason）` / `$pr を` → `${reason}` / `${pr}`
  - 同じパターンで、**エスカレーション時の PR / Issue へのコメント投稿も落ちる状態だった**ので、あわせて修正

波括弧付きの `${WAIT_SECONDS}秒` などは元から安全で、変更していない。制御フローの変更は一切ない。

## 検証

すべて `LANG=ja_JP.UTF-8` + `/bin/bash` 3.2.57（PATH 上の bash はこれのみ）で実施。

**修正前後の比較**（`codex` をスタブに差し替えて実行）:

```
### BEFORE fix:
scripts/loop/run-session.sh: line 59: argument?: unbound variable
exit=1 log=no          ← Issue 記載の症状と一致

### AFTER fix:
exit=0 log=yes         ← セッションが起動しログファイルも作られる
```

- プロンプト内の引数展開も確認済み: `- 手順書中の $ARGUMENTS は「1419」に読み替えること`
- `escalate.sh` の 3 つのメッセージ文字列が正しく組み立たることを確認
- 全スクリプトの `bash -n` 構文チェック通過
- 残存パターンの再走査: 0 件

**ローカル CI**: `pnpm verify` 通過（test / typecheck / lint / knip / depcruise すべて green）。
シェルスクリプトのみの変更で画面の導線・認証・フォーム・ルーティングに影響しないため E2E は未実行。

## 完了条件

- [x] `LANG=ja_JP.UTF-8` の macOS 標準 `/bin/bash` で `run-session.sh astra <コマンド> <引数> <ログ>` が `unbound variable` で落ちず、ログファイルが作られる
- [x] `run-session.sh` 内で変数展開の直後に非 ASCII 文字が続く箇所がなくなっている
- [x] `scripts/loop/` 配下の他のスクリプトと `loop-once.sh` / `loop.sh` にも同じパターンがあれば直っている（`escalate.sh` に 3 件あり修正）
- [x] `pnpm verify` が通る

## 備考

本 PR は `docs/loop-session-rules.md` の絶対ルール 5（ループ機構に触れない）の保護対象ファイルを変更している。これは Issue #1423 がメンテナによって `loop:unblock` 付きで当該ファイルの修正を明示的に依頼したものであるため。実行中のランナーを書き換えないよう、作業は別 worktree で行った。

Closes #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
