### PR TITLE
feat(webapp): 政党ページの調研費セクション（A-6）と組織セレクタの2グループ化

### DIFF
--- a/prisma/seeds/politicians.ts
+++ b/prisma/seeds/politicians.ts
@@ -31,6 +31,16 @@ const data: PoliticianSeedData[] = [
     organizationSlug: null, // 無所属（所属なしでも議員は存在できることの確認用）
   },
   {
+    // 政党ページ A-6 の「準備中の議員もグレーで表示する」を確認するための所属議員。
+    name: 'サンプル 次郎',
+    slug: 'sample-jiro',
+    termStart: '2025-07-21',
+    displayOrder: 3,
+    tenantSlug: 'sample-party',
+    organizationSlug: 'sample-party',
+    startedOn: '2025-07-21',
+  },
+  {
     name: 'E2E 議員',
     slug: 'e2e-politician',
     termStart: '2025-07-21',

--- a/prisma/seeds/researchFundBooks.ts
+++ b/prisma/seeds/researchFundBooks.ts
@@ -30,6 +30,7 @@ const data: ResearchFundBookSeedData[] = [
     },
   },
   { politicianSlug: 'sample-hanako', financialYear: 2026, status: 'preparing' },
+  { politicianSlug: 'sample-jiro', financialYear: 2026, status: 'preparing' },
   { politicianSlug: 'e2e-politician', financialYear: 2026, status: 'active' },
 ];
 

--- a/webapp/e2e/tests/organization.spec.ts
+++ b/webapp/e2e/tests/organization.spec.ts
@@ -75,8 +75,8 @@ test.describe("政治団体ページ", () => {
 			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
 			await selectorButton.click();
 
-			// ドロップダウンが開いて選択肢が表示される
-			await expect(page.getByText("表示する団体名")).toBeVisible();
+			// ドロップダウンが開いて選択肢が表示される（政治資金／調査研究費の2グループ）
+			await expect(page.getByText(/^政治資金 \d+団体$/)).toBeVisible();
 		});
 
 		test("別の政治団体を選択するとページが切り替わる", async ({ page }) => {

--- a/webapp/e2e/tests/research-fund.spec.ts
+++ b/webapp/e2e/tests/research-fund.spec.ts
@@ -121,3 +121,114 @@ async function selectMonth(section: Locator, label: string) {
 		await expect(button).toHaveAttribute("aria-pressed", "true");
 	}).toPass();
 }
+
+test.describe("調査研究費 政党ページのサマリー（A-6）", () => {
+	const ORG_URL = "/o/sample-party/2026";
+
+	test("A-6 が表示され、実行時エラーが発生しないこと", async ({ page }) => {
+		const errors: string[] = [];
+		page.on("pageerror", (error) => {
+			errors.push(`${error.name}: ${error.message}`);
+		});
+
+		await page.goto(ORG_URL);
+		const section = page.locator("#research-fund");
+
+		// 見出し・リード・公開範囲
+		await expect(
+			section.getByRole("heading", { name: /議員\d+人の調査研究費サマリー/ }),
+		).toBeVisible();
+		await expect(
+			section.getByText("国会議員に毎月支給される公費を、何に使ったか"),
+		).toBeVisible();
+		await expect(section.getByText(/分を公開中/).first()).toBeVisible();
+
+		// 「調査研究費とは」コラプスは初期状態で閉じている
+		const collapse = section.getByText("調査研究費とは");
+		await expect(collapse).toBeVisible();
+		await expect(
+			section.getByText(/政党を通らず国から議員に対して毎月直接支給される公費/),
+		).toBeHidden();
+
+		// KPI 2枚
+		await expect(section.getByText(/^支給された/)).toBeVisible();
+		await expect(section.getByText("議員活動に使った")).toBeVisible();
+
+		// 議員リスト（公開中の議員と準備中の議員が両方並ぶ）
+		await expect(
+			section.getByRole("button", { name: /サンプル 太郎/ }),
+		).toBeVisible();
+		await expect(section.getByText("準備中").first()).toBeVisible();
+
+		expect(
+			errors,
+			`以下のエラーが発生しました:\n${errors.join("\n")}`,
+		).toHaveLength(0);
+	});
+
+	test("準備中の議員の行を選ぶとグラフの代わりに準備中の案内が出る", async ({
+		page,
+	}) => {
+		await page.goto(ORG_URL);
+		const section = page.locator("#research-fund");
+
+		const row = section.getByRole("button", { name: /サンプル 次郎/ });
+		await expect(async () => {
+			await row.click();
+			await expect(row).toHaveAttribute("aria-pressed", "true");
+		}).toPass();
+
+		await expect(
+			section.getByText(/サンプル 次郎の調査研究費は現在準備中です。/),
+		).toBeVisible();
+		await expect(section.getByText("議員活動に使った")).toBeHidden();
+	});
+
+	test("詳細ボタンから議員ページに遷移する", async ({ page }) => {
+		await page.goto(ORG_URL);
+
+		await page
+			.locator("#research-fund")
+			.getByRole("link", { name: /詳細/ })
+			.first()
+			.click();
+
+		await expect(page).toHaveURL(/\/p\/sample-taro\/2026$/);
+	});
+
+	test("グローバルナビに「調査研究費」がある", async ({ page }) => {
+		await page.goto(ORG_URL);
+
+		await expect(
+			page
+				.getByRole("navigation", { name: "メインナビゲーション" })
+				.getByRole("link", { name: "調査研究費" }),
+		).toHaveAttribute("href", /#research-fund$/);
+	});
+
+	test("A-7 データについて に調研費の記載がある", async ({ page }) => {
+		await page.goto(ORG_URL);
+
+		await expect(
+			page.locator("#explanation").getByText("調査研究費について"),
+		).toBeVisible();
+	});
+
+	test("組織セレクタが政治資金と調査研究費の2グループになる", async ({
+		page,
+	}) => {
+		await page.goto(ORG_URL);
+
+		await page.getByRole("button", { name: /サンプル党/ }).first().click();
+
+		await expect(page.getByText(/^政治資金 \d+団体$/)).toBeVisible();
+		await expect(page.getByText(/^調査研究費 議員\d+人$/)).toBeVisible();
+
+		// 議員を選ぶと議員ページに遷移する（A-6 の議員リストと取り違えないよう
+		// 調査研究費グループの中だけを探す）
+		await page
+			.getByRole("button", { name: /サンプル 太郎 2026年/ })
+			.click();
+		await expect(page).toHaveURL(/\/p\/sample-taro\/2026$/);
+	});
+});

--- a/webapp/src/app/o/[slug]/[year]/page.tsx
+++ b/webapp/src/app/o/[slug]/[year]/page.tsx
@@ -10,10 +10,12 @@ import MainColumn from "@/client/components/layout/MainColumn";
 import BalanceSheetSection from "@/client/components/top-page/BalanceSheetSection";
 import CashFlowSection from "@/client/components/top-page/CashFlowSection";
 import MonthlyTrendsSection from "@/client/components/top-page/MonthlyTrendsSection";
+import ResearchFundPartySection from "@/client/components/research-fund/ResearchFundPartySection";
 import ProgressSection from "@/client/components/top-page/ProgressSection";
 import TransactionsSection from "@/client/components/top-page/TransactionsSection";
 import { loadTopPageData } from "@/server/contexts/public-finance/presentation/loaders/load-top-page-data";
 import { loadOrganizations } from "@/server/contexts/public-finance/presentation/loaders/load-organizations";
+import { loadResearchFundPartySummary } from "@/server/contexts/research-fund/presentation/loaders/load-research-fund-party-summary";
 import { formatUpdatedAt } from "@/client/lib/format-date";
 
 export const revalidate = 300; // 5 minutes
@@ -79,6 +81,14 @@ export default async function OrgPage({ params }: OrgPageProps) {
     return null;
   });
 
+  // A-6 調査研究費。所属議員がいない政治団体では null になり、セクションごと出さない。
+  const researchFund = await loadResearchFundPartySummary({ slug, financialYear }).catch(
+    (error) => {
+      console.error("loadResearchFundPartySummary error:", error);
+      return null;
+    },
+  );
+
   const updatedAt = formatUpdatedAt(data?.transactionData?.lastUpdatedAt ?? null);
 
   return (
@@ -107,6 +117,12 @@ export default async function OrgPage({ params }: OrgPageProps) {
         year={financialYear}
         organizationName={currentOrganization?.displayName}
       />
+      {researchFund && (
+        <ResearchFundPartySection
+          data={researchFund}
+          updatedAt={formatUpdatedAt(researchFund.asOfDate)}
+        />
+      )}
       <AnotherPageLinkSection currentSlug={slug} year={financialYear} />
       <ProgressSection />
       <ExplanationSection />

--- a/webapp/src/client/components/common/ExplanationSection.tsx
+++ b/webapp/src/client/components/common/ExplanationSection.tsx
@@ -44,6 +44,15 @@ export default function ExplanationSection() {
 
         <div>
           <h3 className="text-base sm:text-lg font-bold text-gray-800 mb-3 font-japanese">
+            調査研究費について
+          </h3>
+          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium sm:font-normal font-japanese">
+            調査研究費（正式名称：調査研究広報滞在費）は、政党を通らず国から国会議員に対して毎月直接支給される公費です。政党を経由しないため、上記の政治資金とは別のお金として、議員ごとに公開しています。金額にかかわらず、公開の準備が整った月の支出を1件ずつ、領収書つきで掲載しています。整理が完了していない議員・月は「準備中」と表示され、順次公開していきます。余った分は国庫に返すため、年末時点で確定します。
+          </p>
+        </div>
+
+        <div>
+          <h3 className="text-base sm:text-lg font-bold text-gray-800 mb-3 font-japanese">
             免責事項
           </h3>
           <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium sm:font-normal font-japanese">

--- a/webapp/src/client/components/layout/header/Header.tsx
+++ b/webapp/src/client/components/layout/header/Header.tsx
@@ -1,20 +1,30 @@
 import "server-only";
 import HeaderClient from "@/client/components/layout/header/HeaderClient";
 import { loadOrganizations } from "@/server/contexts/public-finance/presentation/loaders/load-organizations";
+import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
 import { loadResearchFundPoliticians } from "@/server/contexts/research-fund/presentation/loaders/load-research-fund-politicians";
 
-/** 組織セレクタに出す年度。`AVAILABLE_YEARS` の最新に合わせる。 */
-const DEFAULT_YEAR = 2026;
+/** 組織セレクタに出す年度。`OrganizationYearSheet` の `AVAILABLE_YEARS` と揃える。 */
+const AVAILABLE_YEARS = [2025, 2026] as const;
 
 export default async function Header() {
-  const [organizationsData, politicians] = await Promise.all([
+  const [organizationsData, politicianLists] = await Promise.all([
     loadOrganizations(),
-    // 調研費の帳簿が無い環境（CI のビルド時など）でもヘッダーは描けるようにする。
-    loadResearchFundPoliticians({ financialYear: DEFAULT_YEAR }).catch((error) => {
-      console.error("loadResearchFundPoliticians error:", error);
-      return [];
-    }),
+    // 年度を切り替えたときに、その年度に帳簿のある議員だけを出せるよう年度ごとに取る。
+    Promise.all(
+      AVAILABLE_YEARS.map((financialYear) =>
+        // 調研費の帳簿が無い環境（CI のビルド時など）でもヘッダーは描けるようにする。
+        loadResearchFundPoliticians({ financialYear }).catch((error) => {
+          console.error("loadResearchFundPoliticians error:", error);
+          return [] as ResearchFundPoliticianEntry[];
+        }),
+      ),
+    ),
   ]);
 
-  return <HeaderClient organizations={organizationsData} politicians={politicians} />;
+  const politiciansByYear: Record<number, ResearchFundPoliticianEntry[]> = Object.fromEntries(
+    AVAILABLE_YEARS.map((year, index) => [year, politicianLists[index]]),
+  );
+
+  return <HeaderClient organizations={organizationsData} politiciansByYear={politiciansByYear} />;
 }

--- a/webapp/src/client/components/layout/header/Header.tsx
+++ b/webapp/src/client/components/layout/header/Header.tsx
@@ -1,9 +1,20 @@
 import "server-only";
-import { loadOrganizations } from "@/server/contexts/public-finance/presentation/loaders/load-organizations";
 import HeaderClient from "@/client/components/layout/header/HeaderClient";
+import { loadOrganizations } from "@/server/contexts/public-finance/presentation/loaders/load-organizations";
+import { loadResearchFundPoliticians } from "@/server/contexts/research-fund/presentation/loaders/load-research-fund-politicians";
+
+/** 組織セレクタに出す年度。`AVAILABLE_YEARS` の最新に合わせる。 */
+const DEFAULT_YEAR = 2026;
 
 export default async function Header() {
-  const organizationsData = await loadOrganizations();
+  const [organizationsData, politicians] = await Promise.all([
+    loadOrganizations(),
+    // 調研費の帳簿が無い環境（CI のビルド時など）でもヘッダーは描けるようにする。
+    loadResearchFundPoliticians({ financialYear: DEFAULT_YEAR }).catch((error) => {
+      console.error("loadResearchFundPoliticians error:", error);
+      return [];
+    }),
+  ]);
 
-  return <HeaderClient organizations={organizationsData} />;
+  return <HeaderClient organizations={organizationsData} politicians={politicians} />;
 }

--- a/webapp/src/client/components/layout/header/HeaderClient.tsx
+++ b/webapp/src/client/components/layout/header/HeaderClient.tsx
@@ -50,10 +50,11 @@ const getNavigationItems = (currentSlug: string, currentYear: number) => [
 
 interface HeaderClientProps {
   organizations: OrganizationsResponse;
-  politicians: ResearchFundPoliticianEntry[];
+  /** 年度ごとの議員一覧。年度を切り替えると出す一覧も切り替える */
+  politiciansByYear: Record<number, ResearchFundPoliticianEntry[]>;
 }
 
-export default function HeaderClient({ organizations, politicians }: HeaderClientProps) {
+export default function HeaderClient({ organizations, politiciansByYear }: HeaderClientProps) {
   const pathname = usePathname();
 
   // 現在のslugとyearを取得（/o/[slug]/[year]/... と /p/[slug]/[year] の形式）
@@ -150,7 +151,7 @@ export default function HeaderClient({ organizations, politicians }: HeaderClien
             <div className="flex items-center w-full max-w-[217px] min-w-0 h-12 flex-shrink">
               <OrganizationYearSheet
                 organizations={organizations}
-                politicians={politicians}
+                politiciansByYear={politiciansByYear}
                 initialSlug={currentSlug ?? undefined}
                 initialPoliticianSlug={currentPoliticianSlug ?? undefined}
                 initialYear={currentYear}

--- a/webapp/src/client/components/layout/header/HeaderClient.tsx
+++ b/webapp/src/client/components/layout/header/HeaderClient.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import OrganizationYearSheet from "@/client/components/layout/header/OrganizationYearSheet";
+import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
 import type { OrganizationsResponse } from "@/types/organization";
 
 const DEFAULT_YEAR = 2026;
@@ -31,6 +32,11 @@ const getNavigationItems = (currentSlug: string, currentYear: number) => [
     desktopLabel: "すべての出入金",
   },
   {
+    href: `/o/${currentSlug}/${currentYear}/#research-fund`,
+    label: "調査研究費",
+    desktopLabel: "調査研究費",
+  },
+  {
     href: `/o/${currentSlug}/${currentYear}/#explanation`,
     label: "データについて",
     desktopLabel: "データについて",
@@ -44,18 +50,24 @@ const getNavigationItems = (currentSlug: string, currentYear: number) => [
 
 interface HeaderClientProps {
   organizations: OrganizationsResponse;
+  politicians: ResearchFundPoliticianEntry[];
 }
 
-export default function HeaderClient({ organizations }: HeaderClientProps) {
+export default function HeaderClient({ organizations, politicians }: HeaderClientProps) {
   const pathname = usePathname();
 
-  // 現在のslugとyearを取得（/o/[slug]/[year]/... の形式の場合）
+  // 現在のslugとyearを取得（/o/[slug]/[year]/... と /p/[slug]/[year] の形式）
   const pathSegments = pathname.split("/");
-  const slugFromPath = pathSegments[1] === "o" ? pathSegments[2] : null;
-  const yearFromPath =
-    pathSegments[1] === "o" && pathSegments[3] ? parseInt(pathSegments[3], 10) : null;
+  const isPoliticianPath = pathSegments[1] === "p";
+  const slugFromPath =
+    pathSegments[1] === "o" || isPoliticianPath ? (pathSegments[2] ?? null) : null;
+  const yearFromPath = slugFromPath && pathSegments[3] ? parseInt(pathSegments[3], 10) : null;
 
-  const currentSlug = slugFromPath ?? organizations.default;
+  // 議員ページではナビの遷移先に議員の slug を使えないので、既定の政治団体に寄せる。
+  const currentSlug = isPoliticianPath
+    ? organizations.default
+    : (slugFromPath ?? organizations.default);
+  const currentPoliticianSlug = isPoliticianPath ? slugFromPath : null;
   const currentYear =
     yearFromPath && [2025, 2026].includes(yearFromPath) ? yearFromPath : DEFAULT_YEAR;
 
@@ -138,7 +150,9 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
             <div className="flex items-center w-full max-w-[217px] min-w-0 h-12 flex-shrink">
               <OrganizationYearSheet
                 organizations={organizations}
+                politicians={politicians}
                 initialSlug={currentSlug ?? undefined}
+                initialPoliticianSlug={currentPoliticianSlug ?? undefined}
                 initialYear={currentYear}
               />
             </div>

--- a/webapp/src/client/components/layout/header/OrganizationYearSheet.tsx
+++ b/webapp/src/client/components/layout/header/OrganizationYearSheet.tsx
@@ -1,8 +1,9 @@
 "use client";
 import "client-only";
-import { useRouter, usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
 import Image from "next/image";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
 import type { OrganizationsResponse } from "@/types/organization";
 
 const AVAILABLE_YEARS = [2025, 2026] as const;
@@ -10,26 +11,38 @@ const DEFAULT_YEAR = 2026;
 
 interface OrganizationYearSheetProps {
   organizations: OrganizationsResponse;
+  politicians: ResearchFundPoliticianEntry[];
   initialSlug?: string;
+  /** 議員ページを開いているときの議員 slug。政治団体ページでは undefined */
+  initialPoliticianSlug?: string;
   initialYear?: number;
 }
 
 export default function OrganizationYearSheet({
   organizations,
+  politicians,
   initialSlug,
+  initialPoliticianSlug,
   initialYear,
 }: OrganizationYearSheetProps) {
   const router = useRouter();
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
   const [currentSlug, setCurrentSlug] = useState(initialSlug || "");
+  const [currentPoliticianSlug, setCurrentPoliticianSlug] = useState(initialPoliticianSlug || "");
   const [currentYear, setCurrentYear] = useState(initialYear || DEFAULT_YEAR);
 
   useEffect(() => {
     const pathSegments = pathname.split("/");
-    // URL format: /o/{slug}/{year}/...
-    if (pathSegments[1] === "o" && pathSegments[2]) {
-      setCurrentSlug(pathSegments[2]);
+    // URL format: /o/{slug}/{year}/... または /p/{slug}/{year}
+    const isPolitician = pathSegments[1] === "p";
+    if ((pathSegments[1] === "o" || isPolitician) && pathSegments[2]) {
+      if (isPolitician) {
+        setCurrentPoliticianSlug(pathSegments[2]);
+      } else {
+        setCurrentPoliticianSlug("");
+        setCurrentSlug(pathSegments[2]);
+      }
       if (pathSegments[3]) {
         const yearFromPath = parseInt(pathSegments[3], 10);
         if (AVAILABLE_YEARS.includes(yearFromPath as (typeof AVAILABLE_YEARS)[number])) {
@@ -40,6 +53,9 @@ export default function OrganizationYearSheet({
   }, [pathname]);
 
   const currentOrganization = organizations.organizations.find((org) => org.slug === currentSlug);
+  const currentPolitician = politicians.find(
+    (politician) => politician.slug === currentPoliticianSlug,
+  );
 
   const handleSelect = (slug: string, year: number) => {
     const pathSegments = pathname.split("/");
@@ -61,9 +77,20 @@ export default function OrganizationYearSheet({
     handleSelect(slug, currentYear);
   };
 
+  const handlePoliticianSelect = (slug: string) => {
+    router.push(`/p/${encodeURIComponent(slug)}/${currentYear}`);
+  };
+
   const handleYearSelect = (year: number) => {
+    if (currentPoliticianSlug) {
+      router.push(`/p/${encodeURIComponent(currentPoliticianSlug)}/${year}`);
+      return;
+    }
     handleSelect(currentSlug, year);
   };
+
+  const triggerLabel =
+    currentPolitician?.name ?? currentOrganization?.displayName ?? "政治団体を選択";
 
   return (
     <div className="relative w-full min-w-0 max-w-full">
@@ -79,7 +106,7 @@ export default function OrganizationYearSheet({
       >
         <span className="flex flex-col gap-1.5 items-start flex-1 min-w-0 leading-none">
           <span className="text-[14px] leading-none text-black truncate w-full text-left">
-            {currentOrganization?.displayName || "政治団体を選択"}
+            {triggerLabel}
           </span>
           <span className="text-[9px] leading-none text-[#238778]">{currentYear}年</span>
         </span>
@@ -107,7 +134,9 @@ export default function OrganizationYearSheet({
           <div className="absolute right-0 top-full mt-1 z-50 w-68 bg-white rounded-lg border border-black/50 shadow-lg py-3 max-h-[70vh] overflow-y-auto">
             {/* Organization Selection */}
             <div className="px-4 flex flex-col gap-1">
-              <p className="text-[11px] text-[#5a5a5a]">表示する団体名</p>
+              <p className="text-[11px] text-[#5a5a5a]">
+                政治資金 {organizations.organizations.length}団体
+              </p>
               <div className="flex flex-col">
                 {organizations.organizations.map((org) => (
                   <button
@@ -117,25 +146,7 @@ export default function OrganizationYearSheet({
                     className="flex items-center gap-2 h-9 pl-6 text-left cursor-pointer rounded-md hover:bg-gray-100 transition-colors"
                   >
                     <span className="w-3 flex items-center justify-center">
-                      {currentSlug === org.slug && (
-                        <svg
-                          width="13"
-                          height="11"
-                          viewBox="0 0 13 11"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                          aria-hidden="true"
-                        >
-                          <title>選択中</title>
-                          <path
-                            d="M1 5.5L5 9.5L12 1.5"
-                            stroke="#238778"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                        </svg>
-                      )}
+                      {!currentPoliticianSlug && currentSlug === org.slug && <SelectedMark />}
                     </span>
                     <span className="flex flex-col gap-0.5">
                       <span className="text-xs text-gray-900">{org.displayName}</span>
@@ -147,6 +158,45 @@ export default function OrganizationYearSheet({
                 ))}
               </div>
             </div>
+
+            {/* Research Fund (Politicians) Selection */}
+            {politicians.length > 0 && (
+              <>
+                <hr className="my-2 border-gray-200" />
+                <div className="px-4 flex flex-col gap-1">
+                  <p className="text-[11px] text-[#5a5a5a]">
+                    調査研究費 議員{politicians.length}人
+                  </p>
+                  <div className="flex flex-col">
+                    {politicians.map((politician) => (
+                      <button
+                        key={politician.slug}
+                        type="button"
+                        onClick={() => handlePoliticianSelect(politician.slug)}
+                        // 準備中の議員も隠さず、押せる状態のままグレーで並べる（デザイン仕様 §5）
+                        className="flex items-center gap-2 min-h-9 py-1 pl-6 text-left cursor-pointer rounded-md hover:bg-gray-100 transition-colors"
+                      >
+                        <span className="w-3 flex items-center justify-center">
+                          {currentPoliticianSlug === politician.slug && <SelectedMark />}
+                        </span>
+                        <span className="flex flex-col gap-0.5">
+                          <span
+                            className={`text-xs ${
+                              politician.ready ? "text-gray-900" : "text-[#9CA3AF]"
+                            }`}
+                          >
+                            {politician.name}
+                          </span>
+                          <span className="text-[8px] text-[#6a6a6a]">
+                            {politician.statusLabel}
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
 
             {/* Divider */}
             <hr className="my-2 border-gray-200" />
@@ -195,5 +245,27 @@ export default function OrganizationYearSheet({
         </>
       )}
     </div>
+  );
+}
+
+function SelectedMark() {
+  return (
+    <svg
+      width="13"
+      height="11"
+      viewBox="0 0 13 11"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <title>選択中</title>
+      <path
+        d="M1 5.5L5 9.5L12 1.5"
+        stroke="#238778"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }

--- a/webapp/src/client/components/layout/header/OrganizationYearSheet.tsx
+++ b/webapp/src/client/components/layout/header/OrganizationYearSheet.tsx
@@ -11,7 +11,8 @@ const DEFAULT_YEAR = 2026;
 
 interface OrganizationYearSheetProps {
   organizations: OrganizationsResponse;
-  politicians: ResearchFundPoliticianEntry[];
+  /** 年度ごとの議員一覧。選択中の年度に帳簿がある議員だけを出す */
+  politiciansByYear: Record<number, ResearchFundPoliticianEntry[]>;
   initialSlug?: string;
   /** 議員ページを開いているときの議員 slug。政治団体ページでは undefined */
   initialPoliticianSlug?: string;
@@ -20,7 +21,7 @@ interface OrganizationYearSheetProps {
 
 export default function OrganizationYearSheet({
   organizations,
-  politicians,
+  politiciansByYear,
   initialSlug,
   initialPoliticianSlug,
   initialYear,
@@ -53,6 +54,7 @@ export default function OrganizationYearSheet({
   }, [pathname]);
 
   const currentOrganization = organizations.organizations.find((org) => org.slug === currentSlug);
+  const politicians = politiciansByYear[currentYear] ?? [];
   const currentPolitician = politicians.find(
     (politician) => politician.slug === currentPoliticianSlug,
   );
@@ -82,7 +84,11 @@ export default function OrganizationYearSheet({
   };
 
   const handleYearSelect = (year: number) => {
-    if (currentPoliticianSlug) {
+    // その年度に帳簿が無い議員ページへ送ると 404 になるので、政治団体ページに戻す。
+    const hasBook = (politiciansByYear[year] ?? []).some(
+      (politician) => politician.slug === currentPoliticianSlug,
+    );
+    if (currentPoliticianSlug && hasBook) {
       router.push(`/p/${encodeURIComponent(currentPoliticianSlug)}/${year}`);
       return;
     }

--- a/webapp/src/client/components/research-fund/ResearchFundPartyBars.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundPartyBars.tsx
@@ -1,0 +1,44 @@
+"use client";
+import "client-only";
+import type { ResearchFundBarView } from "@/server/contexts/research-fund/domain/models/research-fund-party-summary";
+
+/**
+ * A-6 の横棒グラフ。円グラフは使わない（デザイン仕様 §5）。
+ * 未使用分は渡されない前提で、最大の費目を全幅として相対比較する。
+ */
+export default function ResearchFundPartyBars({ bars }: { bars: ResearchFundBarView[] }) {
+  if (bars.length === 0) {
+    return <p className="text-sm text-gray-500">公開中の調査研究費のデータがありません</p>;
+  }
+
+  const max = Math.max(...bars.map((bar) => bar.amount));
+  const total = bars.reduce((sum, bar) => sum + bar.amount, 0);
+
+  return (
+    <ul className="grid gap-3">
+      {bars.map((bar) => (
+        <li key={bar.key} className="grid gap-1">
+          <div className="flex items-baseline justify-between gap-3">
+            <span className="text-sm font-bold text-gray-800">{bar.label}</span>
+            <span className="whitespace-nowrap text-[13px] text-[#4B5563] tabular-nums">
+              {bar.amount.toLocaleString("ja-JP")}円
+              <span className="ml-1.5 text-[#9CA3AF]">
+                {total > 0 ? `${Math.round((bar.amount / total) * 100)}%` : "0%"}
+              </span>
+            </span>
+          </div>
+          <div
+            className="h-2.5 overflow-hidden rounded-full bg-[#F3F4F6]"
+            role="img"
+            aria-label={`${bar.label} ${bar.amount.toLocaleString("ja-JP")}円`}
+          >
+            <div
+              className="h-full rounded-full bg-[#2AA693]"
+              style={{ width: `${max > 0 ? (bar.amount / max) * 100 : 0}%` }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundPartyBody.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundPartyBody.tsx
@@ -1,0 +1,76 @@
+"use client";
+import "client-only";
+import { useState } from "react";
+import CategoryModeTabs from "@/client/components/research-fund/CategoryModeTabs";
+import ResearchFundPartyBars from "@/client/components/research-fund/ResearchFundPartyBars";
+import ResearchFundPoliticianList from "@/client/components/research-fund/ResearchFundPoliticianList";
+import FinancialSummaryCard from "@/client/components/top-page/features/financial-summary/FinancialSummaryCard";
+import { formatAmount } from "@/client/lib/financial-calculator";
+import type { ResearchFundPartyPoliticianView } from "@/server/contexts/research-fund/domain/models/research-fund-party-summary";
+import type { ResearchFundCategoryMode } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+interface Props {
+  politicians: ResearchFundPartyPoliticianView[];
+  financialYear: number;
+}
+
+/**
+ * A-6 の本体。議員リストの行選択でグラフ（KPI2枚＋横棒）を絞り込む。
+ * 初期選択は公開中の先頭の議員。誰も公開していなければ先頭の議員。
+ */
+export default function ResearchFundPartyBody({ politicians, financialYear }: Props) {
+  const initialSlug = (politicians.find((item) => item.ready) ?? politicians[0])?.slug ?? "";
+  const [selectedSlug, setSelectedSlug] = useState(initialSlug);
+  const [mode, setMode] = useState<ResearchFundCategoryMode>("detailed");
+
+  const selected = politicians.find((item) => item.slug === selectedSlug) ?? politicians[0];
+  if (!selected) return null;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <ResearchFundPoliticianList
+        politicians={politicians}
+        selectedSlug={selected.slug}
+        onSelect={setSelectedSlug}
+        financialYear={financialYear}
+      />
+
+      {selected.ready ? (
+        <div className="flex flex-col gap-8">
+          {/* KPI は2枚だけ。未使用分はカードにしない（デザイン仕様 §5） */}
+          <div className="flex flex-col gap-2 md:flex-row">
+            <FinancialSummaryCard
+              className="w-full md:flex-1"
+              title={`支給された（${selected.name}）`}
+              amount={formatAmount(selected.kpi.granted)}
+              titleColor="#238778"
+              amountColor="#1F2937"
+            />
+            <FinancialSummaryCard
+              className="w-full md:flex-1"
+              title="議員活動に使った"
+              amount={formatAmount(selected.kpi.spent)}
+              titleColor="#DC2626"
+              amountColor="#1F2937"
+            />
+          </div>
+
+          <div>
+            <CategoryModeTabs value={mode} onChange={setMode} />
+            <ResearchFundPartyBars bars={selected.bars[mode]} />
+            <p className="mt-3 text-xs text-[#9CA3AF]">
+              未使用分は含めていません。全{selected.count.toLocaleString("ja-JP")}件・
+              {selected.kpi.spent.toLocaleString("ja-JP")}円
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-dashed border-gray-300 px-6 py-10 text-center text-sm leading-[1.7] text-[#6A7383]">
+          {selected.name}の調査研究費は現在準備中です。
+          <br />
+          記録の整理が完了した月から順次公開します。
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundPartySection.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundPartySection.tsx
@@ -1,0 +1,52 @@
+import "server-only";
+import Image from "next/image";
+import CardHeader from "@/client/components/layout/CardHeader";
+import MainColumnCard from "@/client/components/layout/MainColumnCard";
+import ResearchFundPartyBody from "@/client/components/research-fund/ResearchFundPartyBody";
+import type { ResearchFundPartySummaryData } from "@/server/contexts/research-fund/domain/models/research-fund-party-summary";
+
+interface Props {
+  data: ResearchFundPartySummaryData;
+  updatedAt: string;
+}
+
+/**
+ * A-6 調査研究費（政党ページ）。
+ * 議員リストが「一覧」と「グラフの絞り込み」を兼ねる。
+ */
+export default function ResearchFundPartySection({ data, updatedAt }: Props) {
+  const count = data.politicians.length;
+
+  return (
+    <MainColumnCard id="research-fund">
+      <CardHeader
+        icon={<Image src="/icons/icon-cashflow.svg" alt="Cash flow icon" width={30} height={31} />}
+        organizationName={data.organization.displayName}
+        title={`議員${count}人の調査研究費サマリー`}
+        updatedAt={updatedAt}
+        subtitle="国会議員に毎月支給される公費を、何に使ったか"
+      />
+
+      <p className="-mt-4 text-[13px] font-bold text-[#6A7383]">{data.coverageLabel}</p>
+
+      {/* 議員ページ B-1 と同じ文言。調研費だけ別の説明にしない。 */}
+      <details className="-mt-4">
+        <summary className="inline-flex cursor-pointer items-center gap-1.5 py-1 text-sm font-bold text-[#238778] hover:underline">
+          調査研究費とは
+        </summary>
+        <p className="mt-3 rounded-xl bg-gradient-to-br from-[#E2F6F3] to-[#EEF6E2] px-5 py-5 text-[15px] leading-[1.87] tracking-[0.01em] text-gray-800">
+          <strong className="mb-3 block text-lg font-bold leading-relaxed">
+            調査研究費は、政党を通らず国から議員に対して毎月直接支給される公費です。
+          </strong>
+          政党を経由しないため、政党の収支とは別のお金として公開しています。全額が税金で、議員活動にのみ使えます。選挙運動には使えません。余った分は国庫に返します。（正式名称：調査研究広報滞在費）
+        </p>
+      </details>
+
+      <ResearchFundPartyBody politicians={data.politicians} financialYear={data.financialYear} />
+
+      <div className="text-right md:hidden">
+        <span className="text-xs font-normal leading-[1.33] text-[#9CA3AF]">{updatedAt}</span>
+      </div>
+    </MainColumnCard>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundPoliticianList.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundPoliticianList.tsx
@@ -1,0 +1,93 @@
+"use client";
+import "client-only";
+import Link from "next/link";
+import type { ResearchFundPartyPoliticianView } from "@/server/contexts/research-fund/domain/models/research-fund-party-summary";
+
+interface Props {
+  politicians: ResearchFundPartyPoliticianView[];
+  selectedSlug: string;
+  onSelect: (slug: string) => void;
+  financialYear: number;
+}
+
+/**
+ * A-6 の議員リスト。行が「一覧」と「グラフの絞り込み」を兼ね、詳細ボタンで議員ページに遷移する。
+ *
+ * 並びは当選期順で固定（ソート機能は付けない）。準備中の議員も隠さず、グレーで表示する。
+ * 行全体とボタンを入れ子にすると操作が曖昧になるので、行の選択ボタンと詳細リンクは横に並べる。
+ */
+export default function ResearchFundPoliticianList({
+  politicians,
+  selectedSlug,
+  onSelect,
+  financialYear,
+}: Props) {
+  return (
+    <ul className="flex flex-col border-t border-[#D5DBE1]">
+      {politicians.map((politician) => {
+        const selected = politician.slug === selectedSlug;
+        return (
+          <li
+            key={politician.slug}
+            className={`flex items-center gap-2 border-b border-[#D5DBE1] pr-2 transition-colors sm:pr-4 ${
+              selected ? "bg-[#F3F7F6]" : ""
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => onSelect(politician.slug)}
+              aria-pressed={selected}
+              className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 py-4 pl-2 text-left hover:bg-black/[0.03] sm:pl-4"
+            >
+              <span
+                aria-hidden="true"
+                className={`h-2 w-2 flex-shrink-0 rounded-full ${
+                  selected ? "bg-black" : "bg-transparent"
+                }`}
+              />
+              <span
+                className={`min-w-0 flex-1 truncate text-[15px] font-bold ${
+                  politician.ready ? "text-gray-800" : "text-[#9CA3AF]"
+                }`}
+              >
+                {politician.name}
+              </span>
+              <span
+                className={`w-[120px] flex-shrink-0 text-right text-sm font-bold tabular-nums sm:w-[160px] sm:text-base ${
+                  politician.ready ? "text-[#DC2626]" : "text-[#9CA3AF]"
+                }`}
+              >
+                {politician.ready ? (
+                  <>
+                    -{politician.kpi.spent.toLocaleString("ja-JP")}
+                    <span className="ml-0.5 text-xs font-normal text-[#4B5563]">円</span>
+                  </>
+                ) : (
+                  "—"
+                )}
+              </span>
+              <span className="hidden w-[200px] flex-shrink-0 text-sm text-[#6A7383] lg:block">
+                {politician.statusLabel}
+              </span>
+            </button>
+
+            {politician.ready ? (
+              <Link
+                href={`/p/${encodeURIComponent(politician.slug)}/${financialYear}`}
+                className="inline-flex h-10 flex-shrink-0 items-center justify-center rounded-md border border-gray-800 bg-white px-3 text-sm font-bold text-gray-800 transition-colors hover:bg-gray-50 sm:px-5"
+              >
+                詳細
+                <span className="hidden sm:inline">を見る</span>
+              </Link>
+            ) : (
+              // 準備中の議員には遷移先が無い。列幅を揃えるため、公開状況を出す枠だけ残す。
+              <span className="w-[52px] flex-shrink-0 text-right text-sm text-[#9CA3AF] sm:w-[92px]">
+                <span className="lg:hidden">準備中</span>
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-party-summary-usecase.ts
+++ b/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-party-summary-usecase.ts
@@ -1,0 +1,131 @@
+import "server-only";
+import type {
+  PublishedAccount,
+  PublishedPoliticianResearchFund,
+} from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type {
+  ResearchFundPartyPoliticianView,
+  ResearchFundPartySummaryData,
+} from "@/server/contexts/research-fund/domain/models/research-fund-party-summary";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+import { buildCoverageLabel } from "@/server/contexts/research-fund/domain/services/research-fund-coverage";
+import {
+  aggregateResearchFund,
+  type ResearchFundAggregation,
+  type ResearchFundRow,
+} from "@/shared/research-fund/aggregation";
+
+export interface GetResearchFundPartySummaryParams {
+  slug: string;
+  financialYear: number;
+}
+
+export class GetResearchFundPartySummaryUsecase {
+  constructor(private repository: ResearchFundRepository) {}
+
+  /**
+   * 政党ページ A-6 のデータ。所属議員がいなければ null を返し、呼び出し側が A-6 を出さない
+   * （所属議員のいない政治団体では既存の表示を変えない）。
+   */
+  async execute(
+    params: GetResearchFundPartySummaryParams,
+  ): Promise<ResearchFundPartySummaryData | null> {
+    const published = await this.repository.findPublishedByOrganization(
+      params.slug,
+      params.financialYear,
+    );
+    if (!published) return null;
+
+    const politicians = published.politicians.map(buildPoliticianView);
+
+    return {
+      organization: published.organization,
+      financialYear: published.financialYear,
+      asOfDate: latestAsOfDate(published.politicians),
+      coverageLabel: buildPartyCoverageLabel(published.politicians),
+      politicians,
+    };
+  }
+}
+
+/**
+ * 「2026年2月〜8月分を公開中（サンプル 太郎のみ）」。
+ * 公開しているのが所属議員の一部だけなら、誰の分なのかを添える。
+ */
+function buildPartyCoverageLabel(politicians: readonly PublishedPoliticianResearchFund[]): string {
+  const publishedOnes = politicians.filter((item) => item.rows.length > 0);
+  const label = buildCoverageLabel(publishedOnes.map(toCoverageInput));
+  if (publishedOnes.length === 0 || publishedOnes.length === politicians.length) return label;
+  return `${label}（${publishedOnes.map((item) => item.politician.name).join("・")}のみ）`;
+}
+
+function buildPoliticianView(
+  published: PublishedPoliticianResearchFund,
+): ResearchFundPartyPoliticianView {
+  // published の仕訳が1件も無い議員は「準備中」。グラフも KPI も描かず、行だけグレーで残す。
+  if (published.rows.length === 0) {
+    return {
+      slug: published.politician.slug,
+      name: published.politician.name,
+      ready: false,
+      statusLabel: "準備中",
+      kpi: { granted: 0, spent: 0 },
+      count: 0,
+      bars: { detailed: [], legal: [] },
+    };
+  }
+
+  const detailed = aggregate(published.rows, published.accounts, "detailed");
+  const legal = aggregate(published.rows, published.accounts, "legal");
+
+  return {
+    slug: published.politician.slug,
+    name: published.politician.name,
+    ready: true,
+    statusLabel: buildCoverageLabel([toCoverageInput(published)]),
+    kpi: detailed.kpi,
+    count: published.expenseCount,
+    bars: { detailed: toBars(detailed), legal: toBars(legal) },
+  };
+}
+
+function toCoverageInput(published: PublishedPoliticianResearchFund) {
+  return {
+    months: published.rows.map((row) => row.date.slice(0, 7)),
+    publishedThrough: published.publishedThrough?.slice(0, 7) ?? null,
+  };
+}
+
+/** 横棒グラフは金額の多い順。未使用分は含めない（デザイン仕様 §5）。 */
+function toBars(aggregation: ResearchFundAggregation) {
+  return aggregation.categories
+    .filter((category) => category.kind === "expense")
+    .map((category) => ({
+      key: category.key,
+      label: category.label,
+      amount: category.totalAmount,
+    }))
+    .sort((a, b) => b.amount - a.amount || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+}
+
+function aggregate(
+  rows: readonly ResearchFundRow[],
+  accounts: Readonly<Record<string, PublishedAccount>>,
+  mode: "detailed" | "legal",
+): ResearchFundAggregation {
+  const result = aggregateResearchFund(rows, accounts, mode);
+  if (result.status === "invalid")
+    throw new Error(
+      `調研費の集計に失敗しました: ${result.errors.map((error) => `${error.path} ${error.message}`).join(", ")}`,
+    );
+  return result.value;
+}
+
+/** 「2026.8.20時点」。公開中の議員のうち最も新しい as_of_date を代表に使う。 */
+function latestAsOfDate(politicians: readonly PublishedPoliticianResearchFund[]): string | null {
+  const dates = politicians
+    .filter((item) => item.rows.length > 0)
+    .map((item) => item.asOfDate)
+    .filter((date): date is string => date !== null);
+  return dates.length > 0 ? dates.reduce((a, b) => (a > b ? a : b)) : null;
+}

--- a/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-politicians-usecase.ts
+++ b/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-politicians-usecase.ts
@@ -1,0 +1,16 @@
+import "server-only";
+import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+export interface GetResearchFundPoliticiansParams {
+  financialYear: number;
+}
+
+export class GetResearchFundPoliticiansUsecase {
+  constructor(private repository: ResearchFundRepository) {}
+
+  /** 組織セレクタの「調査研究費」グループに並べる議員。準備中の議員も隠さない。 */
+  async execute(params: GetResearchFundPoliticiansParams): Promise<ResearchFundPoliticianEntry[]> {
+    return await this.repository.findPoliticians(params.financialYear);
+  }
+}

--- a/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-politicians-usecase.ts
+++ b/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-politicians-usecase.ts
@@ -1,6 +1,10 @@
 import "server-only";
-import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
+import type {
+  ResearchFundPoliticianEntry,
+  ResearchFundPoliticianSource,
+} from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
 import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+import { buildCoverageLabel } from "@/server/contexts/research-fund/domain/services/research-fund-coverage";
 
 export interface GetResearchFundPoliticiansParams {
   financialYear: number;
@@ -11,6 +15,22 @@ export class GetResearchFundPoliticiansUsecase {
 
   /** 組織セレクタの「調査研究費」グループに並べる議員。準備中の議員も隠さない。 */
   async execute(params: GetResearchFundPoliticiansParams): Promise<ResearchFundPoliticianEntry[]> {
-    return await this.repository.findPoliticians(params.financialYear);
+    const politicians = await this.repository.findPoliticians(params.financialYear);
+    return politicians.map(toEntry);
   }
+}
+
+/** published の仕訳が1件も無い議員は「準備中」。行は隠さずグレーで残す。 */
+function toEntry(source: ResearchFundPoliticianSource): ResearchFundPoliticianEntry {
+  const ready = source.publishedMonths.length > 0;
+  return {
+    slug: source.slug,
+    name: source.name,
+    ready,
+    statusLabel: ready
+      ? buildCoverageLabel([
+          { months: source.publishedMonths, publishedThrough: source.publishedThrough },
+        ])
+      : "準備中",
+  };
 }

--- a/webapp/src/server/contexts/research-fund/domain/models/published-research-fund.ts
+++ b/webapp/src/server/contexts/research-fund/domain/models/published-research-fund.ts
@@ -71,3 +71,25 @@ export interface PublishedResearchFund {
 export interface PublishedReceipt {
   storageKey: string;
 }
+
+/** 政党ページ A-6 が読む、議員1人分の published 射影。 */
+export interface PublishedPoliticianResearchFund {
+  politician: { name: string; slug: string };
+  /** 「2026.8.20時点」。未設定なら null */
+  asOfDate: string | null;
+  /** 何月分まで公開したか（YYYY-MM-DD）。未設定なら null */
+  publishedThrough: string | null;
+  /** 集計に渡す行（支給と支出）。published の仕訳が無ければ空配列。 */
+  rows: ResearchFundRow[];
+  accounts: Record<string, PublishedAccount>;
+  /** published の支出の件数（B-4 の行数と同じ数え方）。 */
+  expenseCount: number;
+}
+
+/** 政党ページ A-6 が読む、所属議員全員分の published 射影。 */
+export interface PublishedPartyResearchFund {
+  organization: { slug: string; displayName: string };
+  financialYear: number;
+  /** 当選期順（display_order）。準備中の議員も含む。 */
+  politicians: PublishedPoliticianResearchFund[];
+}

--- a/webapp/src/server/contexts/research-fund/domain/models/research-fund-party-summary.ts
+++ b/webapp/src/server/contexts/research-fund/domain/models/research-fund-party-summary.ts
@@ -1,0 +1,40 @@
+/**
+ * 政党ページの A-6「調査研究費」セクションが描くためのデータ。
+ *
+ * 議員ページ（B-1〜B-5）と同じく published の仕訳だけから作る。
+ * 議員リストの行選択でグラフを差し替えるだけで済むよう、議員ごとに
+ * 詳細／法律上の両方の区分を先に組み立てて渡す。
+ */
+import type { ResearchFundCategoryMode } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+/** 横棒グラフの1本。未使用分は含めない（デザイン仕様 §5）。 */
+export interface ResearchFundBarView {
+  key: string;
+  label: string;
+  amount: number;
+}
+
+/** 議員リストの1行。準備中の議員も隠さず、グレーで表示する。 */
+export interface ResearchFundPartyPoliticianView {
+  slug: string;
+  name: string;
+  /** published の仕訳があり、グラフを描けるか。false なら「準備中」 */
+  ready: boolean;
+  /** 「2026年2月〜8月分を公開中」「準備中」 */
+  statusLabel: string;
+  kpi: { granted: number; spent: number };
+  /** 支出の件数。ready が false なら 0 */
+  count: number;
+  bars: Record<ResearchFundCategoryMode, ResearchFundBarView[]>;
+}
+
+export interface ResearchFundPartySummaryData {
+  organization: { slug: string; displayName: string };
+  financialYear: number;
+  /** 「2026.8.20時点」。公開中の議員の as_of_date のうち最も新しいもの。未設定なら null */
+  asOfDate: string | null;
+  /** 「2026年2月〜8月分を公開中（サンプル 太郎のみ）」 */
+  coverageLabel: string;
+  /** 当選期順（display_order）で固定。ソート機能は付けない（デザイン仕様 §5） */
+  politicians: ResearchFundPartyPoliticianView[];
+}

--- a/webapp/src/server/contexts/research-fund/domain/models/research-fund-politician-list.ts
+++ b/webapp/src/server/contexts/research-fund/domain/models/research-fund-politician-list.ts
@@ -12,3 +12,16 @@ export interface ResearchFundPoliticianEntry {
   /** 「2026年2月〜8月分を公開中」「準備中」 */
   statusLabel: string;
 }
+
+/**
+ * 公開状況を判定する前の、その年度に帳簿を持つ議員。
+ * 公開範囲のルール（ready / statusLabel）は usecase で決める。
+ */
+export interface ResearchFundPoliticianSource {
+  slug: string;
+  name: string;
+  /** published の仕訳がある月（YYYY-MM）。重複していてよい */
+  publishedMonths: string[];
+  /** 何月分まで公開したか（YYYY-MM）。未設定なら null */
+  publishedThrough: string | null;
+}

--- a/webapp/src/server/contexts/research-fund/domain/models/research-fund-politician-list.ts
+++ b/webapp/src/server/contexts/research-fund/domain/models/research-fund-politician-list.ts
@@ -1,0 +1,14 @@
+/**
+ * 組織セレクタの「調査研究費」グループに並べる議員。
+ *
+ * 政治資金（政治団体）と並べて1箇所で切り替えられるようにするためのもので、
+ * 公開状況（「2026年2月〜8月分を公開中」「準備中」）まで含めて渡す。
+ */
+export interface ResearchFundPoliticianEntry {
+  slug: string;
+  name: string;
+  /** published の仕訳があり、議員ページを開く価値があるか */
+  ready: boolean;
+  /** 「2026年2月〜8月分を公開中」「準備中」 */
+  statusLabel: string;
+}

--- a/webapp/src/server/contexts/research-fund/domain/repositories/research-fund-repository.interface.ts
+++ b/webapp/src/server/contexts/research-fund/domain/repositories/research-fund-repository.interface.ts
@@ -3,7 +3,7 @@ import type {
   PublishedReceipt,
   PublishedResearchFund,
 } from "@/server/contexts/research-fund/domain/models/published-research-fund";
-import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
+import type { ResearchFundPoliticianSource } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
 
 export interface ResearchFundRepository {
   /** 議員の slug と年度から、published の仕訳だけを射影して返す。帳簿が無ければ null */
@@ -18,8 +18,11 @@ export interface ResearchFundRepository {
     financialYear: number,
   ): Promise<PublishedPartyResearchFund | null>;
 
-  /** 組織セレクタに出す議員の一覧。その年度の帳簿を持つ議員だけを当選期順で返す。 */
-  findPoliticians(financialYear: number): Promise<ResearchFundPoliticianEntry[]>;
+  /**
+   * 組織セレクタに出す議員の一覧。その年度の帳簿を持つ議員だけを当選期順で返す。
+   * 公開状況（ready / statusLabel）の判定は usecase が行う。
+   */
+  findPoliticians(financialYear: number): Promise<ResearchFundPoliticianSource[]>;
 
   /** published の仕訳に紐づく領収書だけを返す。未公開の仕訳の領収書は返さない。 */
   findPublishedReceipt(entryId: string): Promise<PublishedReceipt | null>;

--- a/webapp/src/server/contexts/research-fund/domain/repositories/research-fund-repository.interface.ts
+++ b/webapp/src/server/contexts/research-fund/domain/repositories/research-fund-repository.interface.ts
@@ -1,11 +1,25 @@
 import type {
+  PublishedPartyResearchFund,
   PublishedReceipt,
   PublishedResearchFund,
 } from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
 
 export interface ResearchFundRepository {
   /** 議員の slug と年度から、published の仕訳だけを射影して返す。帳簿が無ければ null */
   findPublished(slug: string, financialYear: number): Promise<PublishedResearchFund | null>;
+
+  /**
+   * 政治団体の slug と年度から、所属議員（ended_on が NULL の membership）全員分を射影して返す。
+   * 所属議員がいなければ null（政党ページは A-6 を出さない）。
+   */
+  findPublishedByOrganization(
+    slug: string,
+    financialYear: number,
+  ): Promise<PublishedPartyResearchFund | null>;
+
+  /** 組織セレクタに出す議員の一覧。その年度の帳簿を持つ議員だけを当選期順で返す。 */
+  findPoliticians(financialYear: number): Promise<ResearchFundPoliticianEntry[]>;
 
   /** published の仕訳に紐づく領収書だけを返す。未公開の仕訳の領収書は返さない。 */
   findPublishedReceipt(entryId: string): Promise<PublishedReceipt | null>;

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-coverage.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-coverage.ts
@@ -1,0 +1,39 @@
+interface ResearchFundCoverageInput {
+  /** published の仕訳がある月（YYYY-MM）。重複していてよい。 */
+  months: readonly string[];
+  /** 何月分まで公開したか（YYYY-MM）。未設定なら実データの最終月で代用する。 */
+  publishedThrough: string | null;
+}
+
+/**
+ * 「2026年2月〜8月分を公開中」。渡された議員全員分をまとめた公開範囲を返す。
+ * 公開されている月が1つも無ければ「準備中」。
+ */
+export function buildCoverageLabel(politicians: readonly ResearchFundCoverageInput[]): string {
+  const months = politicians.flatMap((politician) =>
+    politician.publishedThrough
+      ? [...politician.months, politician.publishedThrough]
+      : [...politician.months],
+  );
+  if (months.length === 0) return "準備中";
+
+  const start = months.reduce((a, b) => (a < b ? a : b));
+  const end = months.reduce((a, b) => (a > b ? a : b));
+  const sameYear = start.slice(0, 4) === end.slice(0, 4);
+  const range =
+    start === end
+      ? monthLabel(start)
+      : `${monthLabel(start)}〜${sameYear ? monthOnly(end) : monthLabel(end)}`;
+  return `${range}分を公開中`;
+}
+
+/** 「2026年2月」 */
+function monthLabel(month: string): string {
+  const [year, monthNumber] = month.split("-");
+  return `${Number(year)}年${Number(monthNumber)}月`;
+}
+
+/** 「8月」。同じ年の範囲では終端の年を省く。 */
+function monthOnly(month: string): string {
+  return `${Number(month.split("-")[1])}月`;
+}

--- a/webapp/src/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository.ts
+++ b/webapp/src/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository.ts
@@ -8,9 +8,8 @@ import type {
   PublishedPoliticianResearchFund,
   PublishedResearchFund,
 } from "@/server/contexts/research-fund/domain/models/published-research-fund";
-import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
+import type { ResearchFundPoliticianSource } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
 import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
-import { buildCoverageLabel } from "@/server/contexts/research-fund/domain/services/research-fund-coverage";
 import type { ResearchFundRow } from "@/shared/research-fund/aggregation";
 
 /**
@@ -269,7 +268,7 @@ export class PrismaResearchFundRepository implements ResearchFundRepository {
     };
   }
 
-  async findPoliticians(financialYear: number): Promise<ResearchFundPoliticianEntry[]> {
+  async findPoliticians(financialYear: number): Promise<ResearchFundPoliticianSource[]> {
     const politicians = await this.prisma.politician.findMany({
       // 帳簿の無い議員はセレクタに出さない（開いても中身が無いため）。
       where: { books: { some: { financialYear } } },
@@ -293,24 +292,13 @@ export class PrismaResearchFundRepository implements ResearchFundRepository {
 
     return politicians.map((politician) => {
       const book = politician.books[0];
-      const months = (book?.journalEntries ?? []).map((entry) =>
-        dateOf(entry.entryDate).slice(0, 7),
-      );
       return {
         slug: politician.slug,
         name: politician.name,
-        ready: months.length > 0,
-        statusLabel:
-          months.length > 0
-            ? buildCoverageLabel([
-                {
-                  months,
-                  publishedThrough: book?.publishedThrough
-                    ? dateOf(book.publishedThrough).slice(0, 7)
-                    : null,
-                },
-              ])
-            : "準備中",
+        publishedMonths: (book?.journalEntries ?? []).map((entry) =>
+          dateOf(entry.entryDate).slice(0, 7),
+        ),
+        publishedThrough: book?.publishedThrough ? dateOf(book.publishedThrough).slice(0, 7) : null,
       };
     });
   }

--- a/webapp/src/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository.ts
+++ b/webapp/src/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository.ts
@@ -4,9 +4,13 @@ import type {
   PublishedAccount,
   PublishedExpenditureGroup,
   PublishedExpense,
+  PublishedPartyResearchFund,
+  PublishedPoliticianResearchFund,
   PublishedResearchFund,
 } from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type { ResearchFundPoliticianEntry } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
 import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+import { buildCoverageLabel } from "@/server/contexts/research-fund/domain/services/research-fund-coverage";
 import type { ResearchFundRow } from "@/shared/research-fund/aggregation";
 
 /**
@@ -36,12 +40,33 @@ const entrySelect = {
   },
 } satisfies Prisma.ResearchFundJournalEntrySelect;
 
-type Entry = Prisma.ResearchFundJournalEntryGetPayload<{ select: typeof entrySelect }>;
-type Line = Entry["lines"][number];
+/**
+ * 政党ページ A-6 は横棒グラフと KPI しか描かないので、明細（項目名・特記事項・領収書）は取らない。
+ * 議員が増えるほど行数が効くため、必要な列だけに絞る。
+ */
+const summaryEntrySelect = {
+  entryDate: true,
+  lines: {
+    select: {
+      side: true,
+      accountKey: true,
+      amount: true,
+      account: {
+        select: { type: true, label: true, legalLabel: true, legalCategoryKey: true },
+      },
+    },
+  },
+} satisfies Prisma.ResearchFundJournalEntrySelect;
+
+type SummaryLine = Prisma.ResearchFundJournalEntryGetPayload<{
+  select: typeof summaryEntrySelect;
+}>["lines"][number];
 
 /** 公開の集計に使うのは「借方の費用」と「貸方の調査研究費収入」だけ。相手勘定の普通預金は数えない。 */
-const isExpenseLine = (line: Line) => line.side === "debit" && line.account.type === "expense";
-const isGrantLine = (line: Line) => line.side === "credit" && line.accountKey === "grant-income";
+const isExpenseLine = <T extends SummaryLine>(line: T) =>
+  line.side === "debit" && line.account.type === "expense";
+const isGrantLine = <T extends SummaryLine>(line: T) =>
+  line.side === "credit" && line.accountKey === "grant-income";
 
 function dateOf(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -157,6 +182,139 @@ export class PrismaResearchFundRepository implements ResearchFundRepository {
     };
   }
 
+  async findPublishedByOrganization(
+    slug: string,
+    financialYear: number,
+  ): Promise<PublishedPartyResearchFund | null> {
+    const organization = await this.prisma.politicalOrganization.findUnique({
+      where: { slug },
+      select: {
+        slug: true,
+        displayName: true,
+        politicianMemberships: {
+          // 現在所属している議員だけを出す（ended_on が入っていれば離党・任期満了）。
+          where: { endedOn: null },
+          orderBy: [{ politician: { displayOrder: "asc" } }, { politicianId: "asc" }],
+          select: {
+            politician: {
+              select: {
+                name: true,
+                slug: true,
+                books: {
+                  where: { financialYear },
+                  select: {
+                    asOfDate: true,
+                    publishedThrough: true,
+                    journalEntries: {
+                      where: { status: "published" },
+                      select: summaryEntrySelect,
+                      orderBy: [{ entryDate: "asc" }, { id: "asc" }],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    if (!organization || organization.politicianMemberships.length === 0) return null;
+
+    const politicians: PublishedPoliticianResearchFund[] = organization.politicianMemberships.map(
+      ({ politician }) => {
+        const book = politician.books[0];
+        const rows: ResearchFundRow[] = [];
+        const accounts: Record<string, PublishedAccount> = {};
+        let expenseCount = 0;
+
+        for (const entry of book?.journalEntries ?? []) {
+          const date = dateOf(entry.entryDate);
+          for (const line of entry.lines) {
+            if (isGrantLine(line)) {
+              rows.push({
+                date,
+                accountKey: line.accountKey,
+                amount: line.amount.toNumber(),
+                type: "grant",
+              });
+              continue;
+            }
+            if (!isExpenseLine(line)) continue;
+            accounts[line.accountKey] = accountOf(line);
+            rows.push({
+              date,
+              accountKey: line.accountKey,
+              amount: line.amount.toNumber(),
+              type: "expense",
+            });
+            expenseCount += 1;
+          }
+        }
+
+        return {
+          politician: { name: politician.name, slug: politician.slug },
+          asOfDate: book?.asOfDate ? dateOf(book.asOfDate) : null,
+          publishedThrough: book?.publishedThrough ? dateOf(book.publishedThrough) : null,
+          rows,
+          accounts,
+          expenseCount,
+        };
+      },
+    );
+
+    return {
+      organization: { slug: organization.slug, displayName: organization.displayName },
+      financialYear,
+      politicians,
+    };
+  }
+
+  async findPoliticians(financialYear: number): Promise<ResearchFundPoliticianEntry[]> {
+    const politicians = await this.prisma.politician.findMany({
+      // 帳簿の無い議員はセレクタに出さない（開いても中身が無いため）。
+      where: { books: { some: { financialYear } } },
+      orderBy: [{ displayOrder: "asc" }, { id: "asc" }],
+      select: {
+        name: true,
+        slug: true,
+        books: {
+          where: { financialYear },
+          select: {
+            publishedThrough: true,
+            journalEntries: {
+              where: { status: "published" },
+              select: { entryDate: true },
+              orderBy: { entryDate: "asc" },
+            },
+          },
+        },
+      },
+    });
+
+    return politicians.map((politician) => {
+      const book = politician.books[0];
+      const months = (book?.journalEntries ?? []).map((entry) =>
+        dateOf(entry.entryDate).slice(0, 7),
+      );
+      return {
+        slug: politician.slug,
+        name: politician.name,
+        ready: months.length > 0,
+        statusLabel:
+          months.length > 0
+            ? buildCoverageLabel([
+                {
+                  months,
+                  publishedThrough: book?.publishedThrough
+                    ? dateOf(book.publishedThrough).slice(0, 7)
+                    : null,
+                },
+              ])
+            : "準備中",
+      };
+    });
+  }
+
   async findPublishedReceipt(entryId: string) {
     const entry = await this.prisma.researchFundJournalEntry.findFirst({
       where: { id: BigInt(entryId), status: "published" },
@@ -170,7 +328,7 @@ export class PrismaResearchFundRepository implements ResearchFundRepository {
  * 法定区分が未設定の科目（下書き用の「要確認」など）でも法律上の区分に切り替えられるよう、
  * 法定ラベルが空なら科目名で代用する。公開前に21分類へ直す運用なので通常は発生しない。
  */
-function accountOf(line: Line): PublishedAccount {
+function accountOf(line: SummaryLine): PublishedAccount {
   return {
     label: line.account.label,
     legalLabel: line.account.legalLabel || line.account.label,

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-party-summary.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-party-summary.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import {
+  GetResearchFundPartySummaryUsecase,
+  type GetResearchFundPartySummaryParams,
+} from "@/server/contexts/research-fund/application/usecases/get-research-fund-party-summary-usecase";
+import { PrismaResearchFundRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository";
+import {
+  CACHE_REVALIDATE_SECONDS,
+  RESEARCH_FUND_CACHE_TAG,
+} from "@/server/contexts/research-fund/presentation/loaders/constants";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export const loadResearchFundPartySummary = unstable_cache(
+  async (params: GetResearchFundPartySummaryParams) => {
+    const usecase = new GetResearchFundPartySummaryUsecase(
+      new PrismaResearchFundRepository(prisma),
+    );
+    return await usecase.execute(params);
+  },
+  [`${RESEARCH_FUND_CACHE_TAG}-party`],
+  { revalidate: CACHE_REVALIDATE_SECONDS, tags: [RESEARCH_FUND_CACHE_TAG] },
+);

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-politicians.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-politicians.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import {
+  GetResearchFundPoliticiansUsecase,
+  type GetResearchFundPoliticiansParams,
+} from "@/server/contexts/research-fund/application/usecases/get-research-fund-politicians-usecase";
+import { PrismaResearchFundRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository";
+import {
+  CACHE_REVALIDATE_SECONDS,
+  RESEARCH_FUND_CACHE_TAG,
+} from "@/server/contexts/research-fund/presentation/loaders/constants";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export const loadResearchFundPoliticians = unstable_cache(
+  async (params: GetResearchFundPoliticiansParams) => {
+    const usecase = new GetResearchFundPoliticiansUsecase(new PrismaResearchFundRepository(prisma));
+    return await usecase.execute(params);
+  },
+  [`${RESEARCH_FUND_CACHE_TAG}-politicians`],
+  { revalidate: CACHE_REVALIDATE_SECONDS, tags: [RESEARCH_FUND_CACHE_TAG] },
+);

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase.test.ts
@@ -84,6 +84,8 @@ function published(overrides: Partial<PublishedResearchFund> = {}): PublishedRes
 function usecaseWith(value: PublishedResearchFund | null) {
   const repository: ResearchFundRepository = {
     findPublished: jest.fn().mockResolvedValue(value),
+    findPublishedByOrganization: jest.fn().mockResolvedValue(null),
+    findPoliticians: jest.fn().mockResolvedValue([]),
     findPublishedReceipt: jest.fn().mockResolvedValue(null),
   };
   return { usecase: new GetResearchFundPageUsecase(repository), repository };

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-party-summary-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-party-summary-usecase.test.ts
@@ -1,0 +1,186 @@
+import { GetResearchFundPartySummaryUsecase } from "@/server/contexts/research-fund/application/usecases/get-research-fund-party-summary-usecase";
+import type {
+  PublishedPartyResearchFund,
+  PublishedPoliticianResearchFund,
+} from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+const accounts: PublishedPoliticianResearchFund["accounts"] = {
+  taxi: { label: "タクシー代", legalLabel: "⑨ 滞在費", legalCategoryKey: "stay" },
+  "public-transport": {
+    label: "電車・バス代",
+    legalLabel: "⑨ 滞在費",
+    legalCategoryKey: "stay",
+  },
+  "printing-pr": {
+    label: "印刷・広報費",
+    legalLabel: "⑥ 広報紙誌の発行その他の事業費",
+    legalCategoryKey: "publicity",
+  },
+};
+
+/** published の仕訳を持つ議員。 */
+function publishedPolitician(
+  overrides: Partial<PublishedPoliticianResearchFund> = {},
+): PublishedPoliticianResearchFund {
+  return {
+    politician: { name: "サンプル 太郎", slug: "sample-taro" },
+    asOfDate: "2026-08-20",
+    publishedThrough: "2026-08-31",
+    rows: [
+      { date: "2026-02-01", accountKey: "grant-income", amount: 1_000_000, type: "grant" },
+      { date: "2026-03-01", accountKey: "grant-income", amount: 1_000_000, type: "grant" },
+      { date: "2026-02-10", accountKey: "taxi", amount: 3_000, type: "expense" },
+      { date: "2026-03-10", accountKey: "public-transport", amount: 2_000, type: "expense" },
+      { date: "2026-03-11", accountKey: "printing-pr", amount: 99_000, type: "expense" },
+    ],
+    accounts,
+    expenseCount: 3,
+    ...overrides,
+  };
+}
+
+/** 帳簿はあるが published の仕訳がまだ無い「準備中」の議員。 */
+function preparingPolitician(
+  overrides: Partial<PublishedPoliticianResearchFund> = {},
+): PublishedPoliticianResearchFund {
+  return {
+    politician: { name: "サンプル 次郎", slug: "sample-jiro" },
+    asOfDate: null,
+    publishedThrough: null,
+    rows: [],
+    accounts: {},
+    expenseCount: 0,
+    ...overrides,
+  };
+}
+
+function party(
+  politicians: PublishedPoliticianResearchFund[],
+): PublishedPartyResearchFund | null {
+  return {
+    organization: { slug: "sample-party", displayName: "サンプル政党" },
+    financialYear: 2026,
+    politicians,
+  };
+}
+
+function usecaseWith(value: PublishedPartyResearchFund | null) {
+  const repository: ResearchFundRepository = {
+    findPublished: jest.fn().mockResolvedValue(null),
+    findPublishedByOrganization: jest.fn().mockResolvedValue(value),
+    findPoliticians: jest.fn().mockResolvedValue([]),
+    findPublishedReceipt: jest.fn().mockResolvedValue(null),
+  };
+  return { usecase: new GetResearchFundPartySummaryUsecase(repository), repository };
+}
+
+describe("GetResearchFundPartySummaryUsecase", () => {
+  it("所属議員がいなければ null を返す（A-6 を出さない）", async () => {
+    const { usecase } = usecaseWith(null);
+
+    expect(await usecase.execute({ slug: "no-members", financialYear: 2026 })).toBeNull();
+  });
+
+  it("議員ごとに支給・支出を集計する", async () => {
+    const { usecase } = usecaseWith(party([publishedPolitician()]));
+
+    const data = await usecase.execute({ slug: "sample-party", financialYear: 2026 });
+
+    expect(data?.politicians[0].kpi).toEqual({ granted: 2_000_000, spent: 104_000 });
+    expect(data?.politicians[0].count).toBe(3);
+  });
+
+  it("横棒グラフは金額の多い順で、未使用分を含めない", async () => {
+    const { usecase } = usecaseWith(party([publishedPolitician()]));
+
+    const data = await usecase.execute({ slug: "sample-party", financialYear: 2026 });
+
+    expect(data?.politicians[0].bars.detailed).toEqual([
+      { key: "printing-pr", label: "印刷・広報費", amount: 99_000 },
+      { key: "taxi", label: "タクシー代", amount: 3_000 },
+      { key: "public-transport", label: "電車・バス代", amount: 2_000 },
+    ]);
+    // 法律上の区分ではタクシー代と電車・バス代が ⑨ 滞在費 に統合される
+    expect(data?.politicians[0].bars.legal).toEqual([
+      { key: "⑥ 広報紙誌の発行その他の事業費", label: "⑥ 広報紙誌の発行その他の事業費", amount: 99_000 },
+      { key: "⑨ 滞在費", label: "⑨ 滞在費", amount: 5_000 },
+    ]);
+  });
+
+  it("準備中の議員も隠さず、グラフのない行として返す", async () => {
+    const { usecase } = usecaseWith(party([publishedPolitician(), preparingPolitician()]));
+
+    const data = await usecase.execute({ slug: "sample-party", financialYear: 2026 });
+
+    expect(data?.politicians).toHaveLength(2);
+    expect(data?.politicians[1]).toEqual({
+      slug: "sample-jiro",
+      name: "サンプル 次郎",
+      ready: false,
+      statusLabel: "準備中",
+      kpi: { granted: 0, spent: 0 },
+      count: 0,
+      bars: { detailed: [], legal: [] },
+    });
+  });
+
+  it("公開範囲を議員ごと・政党全体の両方でラベルにする", async () => {
+    const { usecase } = usecaseWith(party([publishedPolitician(), preparingPolitician()]));
+
+    const data = await usecase.execute({ slug: "sample-party", financialYear: 2026 });
+
+    expect(data?.politicians[0].statusLabel).toBe("2026年2月〜8月分を公開中");
+    // 一部の議員しか公開していないことが分かるようにする
+    expect(data?.coverageLabel).toBe("2026年2月〜8月分を公開中（サンプル 太郎のみ）");
+  });
+
+  it("所属議員全員が公開していれば政党全体のラベルに「のみ」を付けない", async () => {
+    const { usecase } = usecaseWith(party([publishedPolitician()]));
+
+    const data = await usecase.execute({ slug: "sample-party", financialYear: 2026 });
+
+    expect(data?.coverageLabel).toBe("2026年2月〜8月分を公開中");
+  });
+
+  it("誰も公開していなければ準備中として扱う", async () => {
+    const { usecase } = usecaseWith(party([preparingPolitician()]));
+
+    const data = await usecase.execute({ slug: "sample-party", financialYear: 2026 });
+
+    expect(data?.coverageLabel).toBe("準備中");
+    expect(data?.asOfDate).toBeNull();
+  });
+
+  it("「◯◯時点」は公開中の議員のうち最も新しい日付を使う", async () => {
+    const { usecase } = usecaseWith(
+      party([
+        publishedPolitician({ asOfDate: "2026-07-31" }),
+        publishedPolitician({
+          politician: { name: "サンプル 花子", slug: "sample-hanako" },
+          asOfDate: "2026-08-20",
+        }),
+        // 準備中の議員の日付は代表に使わない
+        preparingPolitician({ asOfDate: "2026-12-31" }),
+      ]),
+    );
+
+    const data = await usecase.execute({ slug: "sample-party", financialYear: 2026 });
+
+    expect(data?.asOfDate).toBe("2026-08-20");
+  });
+
+  it("集計できない行があれば黙って表示せず失敗させる", async () => {
+    const { usecase } = usecaseWith(
+      party([
+        publishedPolitician({
+          rows: [{ date: "2026-13-99", accountKey: "taxi", amount: 1, type: "expense" }],
+        }),
+      ]),
+    );
+
+    await expect(usecase.execute({ slug: "sample-party", financialYear: 2026 })).rejects.toThrow(
+      /調研費の集計に失敗しました/,
+    );
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-politicians-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-politicians-usecase.test.ts
@@ -1,0 +1,61 @@
+import { GetResearchFundPoliticiansUsecase } from "@/server/contexts/research-fund/application/usecases/get-research-fund-politicians-usecase";
+import type { ResearchFundPoliticianSource } from "@/server/contexts/research-fund/domain/models/research-fund-politician-list";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+function build(politicians: ResearchFundPoliticianSource[]) {
+  const repository: ResearchFundRepository = {
+    findPublished: jest.fn().mockResolvedValue(null),
+    findPublishedByOrganization: jest.fn().mockResolvedValue(null),
+    findPoliticians: jest.fn().mockResolvedValue(politicians),
+    findPublishedReceipt: jest.fn().mockResolvedValue(null),
+  };
+  return { usecase: new GetResearchFundPoliticiansUsecase(repository), repository };
+}
+
+describe("GetResearchFundPoliticiansUsecase", () => {
+  it("公開済みの月から公開範囲のラベルを組み立てる", async () => {
+    const { usecase, repository } = build([
+      {
+        slug: "sample-taro",
+        name: "サンプル 太郎",
+        publishedMonths: ["2026-02", "2026-04"],
+        publishedThrough: "2026-08",
+      },
+    ]);
+
+    expect(await usecase.execute({ financialYear: 2026 })).toEqual([
+      {
+        slug: "sample-taro",
+        name: "サンプル 太郎",
+        ready: true,
+        statusLabel: "2026年2月〜8月分を公開中",
+      },
+    ]);
+    expect(repository.findPoliticians).toHaveBeenCalledWith(2026);
+  });
+
+  it("公開済みの仕訳が無い議員も隠さず「準備中」で返す", async () => {
+    const { usecase } = build([
+      { slug: "sample-jiro", name: "サンプル 次郎", publishedMonths: [], publishedThrough: null },
+    ]);
+
+    expect(await usecase.execute({ financialYear: 2026 })).toEqual([
+      { slug: "sample-jiro", name: "サンプル 次郎", ready: false, statusLabel: "準備中" },
+    ]);
+  });
+
+  it("公開範囲が未設定なら実データの月だけでラベルを作る", async () => {
+    const { usecase } = build([
+      {
+        slug: "sample-hanako",
+        name: "サンプル 花子",
+        publishedMonths: ["2026-03"],
+        publishedThrough: null,
+      },
+    ]);
+
+    expect((await usecase.execute({ financialYear: 2026 }))[0].statusLabel).toBe(
+      "2026年3月分を公開中",
+    );
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase.test.ts
@@ -5,6 +5,8 @@ import type { ResearchFundRepository } from "@/server/contexts/research-fund/dom
 function build(receipt: { storageKey: string } | null) {
   const repository: ResearchFundRepository = {
     findPublished: jest.fn().mockResolvedValue(null),
+    findPublishedByOrganization: jest.fn().mockResolvedValue(null),
+    findPoliticians: jest.fn().mockResolvedValue([]),
     findPublishedReceipt: jest.fn().mockResolvedValue(receipt),
   };
   const storage: ReceiptStorage = {

--- a/webapp/tests/server/contexts/research-fund/domain/services/research-fund-coverage.test.ts
+++ b/webapp/tests/server/contexts/research-fund/domain/services/research-fund-coverage.test.ts
@@ -1,0 +1,41 @@
+import { buildCoverageLabel } from "@/server/contexts/research-fund/domain/services/research-fund-coverage";
+
+describe("buildCoverageLabel", () => {
+  it("同じ年の範囲では終端の年を省く", () => {
+    expect(
+      buildCoverageLabel([{ months: ["2026-02", "2026-04"], publishedThrough: "2026-08" }]),
+    ).toBe("2026年2月〜8月分を公開中");
+  });
+
+  it("1か月だけなら範囲にしない", () => {
+    expect(buildCoverageLabel([{ months: ["2026-02"], publishedThrough: "2026-02" }])).toBe(
+      "2026年2月分を公開中",
+    );
+  });
+
+  it("年をまたぐ範囲では終端の年も出す", () => {
+    expect(
+      buildCoverageLabel([{ months: ["2025-11"], publishedThrough: "2026-01" }]),
+    ).toBe("2025年11月〜2026年1月分を公開中");
+  });
+
+  it("複数の議員の範囲をまとめる", () => {
+    expect(
+      buildCoverageLabel([
+        { months: ["2026-04"], publishedThrough: "2026-05" },
+        { months: ["2026-02"], publishedThrough: "2026-08" },
+      ]),
+    ).toBe("2026年2月〜8月分を公開中");
+  });
+
+  it("公開範囲が未設定でも実データの月から範囲を作る", () => {
+    expect(buildCoverageLabel([{ months: ["2026-03", "2026-06"], publishedThrough: null }])).toBe(
+      "2026年3月〜6月分を公開中",
+    );
+  });
+
+  it("公開されている月が無ければ準備中", () => {
+    expect(buildCoverageLabel([])).toBe("準備中");
+    expect(buildCoverageLabel([{ months: [], publishedThrough: null }])).toBe("準備中");
+  });
+});


### PR DESCRIPTION
## 目的（Why）

政党ページを見に来た市民が、そこから所属議員の調査研究費に辿り着けず、議員ページの URL を知らないと見られない状態を解消するため。
議員リストが「一覧」と「グラフの絞り込み」を兼ねることで、誰がいくら使ったかを1画面で見比べつつ、詳細に進める。

## 変更内容

### A-6 調査研究費（政党ページ・新規）

- 見出し「議員n人の調査研究費サマリー」・リード・公開範囲の日付（「2026年2月〜8月分を公開中（サンプル 太郎のみ）」）
- 「調査研究費とは」コラプス（初期は閉じた状態。文言は議員ページ B-1 と同じ）
- 区分トグル（詳細の区分／法律上の区分）は既存の `CategoryModeTabs` を流用
- KPI 2枚（支給された／議員活動に使った）は既存の `FinancialSummaryCard` を流用
- 横棒グラフ。**未使用分は含めない**（円グラフも使わない）
- 議員リスト（ドット／議員名／支出／公開状況／詳細ボタン）。行選択でグラフを絞り込み、詳細ボタンで議員ページへ遷移する
  - 並びは当選期順（`display_order`）で固定。**ソート機能・返還額の列は作らない**
  - 準備中の議員も隠さず、グレーで表示する。選択すると「準備中です」の案内を出す
- 所属議員（`ended_on` が NULL の membership）がいない政治団体では A-6 ごと出さない（既存表示は変わらない）

### そのほか

- グローバルナビに「調査研究費」（`#research-fund`）を追加
- A-7「データについて」に調研費の記載を追加
- 組織セレクタを「政治資金 n団体／調査研究費 議員n人」の2グループ化。議員を選ぶと `/p/[slug]/[year]` へ遷移し、議員ページでは現在の議員がトリガーとチェックに出る

### サーバー側

- `ResearchFundRepository` に `findPublishedByOrganization` / `findPoliticians` を追加。A-6 は明細を引かない軽い select で取る
- 集計は議員ページと同じ `shared/research-fund/aggregation` を使う
- 公開範囲のラベル（「2026年2月〜8月分を公開中」）を domain のサービスに切り出し、セレクタと A-6 の両方から使う
- loader は既存と同じ tags 方式のキャッシュに乗せる（admin の公開アクションが `/api/refresh` で無効化する）

### シード

- A-6 の「準備中の議員もグレーで表示する」を確認できるよう、`sample-party` 所属の準備中議員（`sample-jiro`）を追加

## やらないこと（Issue の Out of scope に準拠）

- 返還額の KPI・議員リストの返還額列・ソート機能・円グラフ（spec §5）
- 議員ページ本体の変更

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）✅
- `pnpm test:e2e`（webapp）✅ 26 passed
  - 画面の導線・ナビ・組織セレクタを変更したため E2E も実行した
  - 組織セレクタの見出し変更に追随して既存の `organization.spec.ts` を1箇所更新した

## スコープアウトして起票した Issue

なし

Closes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 政党ページに「調査研究費」セクションを追加しました。
  - 議員ごとの支給額・支出額、費目別グラフ、公開状況を確認できます。
  - 準備中の議員も一覧に表示し、公開済みの議員は詳細ページへ移動できます。
  - 年度や議員を組織セレクターから切り替えられます。
  - 調査研究費の概要、公開範囲、データ更新日を表示します。

- **ドキュメント**
  - 調査研究費の制度や「準備中」表示についての説明を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->