### PR TITLE
feat(webapp): 調研費 議員ページをサイトマップとヘッダーナビに載せる

### DIFF
--- a/webapp/e2e/tests/research-fund.spec.ts
+++ b/webapp/e2e/tests/research-fund.spec.ts
@@ -105,6 +105,27 @@ test.describe("調査研究費 議員ページ", () => {
 		}).toPass();
 	});
 
+	test("ヘッダーのナビが同じ議員ページ内のセクションを指す", async ({ page }) => {
+		await page.goto(PAGE_URL);
+
+		const nav = page.getByRole("navigation", { name: "メインナビゲーション" });
+
+		// 政治団体ページ（/o/...）へ飛ばず、B-1〜B-5 のアンカーを指す。
+		// next/link は末尾スラッシュを落とすので href は /p/[slug]/[year]#... になる。
+		for (const section of [
+			"cash-flow",
+			"highlights",
+			"monthly-trends",
+			"transactions",
+			"explanation",
+		]) {
+			await expect(
+				nav.locator(`a[href="/p/sample-taro/2026#${section}"]`),
+			).toHaveCount(1);
+		}
+		await expect(nav.locator('a[href*="/o/"]')).toHaveCount(0);
+	});
+
 	test("存在しない議員のページは政治団体ページに寄せられる", async ({ page }) => {
 		await page.goto("/p/no-such-politician/2026");
 

--- a/webapp/src/app/sitemap.ts
+++ b/webapp/src/app/sitemap.ts
@@ -1,13 +1,17 @@
 import type { MetadataRoute } from "next";
 import { loadOrganizations } from "@/server/contexts/public-finance/presentation/loaders/load-organizations";
+import { loadPublishedResearchFundPages } from "@/server/contexts/research-fund/presentation/loaders/load-published-research-fund-pages";
 
 export const dynamic = "force-static";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.WEBAPP_URL || "https://marumie.team-mir.ai";
 
-  // 組織データを取得（0件の場合は空配列が返される）
-  const { organizations } = await loadOrganizations();
+  // 組織データと調研費の公開ページを取得（0件の場合は空配列が返される）
+  const [{ organizations }, researchFundPages] = await Promise.all([
+    loadOrganizations(),
+    loadPublishedResearchFundPages(),
+  ]);
 
   const sitemap: MetadataRoute.Sitemap = [
     {
@@ -31,6 +35,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${baseUrl}/o/${org.slug}/transactions`,
       changeFrequency: "weekly",
       priority: 0.8,
+    });
+  });
+
+  // 調査研究費の議員ページ（/p/[slug]/[year]）
+  researchFundPages.forEach(({ slug, financialYear }) => {
+    sitemap.push({
+      url: `${baseUrl}/p/${encodeURIComponent(slug)}/${financialYear}`,
+      changeFrequency: "weekly",
+      priority: 0.9,
     });
   });
 

--- a/webapp/src/client/components/layout/header/HeaderClient.tsx
+++ b/webapp/src/client/components/layout/header/HeaderClient.tsx
@@ -4,43 +4,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import OrganizationYearSheet from "@/client/components/layout/header/OrganizationYearSheet";
+import { getHeaderNavigation } from "@/client/lib/header-navigation";
 import type { OrganizationsResponse } from "@/types/organization";
 
 const DEFAULT_YEAR = 2026;
-
-const getNavigationItems = (currentSlug: string, currentYear: number) => [
-  { href: `/o/${currentSlug}/${currentYear}/`, label: "トップ", desktopLabel: null },
-  {
-    href: `/o/${currentSlug}/${currentYear}/#cash-flow`,
-    label: "チームみらいの収支の流れ",
-    desktopLabel: "収支の流れ",
-  },
-  {
-    href: `/o/${currentSlug}/${currentYear}/#monthly-trends`,
-    label: "１年間の収支推移",
-    desktopLabel: "1年間の推移",
-  },
-  {
-    href: `/o/${currentSlug}/${currentYear}/#balance-sheet`,
-    label: "貸借対照表",
-    desktopLabel: "貸借対照表",
-  },
-  {
-    href: `/o/${currentSlug}/${currentYear}/#transactions`,
-    label: "すべての出入金",
-    desktopLabel: "すべての出入金",
-  },
-  {
-    href: `/o/${currentSlug}/${currentYear}/#explanation`,
-    label: "データについて",
-    desktopLabel: "データについて",
-  },
-  {
-    href: "https://team-mirai.notion.site/FAQ-27ef6f56bae180c085e9f97d05a5d59c",
-    label: "よくあるご質問",
-    desktopLabel: "よくあるご質問",
-  },
-];
+const AVAILABLE_YEARS = [2025, 2026];
 
 interface HeaderClientProps {
   organizations: OrganizationsResponse;
@@ -49,18 +17,29 @@ interface HeaderClientProps {
 export default function HeaderClient({ organizations }: HeaderClientProps) {
   const pathname = usePathname();
 
-  // 現在のslugとyearを取得（/o/[slug]/[year]/... の形式の場合）
+  // 現在のslugとyearを取得（/o/[slug]/[year]/... または /p/[slug]/[year]/... の形式の場合）
   const pathSegments = pathname.split("/");
-  const slugFromPath = pathSegments[1] === "o" ? pathSegments[2] : null;
-  const yearFromPath =
-    pathSegments[1] === "o" && pathSegments[3] ? parseInt(pathSegments[3], 10) : null;
+  const rootSegment = pathSegments[1];
+  const isPoliticianPage = rootSegment === "p";
+  const isPageWithSlug = rootSegment === "o" || isPoliticianPage;
+  const slugFromPath = isPageWithSlug ? pathSegments[2] : null;
+  const yearFromPath = isPageWithSlug && pathSegments[3] ? parseInt(pathSegments[3], 10) : null;
 
-  const currentSlug = slugFromPath ?? organizations.default;
   const currentYear =
-    yearFromPath && [2025, 2026].includes(yearFromPath) ? yearFromPath : DEFAULT_YEAR;
+    yearFromPath && AVAILABLE_YEARS.includes(yearFromPath) ? yearFromPath : DEFAULT_YEAR;
 
-  const logoHref = currentSlug ? `/o/${currentSlug}/${currentYear}/` : "/";
-  const navigationItems = currentSlug ? getNavigationItems(currentSlug, currentYear) : [];
+  // ナビとロゴは今いるページ（議員ページならそのページ自身）を指す。
+  const navSlug = slugFromPath ?? organizations.default;
+  const navigation = navSlug
+    ? getHeaderNavigation(isPoliticianPage ? "politician" : "organization", navSlug, currentYear)
+    : null;
+  const logoHref = navigation?.homeHref ?? "/";
+  const navigationItems = navigation?.items ?? [];
+
+  // 団体セレクタは政治団体しか扱えないので、議員ページでは既定の団体を初期値にする（2グループ化は #1361）。
+  const currentOrganizationSlug = isPoliticianPage
+    ? organizations.default
+    : (slugFromPath ?? organizations.default);
 
   return (
     <header className="fixed top-0 left-0 right-0 z-40 px-2.5 py-3 xl:px-6 xl:py-4">
@@ -116,29 +95,27 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
               className="hidden lg:flex items-center gap-6 flex-shrink-0"
               aria-label="メインナビゲーション"
             >
-              {navigationItems
-                .filter((item) => item.desktopLabel)
-                .map((item) => {
-                  const isExternal = item.href.startsWith("http");
-                  return (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      className="text-sm font-bold text-black hover:text-teal-600 transition-colors whitespace-nowrap cursor-pointer"
-                      {...(isExternal && {
-                        target: "_blank",
-                        rel: "noopener noreferrer",
-                      })}
-                    >
-                      {item.desktopLabel}
-                    </Link>
-                  );
-                })}
+              {navigationItems.map((item) => {
+                const isExternal = item.href.startsWith("http");
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className="text-sm font-bold text-black hover:text-teal-600 transition-colors whitespace-nowrap cursor-pointer"
+                    {...(isExternal && {
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                    })}
+                  >
+                    {item.label}
+                  </Link>
+                );
+              })}
             </nav>
             <div className="flex items-center w-full max-w-[217px] min-w-0 h-12 flex-shrink">
               <OrganizationYearSheet
                 organizations={organizations}
-                initialSlug={currentSlug ?? undefined}
+                initialSlug={currentOrganizationSlug ?? undefined}
                 initialYear={currentYear}
               />
             </div>

--- a/webapp/src/client/lib/header-navigation.ts
+++ b/webapp/src/client/lib/header-navigation.ts
@@ -1,0 +1,61 @@
+const FAQ_URL = "https://team-mirai.notion.site/FAQ-27ef6f56bae180c085e9f97d05a5d59c";
+
+interface HeaderNavigationItem {
+  href: string;
+  label: string;
+}
+
+/**
+ * ヘッダーが表示している対象のページ。
+ * 調研費の議員ページ（/p/[slug]/[year]）は政治団体ページ（/o/[slug]/[year]）とセクション構成が違うので、
+ * アンカーの行き先を分ける。
+ */
+type HeaderPageKind = "organization" | "politician";
+
+interface HeaderNavigation {
+  /** ロゴとトップリンクの行き先（今いるページ自身） */
+  homeHref: string;
+  items: HeaderNavigationItem[];
+}
+
+/** 政治団体ページのセクション（/o/[slug]/[year]）。 */
+const ORGANIZATION_SECTIONS: HeaderNavigationItem[] = [
+  { href: "#cash-flow", label: "収支の流れ" },
+  { href: "#monthly-trends", label: "1年間の推移" },
+  { href: "#balance-sheet", label: "貸借対照表" },
+  { href: "#transactions", label: "すべての出入金" },
+  { href: "#explanation", label: "データについて" },
+];
+
+/** 議員ページのセクション（B-1〜B-5）。 */
+const POLITICIAN_SECTIONS: HeaderNavigationItem[] = [
+  { href: "#cash-flow", label: "使いみち" },
+  { href: "#highlights", label: "活用方針と成果" },
+  { href: "#monthly-trends", label: "1年間の推移" },
+  { href: "#transactions", label: "すべての支出" },
+  { href: "#explanation", label: "データについて" },
+];
+
+/**
+ * ヘッダーのナビの行き先を組み立てる。
+ * アンカーは今いるページ自身を基準にするので、議員ページで押しても政治団体ページに飛ばない。
+ */
+export function getHeaderNavigation(
+  kind: HeaderPageKind,
+  slug: string,
+  year: number,
+): HeaderNavigation {
+  const homeHref =
+    kind === "politician"
+      ? `/p/${encodeURIComponent(slug)}/${year}/`
+      : `/o/${encodeURIComponent(slug)}/${year}/`;
+  const sections = kind === "politician" ? POLITICIAN_SECTIONS : ORGANIZATION_SECTIONS;
+
+  return {
+    homeHref,
+    items: [
+      ...sections.map((section) => ({ ...section, href: `${homeHref}${section.href}` })),
+      { href: FAQ_URL, label: "よくあるご質問" },
+    ],
+  };
+}

--- a/webapp/src/server/contexts/research-fund/application/usecases/get-published-research-fund-pages-usecase.ts
+++ b/webapp/src/server/contexts/research-fund/application/usecases/get-published-research-fund-pages-usecase.ts
@@ -1,0 +1,12 @@
+import "server-only";
+import type { PublishedResearchFundPageRef } from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+export class GetPublishedResearchFundPagesUsecase {
+  constructor(private repository: ResearchFundRepository) {}
+
+  /** sitemap に載せる議員ページ（/p/[slug]/[year]）の一覧。 */
+  async execute(): Promise<PublishedResearchFundPageRef[]> {
+    return await this.repository.findPublishedPageRefs();
+  }
+}

--- a/webapp/src/server/contexts/research-fund/domain/models/published-research-fund.ts
+++ b/webapp/src/server/contexts/research-fund/domain/models/published-research-fund.ts
@@ -71,3 +71,9 @@ export interface PublishedResearchFund {
 export interface PublishedReceipt {
   storageKey: string;
 }
+
+/** sitemap に載せる公開ページの所在（議員の slug と年度）。 */
+export interface PublishedResearchFundPageRef {
+  slug: string;
+  financialYear: number;
+}

--- a/webapp/src/server/contexts/research-fund/domain/repositories/research-fund-repository.interface.ts
+++ b/webapp/src/server/contexts/research-fund/domain/repositories/research-fund-repository.interface.ts
@@ -1,11 +1,15 @@
 import type {
   PublishedReceipt,
   PublishedResearchFund,
+  PublishedResearchFundPageRef,
 } from "@/server/contexts/research-fund/domain/models/published-research-fund";
 
 export interface ResearchFundRepository {
   /** 議員の slug と年度から、published の仕訳だけを射影して返す。帳簿が無ければ null */
   findPublished(slug: string, financialYear: number): Promise<PublishedResearchFund | null>;
+
+  /** 公開ページが成立する議員×年度の一覧（sitemap 用）。published の仕訳を 1 件以上持つ帳簿だけ */
+  findPublishedPageRefs(): Promise<PublishedResearchFundPageRef[]>;
 
   /** published の仕訳に紐づく領収書だけを返す。未公開の仕訳の領収書は返さない。 */
   findPublishedReceipt(entryId: string): Promise<PublishedReceipt | null>;

--- a/webapp/src/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository.ts
+++ b/webapp/src/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository.ts
@@ -5,6 +5,7 @@ import type {
   PublishedExpenditureGroup,
   PublishedExpense,
   PublishedResearchFund,
+  PublishedResearchFundPageRef,
 } from "@/server/contexts/research-fund/domain/models/published-research-fund";
 import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
 import type { ResearchFundRow } from "@/shared/research-fund/aggregation";
@@ -155,6 +156,20 @@ export class PrismaResearchFundRepository implements ResearchFundRepository {
       expenses,
       groups,
     };
+  }
+
+  async findPublishedPageRefs(): Promise<PublishedResearchFundPageRef[]> {
+    // 公開する仕訳が 1 件も無い帳簿はページとして中身が無いので sitemap に載せない。
+    const books = await this.prisma.researchFundBook.findMany({
+      where: { journalEntries: { some: { status: "published" } } },
+      select: { financialYear: true, politician: { select: { slug: true } } },
+      orderBy: [{ politicianId: "asc" }, { financialYear: "asc" }],
+    });
+
+    return books.map((book) => ({
+      slug: book.politician.slug,
+      financialYear: book.financialYear,
+    }));
   }
 
   async findPublishedReceipt(entryId: string) {

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/load-published-research-fund-pages.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/load-published-research-fund-pages.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import { GetPublishedResearchFundPagesUsecase } from "@/server/contexts/research-fund/application/usecases/get-published-research-fund-pages-usecase";
+import { PrismaResearchFundRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository";
+import {
+  CACHE_REVALIDATE_SECONDS,
+  RESEARCH_FUND_CACHE_TAG,
+} from "@/server/contexts/research-fund/presentation/loaders/constants";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export const loadPublishedResearchFundPages = unstable_cache(
+  async () => {
+    const usecase = new GetPublishedResearchFundPagesUsecase(
+      new PrismaResearchFundRepository(prisma),
+    );
+    return await usecase.execute();
+  },
+  [RESEARCH_FUND_CACHE_TAG, "published-pages"],
+  { revalidate: CACHE_REVALIDATE_SECONDS, tags: [RESEARCH_FUND_CACHE_TAG] },
+);

--- a/webapp/tests/app/sitemap.test.ts
+++ b/webapp/tests/app/sitemap.test.ts
@@ -1,0 +1,54 @@
+jest.mock("@/server/contexts/public-finance/presentation/loaders/load-organizations", () => ({
+  loadOrganizations: jest.fn(),
+}));
+jest.mock(
+  "@/server/contexts/research-fund/presentation/loaders/load-published-research-fund-pages",
+  () => ({ loadPublishedResearchFundPages: jest.fn() }),
+);
+
+import sitemap from "@/app/sitemap";
+import { loadOrganizations } from "@/server/contexts/public-finance/presentation/loaders/load-organizations";
+import { loadPublishedResearchFundPages } from "@/server/contexts/research-fund/presentation/loaders/load-published-research-fund-pages";
+
+const loadOrganizationsMock = loadOrganizations as jest.Mock;
+const loadPublishedResearchFundPagesMock = loadPublishedResearchFundPages as jest.Mock;
+
+const BASE_URL = process.env.WEBAPP_URL || "https://marumie.team-mir.ai";
+
+describe("sitemap", () => {
+  beforeEach(() => {
+    loadOrganizationsMock.mockResolvedValue({
+      default: "team-mirai",
+      organizations: [{ slug: "team-mirai", orgName: null, displayName: "チームみらい" }],
+    });
+    loadPublishedResearchFundPagesMock.mockResolvedValue([]);
+  });
+
+  it("published の帳簿を持つ議員×年度を列挙する", async () => {
+    loadPublishedResearchFundPagesMock.mockResolvedValue([
+      { slug: "sample-taro", financialYear: 2025 },
+      { slug: "sample-taro", financialYear: 2026 },
+    ]);
+
+    const urls = (await sitemap()).map((entry) => entry.url);
+
+    expect(urls).toContain(`${BASE_URL}/p/sample-taro/2025`);
+    expect(urls).toContain(`${BASE_URL}/p/sample-taro/2026`);
+  });
+
+  it("政治団体のページは従来どおり列挙する", async () => {
+    const urls = (await sitemap()).map((entry) => entry.url);
+
+    expect(urls).toEqual([
+      BASE_URL,
+      `${BASE_URL}/o/team-mirai`,
+      `${BASE_URL}/o/team-mirai/transactions`,
+    ]);
+  });
+
+  it("公開中の議員ページが無ければ /p/ の URL を出さない", async () => {
+    const urls = (await sitemap()).map((entry) => entry.url);
+
+    expect(urls.filter((url) => url.includes("/p/"))).toEqual([]);
+  });
+});

--- a/webapp/tests/client/lib/header-navigation.test.ts
+++ b/webapp/tests/client/lib/header-navigation.test.ts
@@ -1,0 +1,41 @@
+import { getHeaderNavigation } from "@/client/lib/header-navigation";
+
+describe("getHeaderNavigation", () => {
+  it("政治団体ページでは /o/[slug]/[year] のセクションを指す", () => {
+    const { homeHref, items } = getHeaderNavigation("organization", "team-mirai", 2025);
+
+    expect(homeHref).toBe("/o/team-mirai/2025/");
+    expect(items.map((item) => item.href)).toEqual([
+      "/o/team-mirai/2025/#cash-flow",
+      "/o/team-mirai/2025/#monthly-trends",
+      "/o/team-mirai/2025/#balance-sheet",
+      "/o/team-mirai/2025/#transactions",
+      "/o/team-mirai/2025/#explanation",
+      "https://team-mirai.notion.site/FAQ-27ef6f56bae180c085e9f97d05a5d59c",
+    ]);
+  });
+
+  it("議員ページでは同じページ内のセクション（B-1〜B-5）を指す", () => {
+    const { homeHref, items } = getHeaderNavigation("politician", "sample-taro", 2026);
+
+    expect(homeHref).toBe("/p/sample-taro/2026/");
+    expect(items.map((item) => item.href)).toEqual([
+      "/p/sample-taro/2026/#cash-flow",
+      "/p/sample-taro/2026/#highlights",
+      "/p/sample-taro/2026/#monthly-trends",
+      "/p/sample-taro/2026/#transactions",
+      "/p/sample-taro/2026/#explanation",
+      "https://team-mirai.notion.site/FAQ-27ef6f56bae180c085e9f97d05a5d59c",
+    ]);
+  });
+
+  it("議員ページのナビは政治団体ページ（/o/）へ飛ばない", () => {
+    const { items } = getHeaderNavigation("politician", "sample-taro", 2026);
+
+    expect(items.filter((item) => item.href.startsWith("/o/"))).toEqual([]);
+  });
+
+  it("slug は URL エンコードする", () => {
+    expect(getHeaderNavigation("politician", "a/b", 2026).homeHref).toBe("/p/a%2Fb/2026/");
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-published-research-fund-pages-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-published-research-fund-pages-usecase.test.ts
@@ -1,0 +1,31 @@
+import { GetPublishedResearchFundPagesUsecase } from "@/server/contexts/research-fund/application/usecases/get-published-research-fund-pages-usecase";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+function build(refs: { slug: string; financialYear: number }[]) {
+  const repository: ResearchFundRepository = {
+    findPublished: jest.fn().mockResolvedValue(null),
+    findPublishedPageRefs: jest.fn().mockResolvedValue(refs),
+    findPublishedReceipt: jest.fn().mockResolvedValue(null),
+  };
+  return { usecase: new GetPublishedResearchFundPagesUsecase(repository), repository };
+}
+
+describe("GetPublishedResearchFundPagesUsecase", () => {
+  it("公開ページが成立する議員×年度を返す", async () => {
+    const { usecase } = build([
+      { slug: "sample-taro", financialYear: 2025 },
+      { slug: "sample-taro", financialYear: 2026 },
+    ]);
+
+    expect(await usecase.execute()).toEqual([
+      { slug: "sample-taro", financialYear: 2025 },
+      { slug: "sample-taro", financialYear: 2026 },
+    ]);
+  });
+
+  it("公開ページが1件も無ければ空配列を返す", async () => {
+    const { usecase } = build([]);
+
+    expect(await usecase.execute()).toEqual([]);
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-page-usecase.test.ts
@@ -84,6 +84,7 @@ function published(overrides: Partial<PublishedResearchFund> = {}): PublishedRes
 function usecaseWith(value: PublishedResearchFund | null) {
   const repository: ResearchFundRepository = {
     findPublished: jest.fn().mockResolvedValue(value),
+    findPublishedPageRefs: jest.fn().mockResolvedValue([]),
     findPublishedReceipt: jest.fn().mockResolvedValue(null),
   };
   return { usecase: new GetResearchFundPageUsecase(repository), repository };

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-receipt-usecase.test.ts
@@ -5,6 +5,7 @@ import type { ResearchFundRepository } from "@/server/contexts/research-fund/dom
 function build(receipt: { storageKey: string } | null) {
   const repository: ResearchFundRepository = {
     findPublished: jest.fn().mockResolvedValue(null),
+    findPublishedPageRefs: jest.fn().mockResolvedValue([]),
     findPublishedReceipt: jest.fn().mockResolvedValue(receipt),
   };
   const storage: ReceiptStorage = {


### PR DESCRIPTION
## 目的（Why）

調研費の議員ページ `/p/[slug]/[year]`（#1360）は公開ページでありながら、既存の政治団体ページと扱いが揃っていなかった。

- **検索してページに辿り着きたい市民** が辿り着けない: `sitemap.ts` が `/o/...` しか列挙しておらず、議員ページが検索エンジンに拾われない
- **議員ページを読んでいる市民** がページ内を移動できない: ヘッダーのナビが `/o/...` のアンカーを決め打ちで出すため、押すと別ページ（政治団体ページ）に飛ばされる

この2点を解消する。

## 変更内容

### sitemap に議員ページを載せる

- `ResearchFundRepository.findPublishedPageRefs()` を追加。**published の仕訳を1件以上持つ帳簿**の議員×年度だけを返す
  （公開する仕訳が無い帳簿は中身が無いので載せない）
- `GetPublishedResearchFundPagesUsecase` / `loadPublishedResearchFundPages` を追加（既存の調研費ページと同じキャッシュタグ・保持時間）
- `sitemap.ts` が `/p/{slug}/{year}` を列挙する。組織データの取得とは `Promise.all` で並行化

### ヘッダーのナビを今いるページに向ける

- ナビの組み立てを `webapp/src/client/lib/header-navigation.ts` に切り出し、ページ種別（`organization` / `politician`）でセクションを出し分ける純関数にした
- 議員ページでは B-1〜B-5（`#cash-flow` / `#highlights` / `#monthly-trends` / `#transactions` / `#explanation`）を指す
- ロゴのリンク先も今いるページ自身になる（議員ページで押しても政治団体ページに飛ばない）
- 元のコードにあった未使用の `label` フィールドは整理し、描画に使う1つのラベルに統一した

団体セレクタは政治団体しか扱えないので、議員ページでは従来どおり既定の団体を初期値にしている（2グループ化は #1361 の範囲なので触っていない）。

## ローカル CI

- `pnpm verify`: ✅ 通過（test / typecheck / lint / knip / depcruise）
- `pnpm test:e2e`（webapp + admin 全 48 件）: ✅ 通過

追加したテスト:
- `webapp/tests/app/sitemap.test.ts` — 議員×年度の列挙、公開ページが無いときは `/p/` を出さない、政治団体の URL は従来どおり
- `webapp/tests/client/lib/header-navigation.test.ts` — 議員ページのアンカーが `/o/` を指さないこと、slug の URL エンコード
- `webapp/tests/.../get-published-research-fund-pages-usecase.test.ts`
- `webapp/e2e/tests/research-fund.spec.ts` — 議員ページのヘッダーナビが同ページ内セクションを指し、`/o/` へのリンクが 0 件であること

## スコープアウト

なし（Issue の Out of scope に従い、組織セレクタの2グループ化・OGP・多言語は対象外）。

なお Issue 本文には「`sitemap.ts` が `/o/[slug]/[year]` しか列挙しておらず」とあるが、実際に列挙されているのは `/o/[slug]` と `/o/[slug]/transactions` で年度付き URL は元から無い。政治団体側の URL 形式の変更は本 Issue の完了条件に含まれないため、既存のまま据え置いた。

Closes #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 公開中の議員ページがサイトマップに自動掲載されるようになりました。
  - 議員ページのヘッダーナビゲーションから、各セクションへ直接移動できるようになりました。
  - 外部リンクは新しいタブで安全に開かれます。
  - 議員ページでは、政治団体ページへの不要なリンクを表示しないようにしました。

- **テスト**
  - サイトマップとヘッダーナビゲーションの動作確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->