### PR TITLE
feat(webapp): 調研費の CSV ダウンロード

### DIFF
--- a/webapp/src/client/components/research-fund/ResearchFundCsvDownloadLink.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundCsvDownloadLink.tsx
@@ -1,0 +1,67 @@
+"use client";
+import "client-only";
+
+import { useState } from "react";
+import { downloadResearchFundCsv } from "@/server/contexts/research-fund/presentation/loaders/download-research-fund-csv";
+
+interface Props {
+  slug: string;
+  financialYear: number;
+  className?: string;
+}
+
+/**
+ * B-4 の支出を CSV でダウンロードする。
+ *
+ * 画面は月ごとに区切って見せるが、CSV はその年度の公開中の支出を全件出す。
+ */
+export default function ResearchFundCsvDownloadLink({
+  slug,
+  financialYear,
+  className = "",
+}: Props) {
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    if (isDownloading) return;
+
+    setIsDownloading(true);
+    try {
+      const result = await downloadResearchFundCsv(slug, financialYear);
+
+      if (result.success && result.data) {
+        // Excel が文字化けしないよう UTF-8 BOM を付ける（既存の取引 CSV と同じ）
+        const blob = new Blob([`\uFEFF${result.data}`], {
+          type: "text/csv;charset=utf-8;",
+        });
+
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = result.filename ?? "research_fund.csv";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(url);
+      } else {
+        alert(result.error ?? "ダウンロードに失敗しました");
+      }
+    } catch (error) {
+      console.error("Download failed:", error);
+      alert("ダウンロードに失敗しました");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      disabled={isDownloading}
+      className={`cursor-pointer rounded-md bg-white px-4 py-3 text-sm font-bold text-[#238778] transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+    >
+      {isDownloading ? "ダウンロード中..." : "すべての支出をCSVでダウンロード"}
+    </button>
+  );
+}

--- a/webapp/src/client/components/research-fund/ResearchFundExpensesSection.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundExpensesSection.tsx
@@ -7,6 +7,7 @@ import MainColumnCard from "@/client/components/layout/MainColumnCard";
 import CategoryModeTabs from "@/client/components/research-fund/CategoryModeTabs";
 import ReceiptModal from "@/client/components/research-fund/ReceiptModal";
 import ResearchFundCategoryPill from "@/client/components/research-fund/ResearchFundCategoryPill";
+import ResearchFundCsvDownloadLink from "@/client/components/research-fund/ResearchFundCsvDownloadLink";
 import type {
   ResearchFundCategoryMode,
   ResearchFundExpenseView,
@@ -139,10 +140,20 @@ export default function ResearchFundExpensesSection({ data, updatedAt }: Props) 
               );
             })}
 
-            <p className="mt-5 text-center text-sm font-medium text-[#6A7383]">
-              {Number(month.slice(5, 7))}月の支出 {rows.length}件・合計{" "}
-              {total.toLocaleString("ja-JP")}円
-            </p>
+            <div className="mt-5 flex flex-col items-end gap-3 md:grid md:grid-cols-[1fr_auto_1fr] md:items-center">
+              <div className="hidden md:block" />
+              <p className="w-full text-center text-sm font-medium text-[#6A7383] md:w-auto">
+                {Number(month.slice(5, 7))}月の支出 {rows.length}件・合計{" "}
+                {total.toLocaleString("ja-JP")}円
+              </p>
+              {/* 月切り替えとは独立に、その年度の公開中の支出を全件出す */}
+              <div className="md:flex md:justify-end">
+                <ResearchFundCsvDownloadLink
+                  slug={data.politician.slug}
+                  financialYear={data.financialYear}
+                />
+              </div>
+            </div>
           </div>
         </>
       )}

--- a/webapp/src/server/contexts/research-fund/domain/models/research-fund-page.ts
+++ b/webapp/src/server/contexts/research-fund/domain/models/research-fund-page.ts
@@ -32,6 +32,8 @@ export interface ResearchFundExpenseView {
   legal: ResearchFundCategoryView;
   /** 特記事項。同一注文の分割行はその説明もここに含む。無ければ null */
   note: string | null;
+  /** 同一注文の分割グループ。単独の支出は null。CSV で注文単位に束ね直すのに使う。 */
+  splitGroup: string | null;
   hasReceipt: boolean;
 }
 

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-csv.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-csv.ts
@@ -1,0 +1,56 @@
+import type { ResearchFundExpenseView } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+
+/**
+ * 調研費の支出 CSV。
+ *
+ * 画面（B-4）が月ごとに区切って見せるのに対し、CSV はその年度の published の支出を
+ * 全件そのまま渡す。表示用の view から作るので、未公開の仕訳と備考（memo）は
+ * 構造上ここに入り込まない。
+ */
+export const RESEARCH_FUND_CSV_HEADERS = [
+  "日付",
+  "カテゴリー",
+  "法定区分",
+  "項目",
+  "金額",
+  "特記事項",
+  "分割グループ",
+  "領収書",
+] as const;
+
+/** 領収書の有無は URL ではなく有無だけを載せる（配信は認可付きの API 経由のため）。 */
+function receiptLabel(hasReceipt: boolean): string {
+  return hasReceipt ? "あり" : "なし";
+}
+
+function escapeCell(value: string | number): string {
+  return `"${String(value).replace(/"/g, '""')}"`;
+}
+
+/** 区切りは既存の取引 CSV に合わせた LF。UTF-8 BOM はダウンロード時に付ける。 */
+export function buildResearchFundCsv(expenses: readonly ResearchFundExpenseView[]): string {
+  const rows = [
+    RESEARCH_FUND_CSV_HEADERS.map(escapeCell).join(","),
+    ...expenses.map((expense) =>
+      [
+        expense.date,
+        expense.detailed.label,
+        expense.legal.label,
+        expense.description,
+        expense.amount,
+        expense.note ?? "",
+        expense.splitGroup ?? "",
+        receiptLabel(expense.hasReceipt),
+      ]
+        .map(escapeCell)
+        .join(","),
+    ),
+  ];
+
+  return rows.join("\n");
+}
+
+/** 例: `research_fund_mineshima_2026.csv`。既存の取引 CSV と同じ snake_case の慣習に合わせる。 */
+export function buildResearchFundCsvFilename(slug: string, financialYear: number): string {
+  return `research_fund_${slug}_${financialYear}.csv`;
+}

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-expense-list.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-expense-list.ts
@@ -62,6 +62,7 @@ export function buildExpenseViews(
         detailed: { label: account?.label || UNKNOWN_CATEGORY_LABEL, color },
         legal: { label: account?.legalLabel || UNKNOWN_CATEGORY_LABEL, color },
         note: mergeNotes(expense.note, splitCount > 1 ? splitGroupNote(splitCount) : null),
+        splitGroup: expense.splitGroup,
         hasReceipt: expense.hasReceipt,
       };
     });

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/download-research-fund-csv.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/download-research-fund-csv.ts
@@ -1,0 +1,43 @@
+"use server";
+
+import "server-only";
+
+import {
+  buildResearchFundCsv,
+  buildResearchFundCsvFilename,
+} from "@/server/contexts/research-fund/domain/services/research-fund-csv";
+import { loadResearchFundPage } from "@/server/contexts/research-fund/presentation/loaders/load-research-fund-page";
+
+interface DownloadResearchFundCsvResult {
+  success: boolean;
+  data?: string;
+  filename?: string;
+  error?: string;
+}
+
+/**
+ * 議員ページの支出を CSV にして返す。
+ *
+ * 画面が読むのと同じ loader を使うので、published の支出だけが対象になり、
+ * 備考（memo）や未公開の仕訳は含まれない。
+ */
+export async function downloadResearchFundCsv(
+  slug: string,
+  financialYear: number,
+): Promise<DownloadResearchFundCsvResult> {
+  try {
+    const data = await loadResearchFundPage({ slug, financialYear });
+    if (!data) {
+      return { success: false, error: "公開中のデータが見つかりませんでした" };
+    }
+
+    return {
+      success: true,
+      data: buildResearchFundCsv(data.expenses),
+      filename: buildResearchFundCsvFilename(slug, financialYear),
+    };
+  } catch (error) {
+    console.error("Research fund CSV download error:", error);
+    return { success: false, error: "CSVのダウンロードに失敗しました" };
+  }
+}

--- a/webapp/tests/server/contexts/research-fund/domain/services/research-fund-csv.test.ts
+++ b/webapp/tests/server/contexts/research-fund/domain/services/research-fund-csv.test.ts
@@ -1,0 +1,96 @@
+import type { ResearchFundExpenseView } from "@/server/contexts/research-fund/domain/models/research-fund-page";
+import {
+  buildResearchFundCsv,
+  buildResearchFundCsvFilename,
+  RESEARCH_FUND_CSV_HEADERS,
+} from "@/server/contexts/research-fund/domain/services/research-fund-csv";
+
+function view(overrides: Partial<ResearchFundExpenseView> = {}): ResearchFundExpenseView {
+  return {
+    id: "1",
+    entryId: "1",
+    date: "2026-04-23",
+    month: "2026-04",
+    description: "タクシー代",
+    amount: 1200,
+    detailed: { label: "タクシー代", color: "#111111" },
+    legal: { label: "⑨ 滞在費", color: "#111111" },
+    note: null,
+    splitGroup: null,
+    hasReceipt: false,
+    ...overrides,
+  };
+}
+
+describe("buildResearchFundCsv", () => {
+  it("完了条件の列を順番どおりに出す", () => {
+    const [header] = buildResearchFundCsv([]).split("\n");
+
+    expect(header).toBe(
+      '"日付","カテゴリー","法定区分","項目","金額","特記事項","分割グループ","領収書"',
+    );
+    expect(RESEARCH_FUND_CSV_HEADERS).toHaveLength(8);
+  });
+
+  it("支出1件を1行に書き出す", () => {
+    const csv = buildResearchFundCsv([
+      view({
+        date: "2026-04-23",
+        detailed: { label: "文房具・備品", color: "#111111" },
+        legal: { label: "③ 備品・消耗品費", color: "#111111" },
+        description: "ボールペン",
+        amount: 330,
+        note: "同一注文で3点購入",
+        splitGroup: "order-1",
+        hasReceipt: true,
+      }),
+    ]);
+
+    expect(csv.split("\n")[1]).toBe(
+      '"2026-04-23","文房具・備品","③ 備品・消耗品費","ボールペン","330","同一注文で3点購入","order-1","あり"',
+    );
+  });
+
+  it("特記事項と分割グループが無ければ空欄にし、領収書の有無を出す", () => {
+    const csv = buildResearchFundCsv([view({ note: null, splitGroup: null, hasReceipt: false })]);
+
+    expect(csv.split("\n")[1]).toBe(
+      '"2026-04-23","タクシー代","⑨ 滞在費","タクシー代","1200","","","なし"',
+    );
+  });
+
+  it("ダブルクォートを含む値をエスケープする", () => {
+    const csv = buildResearchFundCsv([view({ description: '書籍「"AI"入門」' })]);
+
+    expect(csv).toContain('"書籍「""AI""入門」"');
+  });
+
+  it("カンマや改行を含む値でも列がずれない", () => {
+    const csv = buildResearchFundCsv([view({ note: "打ち合わせ, 資料作成" })]);
+
+    expect(csv.split("\n")[1]).toContain('"打ち合わせ, 資料作成"');
+    // 区切りのカンマだけで数えると列が増えてしまうので、引用の外のカンマは7個のまま
+    expect(csv.split("\n")).toHaveLength(2);
+  });
+
+  it("渡された順序をそのまま保つ（並べ替えは明細の組み立て側の責務）", () => {
+    const csv = buildResearchFundCsv([
+      view({ id: "1", description: "先頭" }),
+      view({ id: "2", description: "2番目" }),
+    ]);
+
+    const rows = csv.split("\n");
+    expect(rows[1]).toContain("先頭");
+    expect(rows[2]).toContain("2番目");
+  });
+
+  it("支出が無ければヘッダーだけを返す", () => {
+    expect(buildResearchFundCsv([]).split("\n")).toHaveLength(1);
+  });
+});
+
+describe("buildResearchFundCsvFilename", () => {
+  it("議員の slug と年度からファイル名を作る", () => {
+    expect(buildResearchFundCsvFilename("mineshima", 2026)).toBe("research_fund_mineshima_2026.csv");
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/domain/services/research-fund-expense-list.test.ts
+++ b/webapp/tests/server/contexts/research-fund/domain/services/research-fund-expense-list.test.ts
@@ -102,4 +102,17 @@ describe("buildExpenseViews", () => {
     expect(view.detailed.label).toBe("その他");
     expect(view.legal.label).toBe("その他");
   });
+
+  it("分割グループをそのまま渡す（CSV が注文単位に束ね直せるように）", () => {
+    const views = buildExpenseViews(
+      [
+        expense({ id: "1", entryId: "1", splitGroup: "order-1" }),
+        expense({ id: "2", entryId: "2", splitGroup: null }),
+      ],
+      accounts,
+    );
+
+    expect(views.find((view) => view.id === "1")?.splitGroup).toBe("order-1");
+    expect(views.find((view) => view.id === "2")?.splitGroup).toBeNull();
+  });
 });


### PR DESCRIPTION
## 目的（Why）

既存の政治資金と同様に、調査研究費を見にきた市民が、公開されている支出を機械可読な形で持ち帰れるようにするため。
これまで議員ページの支出は画面上で月ごとに1件ずつ眺めることしかできず、年度分をまとめて集計・検証する手段がなかった。

## 変更内容

- `buildResearchFundCsv` / `buildResearchFundCsvFilename`（domain/services）を追加。
  列は 日付・カテゴリー・法定区分・項目・金額・特記事項・分割グループ・領収書 の8列。
- `downloadResearchFundCsv`（presentation/loaders の `"use server"`）を追加。
  画面が読むのと同じ `loadResearchFundPage` を使うので、**published の支出だけ**が対象になり、
  備考（memo）と未公開の仕訳は構造上入り込まない。
- `ResearchFundCsvDownloadLink`（client）を追加し、B-4「すべての支出」の表のフッターに配置。
  画面は月で絞り込むが、CSV は**その年度の公開中の支出を全件**出す。
- `ResearchFundExpenseView` に `splitGroup` を追加（既存は `note` に畳み込まれていて、分割グループそのものを出せなかった）。

### 慣習の踏襲

- 文字コード: UTF-8 + BOM（Excel で開いて文字化けしない）。既存の `CsvDownloadLink` と同じ。
- ファイル名: `research_fund_<slug>_<年度>.csv`。既存の `transactions_<slug>_<日付>.csv` と同じ snake_case。
- 領収書は URL ではなく「あり / なし」を出す。配信は認可付きの API（`/api/research-fund/receipts/[entryId]`）経由のため、
  CSV に直リンクを載せる形にはしていない。

## ローカル CI

- `pnpm verify` ✅（test 203 → 210 passed / typecheck / lint / knip / depcruise すべて通過）
- `pnpm test:e2e` ✅（webapp 27 passed・admin 48 passed）
  B-4 のフッターの DOM を触ったため E2E も実行。`research-fund.spec.ts` の月切り替え・区分トグルを含めて回帰なし。

## スコープアウト

Issue の Out of scope（領収書ファイルの一括ダウンロード / 政党単位の CSV）はいずれも未実装のまま。追加の起票はなし。

Closes #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 研究費ページから、年度全体の公開支出をCSV形式でダウンロードできるようになりました。
  * CSVには支出日、カテゴリー、金額、特記事項、領収書の有無などが含まれます。
  * ダウンロード中はボタンが無効化され、エラー時には通知が表示されます。

* **テスト**
  * CSVの出力内容、文字のエスケープ、ファイル名、分割支出の処理を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->