### PR TITLE
feat(webapp): 調研費の CSV ダウンロード

### DIFF
--- a/webapp/e2e/tests/research-fund.spec.ts
+++ b/webapp/e2e/tests/research-fund.spec.ts
@@ -105,6 +105,34 @@ test.describe("調査研究費 議員ページ", () => {
 		}).toPass();
 	});
 
+	test("公開中の全支出を CSV でダウンロードできる", async ({ page }) => {
+		await page.goto(PAGE_URL);
+		await expect(
+			page
+				.locator("#transactions")
+				.getByRole("link", { name: "すべての支出をCSVでダウンロード" }),
+		).toBeVisible();
+
+		const response = await page.request.get("/api/research-fund/csv/sample-taro/2026");
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()["content-type"]).toContain("text/csv");
+		expect(response.headers()["content-disposition"]).toContain(
+			"research_fund_sample-taro_2026_",
+		);
+
+		const body = await response.text();
+		// Excel で文字化けしないよう BOM つきの UTF-8 で配信する。
+		expect(body.startsWith("\uFEFF")).toBe(true);
+		const [header, ...rows] = body.slice(1).split("\n");
+		expect(header).toBe(
+			'"日付","カテゴリー","法定区分","項目","金額","特記事項","分割グループ","領収書"',
+		);
+		expect(rows.length).toBeGreaterThan(0);
+		// シードでは 8/10 以降が未公開（確認済・下書き）。CSV にも含まれない。
+		expect(rows.filter((row) => /^"2026-08-(1|2|3)\d"/.test(row))).toHaveLength(0);
+	});
+
 	test("存在しない議員のページは政治団体ページに寄せられる", async ({ page }) => {
 		await page.goto("/p/no-such-politician/2026");
 

--- a/webapp/src/app/api/research-fund/csv/[slug]/[year]/route.ts
+++ b/webapp/src/app/api/research-fund/csv/[slug]/[year]/route.ts
@@ -1,0 +1,34 @@
+import "server-only";
+import { NextResponse } from "next/server";
+import { researchFundCsvFilename } from "@/server/contexts/research-fund/domain/services/research-fund-csv";
+import { loadResearchFundCsv } from "@/server/contexts/research-fund/presentation/loaders/load-research-fund-csv";
+
+/**
+ * 議員ページの全支出を CSV で配信する。published の仕訳だけが含まれる。
+ *
+ * 既存の取引 CSV に合わせて UTF-8 + BOM（Excel で文字化けしないため）で返す。
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string; year: string }> },
+) {
+  const { slug, year } = await params;
+  // 年度が数字でない URL では DB を引かずに 404 にする。
+  if (!/^\d{4}$/.test(year)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const financialYear = Number(year);
+  const csv = await loadResearchFundCsv({ slug, financialYear });
+  if (csv === null) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const filename = researchFundCsvFilename(slug, financialYear, new Date());
+  return new NextResponse(`\uFEFF${csv}`, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/webapp/src/client/components/research-fund/ResearchFundExpensesSection.tsx
+++ b/webapp/src/client/components/research-fund/ResearchFundExpensesSection.tsx
@@ -143,6 +143,17 @@ export default function ResearchFundExpensesSection({ data, updatedAt }: Props) 
               {Number(month.slice(5, 7))}月の支出 {rows.length}件・合計{" "}
               {total.toLocaleString("ja-JP")}円
             </p>
+
+            {/* 月の切り替えとは独立に、公開中の全支出をまとめて持ち帰れるようにする。 */}
+            <div className="mt-3 text-right">
+              <a
+                href={`/api/research-fund/csv/${data.politician.slug}/${data.financialYear}`}
+                download
+                className="text-sm font-bold text-[#238778] hover:bg-gray-50 transition-all cursor-pointer"
+              >
+                すべての支出をCSVでダウンロード
+              </a>
+            </div>
           </div>
         </>
       )}

--- a/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-csv-usecase.ts
+++ b/webapp/src/server/contexts/research-fund/application/usecases/get-research-fund-csv-usecase.ts
@@ -1,0 +1,22 @@
+import "server-only";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+import { buildResearchFundCsv } from "@/server/contexts/research-fund/domain/services/research-fund-csv";
+
+export interface GetResearchFundCsvParams {
+  slug: string;
+  financialYear: number;
+}
+
+export class GetResearchFundCsvUsecase {
+  constructor(private repository: ResearchFundRepository) {}
+
+  /**
+   * 議員ページの全支出 CSV の中身。帳簿が無ければ null を返し、呼び出し側が 404 にする。
+   * ファイル名はダウンロード時刻に依るのでここでは組み立てない（キャッシュに載せない）。
+   */
+  async execute(params: GetResearchFundCsvParams): Promise<string | null> {
+    const published = await this.repository.findPublished(params.slug, params.financialYear);
+    if (!published) return null;
+    return buildResearchFundCsv(published);
+  }
+}

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-csv.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-csv.ts
@@ -1,0 +1,66 @@
+import type { PublishedResearchFund } from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import {
+  compareExpenseOrder,
+  UNKNOWN_CATEGORY_LABEL,
+} from "@/server/contexts/research-fund/domain/services/research-fund-expense-list";
+
+/**
+ * CSV の列。
+ *
+ * 備考（memo）は公開されない事務所内メモなので列に無い（そもそも公開ページの
+ * 射影に入っていない）。分割の説明は「分割グループ」列で表せるため、
+ * 特記事項には仕訳の note をそのまま出す。
+ */
+const HEADERS = [
+  "日付",
+  "カテゴリー",
+  "法定区分",
+  "項目",
+  "金額",
+  "特記事項",
+  "分割グループ",
+  "領収書",
+] as const;
+
+/** ファイル名に使える文字だけを残す（Content-Disposition ヘッダへの混入を防ぐ）。 */
+function sanitizeForFilename(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
+/** すべての値を引用符で囲み、値の中の引用符は2つ重ねて表す（RFC 4180）。 */
+function escapeCsvValue(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/**
+ * 議員ページの CSV。published の支出だけを、画面（B-4）と同じ並び順で出す。
+ *
+ * 文字コード（UTF-8 + BOM）は配信側で付ける。既存の取引 CSV と同じ扱い。
+ */
+export function buildResearchFundCsv(
+  published: Pick<PublishedResearchFund, "expenses" | "accounts">,
+): string {
+  const rows = [...published.expenses].sort(compareExpenseOrder).map((expense) => {
+    const account = published.accounts[expense.accountKey];
+    return [
+      expense.date,
+      account?.label || UNKNOWN_CATEGORY_LABEL,
+      account?.legalLabel || UNKNOWN_CATEGORY_LABEL,
+      expense.description,
+      String(expense.amount),
+      expense.note?.trim() ? expense.note : "",
+      expense.splitGroup ?? "",
+      expense.hasReceipt ? "あり" : "なし",
+    ]
+      .map(escapeCsvValue)
+      .join(",");
+  });
+
+  return [HEADERS.map(escapeCsvValue).join(","), ...rows].join("\n");
+}
+
+/** 既存の取引 CSV（`transactions_<slug>_<日付>.csv`）に合わせたファイル名。 */
+export function researchFundCsvFilename(slug: string, financialYear: number, now: Date): string {
+  const timestamp = now.toISOString().slice(0, 10);
+  return `research_fund_${sanitizeForFilename(slug)}_${financialYear}_${timestamp}.csv`;
+}

--- a/webapp/src/server/contexts/research-fund/domain/services/research-fund-expense-list.ts
+++ b/webapp/src/server/contexts/research-fund/domain/services/research-fund-expense-list.ts
@@ -6,7 +6,7 @@ import type { ResearchFundExpenseView } from "@/server/contexts/research-fund/do
 import { researchFundCategoryColor } from "@/server/contexts/research-fund/domain/services/research-fund-category-color";
 
 /** 科目マスタに無い科目のラベル（要確認の仕訳は公開されない想定だが、表示は落とさない）。 */
-const UNKNOWN_CATEGORY_LABEL = "その他";
+export const UNKNOWN_CATEGORY_LABEL = "その他";
 
 /**
  * 同一注文の分割行につける説明。
@@ -40,31 +40,35 @@ export function buildExpenseViews(
     splitCounts.set(expense.splitGroup, (splitCounts.get(expense.splitGroup) ?? 0) + 1);
   }
 
-  return [...expenses]
-    .sort(
-      (a, b) =>
-        compare(b.date, a.date) ||
-        // 同一注文の行が他の支出に割り込まれないよう、日付の中では注文ごとにまとめる。
-        compare(a.splitGroup ?? "", b.splitGroup ?? "") ||
-        compareIds(a.id, b.id),
-    )
-    .map((expense) => {
-      const account = accounts[expense.accountKey];
-      const color = researchFundCategoryColor(account?.legalCategoryKey ?? "");
-      const splitCount = expense.splitGroup ? (splitCounts.get(expense.splitGroup) ?? 1) : 1;
-      return {
-        id: expense.id,
-        entryId: expense.entryId,
-        date: expense.date,
-        month: expense.date.slice(0, 7),
-        description: expense.description,
-        amount: expense.amount,
-        detailed: { label: account?.label || UNKNOWN_CATEGORY_LABEL, color },
-        legal: { label: account?.legalLabel || UNKNOWN_CATEGORY_LABEL, color },
-        note: mergeNotes(expense.note, splitCount > 1 ? splitGroupNote(splitCount) : null),
-        hasReceipt: expense.hasReceipt,
-      };
-    });
+  return [...expenses].sort(compareExpenseOrder).map((expense) => {
+    const account = accounts[expense.accountKey];
+    const color = researchFundCategoryColor(account?.legalCategoryKey ?? "");
+    const splitCount = expense.splitGroup ? (splitCounts.get(expense.splitGroup) ?? 1) : 1;
+    return {
+      id: expense.id,
+      entryId: expense.entryId,
+      date: expense.date,
+      month: expense.date.slice(0, 7),
+      description: expense.description,
+      amount: expense.amount,
+      detailed: { label: account?.label || UNKNOWN_CATEGORY_LABEL, color },
+      legal: { label: account?.legalLabel || UNKNOWN_CATEGORY_LABEL, color },
+      note: mergeNotes(expense.note, splitCount > 1 ? splitGroupNote(splitCount) : null),
+      hasReceipt: expense.hasReceipt,
+    };
+  });
+}
+
+/**
+ * 画面（B-4）と CSV で共通の並び順。日付の新しい順に並べ、
+ * 同一注文（split_group）の行が他の支出に割り込まれないよう日付の中で注文ごとにまとめる。
+ */
+export function compareExpenseOrder(a: PublishedExpense, b: PublishedExpense): number {
+  return (
+    compare(b.date, a.date) ||
+    compare(a.splitGroup ?? "", b.splitGroup ?? "") ||
+    compareIds(a.id, b.id)
+  );
 }
 
 function compare(a: string, b: string): number {

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/constants.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/constants.ts
@@ -6,3 +6,6 @@ export const CACHE_REVALIDATE_SECONDS = process.env.VERCEL_ENV === "production" 
  * admin の公開アクションが webapp の /api/refresh を叩き、このタグを無効化する。
  */
 export const RESEARCH_FUND_CACHE_TAG = "research-fund-page-data";
+
+/** CSV のキャッシュキー。無効化は RESEARCH_FUND_CACHE_TAG で公開ページとまとめて行う。 */
+export const RESEARCH_FUND_CSV_CACHE_KEY = "research-fund-csv";

--- a/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-csv.ts
+++ b/webapp/src/server/contexts/research-fund/presentation/loaders/load-research-fund-csv.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import {
+  GetResearchFundCsvUsecase,
+  type GetResearchFundCsvParams,
+} from "@/server/contexts/research-fund/application/usecases/get-research-fund-csv-usecase";
+import { PrismaResearchFundRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-research-fund.repository";
+import {
+  CACHE_REVALIDATE_SECONDS,
+  RESEARCH_FUND_CACHE_TAG,
+  RESEARCH_FUND_CSV_CACHE_KEY,
+} from "@/server/contexts/research-fund/presentation/loaders/constants";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+/** 公開ページと同じタグでキャッシュし、admin が公開したら CSV も一緒に無効化されるようにする。 */
+export const loadResearchFundCsv = unstable_cache(
+  async (params: GetResearchFundCsvParams) => {
+    const usecase = new GetResearchFundCsvUsecase(new PrismaResearchFundRepository(prisma));
+    return await usecase.execute(params);
+  },
+  [RESEARCH_FUND_CSV_CACHE_KEY],
+  { revalidate: CACHE_REVALIDATE_SECONDS, tags: [RESEARCH_FUND_CACHE_TAG] },
+);

--- a/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-csv-usecase.test.ts
+++ b/webapp/tests/server/contexts/research-fund/application/usecases/get-research-fund-csv-usecase.test.ts
@@ -1,0 +1,59 @@
+import { GetResearchFundCsvUsecase } from "@/server/contexts/research-fund/application/usecases/get-research-fund-csv-usecase";
+import type { PublishedResearchFund } from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import type { ResearchFundRepository } from "@/server/contexts/research-fund/domain/repositories/research-fund-repository.interface";
+
+function published(): PublishedResearchFund {
+  return {
+    politician: { name: "サンプル 太郎", slug: "sample-taro" },
+    financialYear: 2026,
+    asOfDate: null,
+    nextUpdateNote: null,
+    policyComment: null,
+    details: null,
+    publishedThrough: null,
+    rows: [{ date: "2026-02-10", accountKey: "taxi", amount: 3_000, type: "expense" }],
+    accounts: { taxi: { label: "タクシー代", legalLabel: "⑨ 滞在費", legalCategoryKey: "stay" } },
+    expenses: [
+      {
+        id: "1",
+        entryId: "1",
+        date: "2026-02-10",
+        accountKey: "taxi",
+        description: "タクシー代",
+        amount: 3_000,
+        note: null,
+        splitGroup: null,
+        hasReceipt: true,
+      },
+    ],
+    groups: [],
+  };
+}
+
+function setup(value: PublishedResearchFund | null) {
+  const repository: ResearchFundRepository = {
+    findPublished: jest.fn().mockResolvedValue(value),
+    findPublishedReceipt: jest.fn().mockResolvedValue(null),
+  };
+  return { usecase: new GetResearchFundCsvUsecase(repository), repository };
+}
+
+describe("GetResearchFundCsvUsecase", () => {
+  it("published の支出を CSV にして返す", async () => {
+    const { usecase, repository } = setup(published());
+
+    const csv = await usecase.execute({ slug: "sample-taro", financialYear: 2026 });
+
+    expect(repository.findPublished).toHaveBeenCalledWith("sample-taro", 2026);
+    expect(csv?.split("\n")).toEqual([
+      '"日付","カテゴリー","法定区分","項目","金額","特記事項","分割グループ","領収書"',
+      '"2026-02-10","タクシー代","⑨ 滞在費","タクシー代","3000","","","あり"',
+    ]);
+  });
+
+  it("帳簿が無ければ null を返す", async () => {
+    const { usecase } = setup(null);
+
+    expect(await usecase.execute({ slug: "unknown", financialYear: 2026 })).toBeNull();
+  });
+});

--- a/webapp/tests/server/contexts/research-fund/domain/services/research-fund-csv.test.ts
+++ b/webapp/tests/server/contexts/research-fund/domain/services/research-fund-csv.test.ts
@@ -1,0 +1,114 @@
+import type {
+  PublishedAccount,
+  PublishedExpense,
+} from "@/server/contexts/research-fund/domain/models/published-research-fund";
+import {
+  buildResearchFundCsv,
+  researchFundCsvFilename,
+} from "@/server/contexts/research-fund/domain/services/research-fund-csv";
+
+const accounts: Record<string, PublishedAccount> = {
+  taxi: { label: "タクシー代", legalLabel: "⑨ 滞在費", legalCategoryKey: "stay" },
+  "stationery-supplies": {
+    label: "文房具・備品",
+    legalLabel: "③ 備品・消耗品費",
+    legalCategoryKey: "equipment-supplies",
+  },
+};
+
+function expense(overrides: Partial<PublishedExpense> = {}): PublishedExpense {
+  return {
+    id: "1",
+    entryId: "1",
+    date: "2026-04-23",
+    accountKey: "taxi",
+    description: "タクシー代",
+    amount: 1200,
+    note: null,
+    splitGroup: null,
+    hasReceipt: false,
+    ...overrides,
+  };
+}
+
+function lines(csv: string): string[] {
+  return csv.split("\n");
+}
+
+describe("buildResearchFundCsv", () => {
+  it("ヘッダーと1行分の値を出す", () => {
+    const csv = buildResearchFundCsv({
+      accounts,
+      expenses: [expense({ note: "会派で按分", splitGroup: "order-1", hasReceipt: true })],
+    });
+
+    expect(lines(csv)[0]).toBe(
+      '"日付","カテゴリー","法定区分","項目","金額","特記事項","分割グループ","領収書"',
+    );
+    expect(lines(csv)[1]).toBe(
+      '"2026-04-23","タクシー代","⑨ 滞在費","タクシー代","1200","会派で按分","order-1","あり"',
+    );
+  });
+
+  it("特記事項・分割グループが無ければ空欄、領収書が無ければ「なし」", () => {
+    const csv = buildResearchFundCsv({ accounts, expenses: [expense({ note: "   " })] });
+
+    expect(lines(csv)[1]).toBe(
+      '"2026-04-23","タクシー代","⑨ 滞在費","タクシー代","1200","","","なし"',
+    );
+  });
+
+  it("値に含まれる引用符を2つ重ねて表す", () => {
+    const csv = buildResearchFundCsv({
+      accounts,
+      expenses: [expense({ description: '書籍「"AI"入門」, 上巻' })],
+    });
+
+    expect(lines(csv)[1]).toContain('"書籍「""AI""入門」, 上巻"');
+    // 引用符で囲んでいるので、値の中のカンマで列がずれない。
+    expect(lines(csv)[1].split('","')).toHaveLength(8);
+  });
+
+  it("画面（B-4）と同じ並び順（日付の新しい順・同一注文はまとめる）で出す", () => {
+    const csv = buildResearchFundCsv({
+      accounts,
+      expenses: [
+        expense({ id: "10", date: "2026-04-01", splitGroup: "order-1" }),
+        expense({ id: "11", date: "2026-04-01" }),
+        expense({ id: "12", date: "2026-04-01", splitGroup: "order-1" }),
+        expense({ id: "13", date: "2026-05-01" }),
+      ],
+    });
+
+    expect(lines(csv).slice(1).map((line) => line.split(",")[0])).toEqual([
+      '"2026-05-01"',
+      '"2026-04-01"',
+      '"2026-04-01"',
+      '"2026-04-01"',
+    ]);
+  });
+
+  it("科目マスタに無い科目でも行を落とさない", () => {
+    const csv = buildResearchFundCsv({ accounts, expenses: [expense({ accountKey: "unknown" })] });
+
+    expect(lines(csv)[1]).toContain('"その他","その他"');
+  });
+
+  it("公開中の支出が無ければヘッダーだけを出す", () => {
+    expect(lines(buildResearchFundCsv({ accounts, expenses: [] }))).toHaveLength(1);
+  });
+});
+
+describe("researchFundCsvFilename", () => {
+  it("既存の取引 CSV に合わせて slug と日付を含める", () => {
+    expect(researchFundCsvFilename("sample-taro", 2026, new Date("2026-09-11T02:00:00Z"))).toBe(
+      "research_fund_sample-taro_2026_2026-09-11.csv",
+    );
+  });
+
+  it("ファイル名に使えない文字を落とす", () => {
+    expect(researchFundCsvFilename('a"; b', 2026, new Date("2026-09-11T02:00:00Z"))).toBe(
+      "research_fund_a---b_2026_2026-09-11.csv",
+    );
+  });
+});


### PR DESCRIPTION
## 目的（Why）

調研費のページを見た市民・記者が、公開されている支出を画面で1件ずつ追うしかない状態を解消するため。既存の政治資金と同様に、機械可読な形で持ち帰れるようにする。

## 変更内容

- 議員ページ（B-4「すべての支出」）に「すべての支出をCSVでダウンロード」のリンクを追加。月の切り替えとは独立に、その年度の published の全支出が落ちてくる
- `GET /api/research-fund/csv/[slug]/[year]` を追加（領収書配信と同じくルートハンドラ。公開ページと同じキャッシュタグに載せ、admin の公開で一緒に無効化される）
- CSV の組み立ては domain サービス（`research-fund-csv.ts`）。列は 日付・カテゴリー・法定区分・項目・金額・特記事項・分割グループ・領収書
  - 公開ページと同じ published の射影（`findPublished`）から作るので、**未公開の仕訳と備考（memo）は構造的に入らない**（memo はそもそも repository の select に無い）
  - 並びは画面（B-4）と共通の比較関数に切り出して共有（日付の新しい順・同一注文はまとめる）
  - 既存の取引 CSV と同じ UTF-8 + BOM、`research_fund_<slug>_<年度>_<日付>.csv`
- ユニットテスト（CSV 組み立て・ファイル名・usecase）と E2E（リンク表示・ヘッダー・BOM・未公開が混ざらないこと）を追加

## やらないこと（Issue の Out of scope 通り）

- 領収書ファイルの一括ダウンロード
- 政党単位の CSV

## ローカル CI

- `pnpm verify` ✅（webapp のテストは Test Suites 26 passed / Tests 177 passed。type-check / lint / knip / depcruise も green）
- `pnpm --filter webapp test:e2e` ✅ 追加した CSV の E2E を含め green。1件だけ `transactions.spec.ts` のソート状態のテストが落ちたが、本 PR と無関係な箇所で、単体で再実行すると 3 passed（フレーク）

スコープアウトして起票した Issue はありません。

Closes #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 議員ページから、公開中の全支出をCSV形式でダウンロードできるようになりました。
  * CSVには支出の詳細、領収書の有無、分割情報などが含まれます。
  * 未公開の支出はダウンロード対象に含まれません。
  * CSVファイル名に議員識別子、年度、作成日時が反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->