### PR TITLE
feat(admin): 書類スキャン画面（アップロード → バッチ・ジョブ一覧）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,10 +287,10 @@ jobs:
       - name: Start Supabase (background)
         run: |
           # admin E2E が必要とするのは db / kong / gotrue（認証）/ postgrest（疎通確認）と、
-          # gotrue の SMTP 先である mailpit のみ。storage-api（pull が最も遅い）・realtime・
-          # postgres-meta（studio 専用）・logflare（analytics）は使わないので除外する。
+          # gotrue の SMTP 先である mailpit、書類スキャンが原本を置く storage-api のみ。
+          # imgproxy・realtime・postgres-meta（studio 専用）・logflare（analytics）は使わないので除外する。
           nohup bash -c '
-            supabase start --exclude imgproxy,edge-runtime,vector,studio,storage-api,realtime,postgres-meta,logflare
+            supabase start --exclude imgproxy,edge-runtime,vector,studio,realtime,postgres-meta,logflare
             echo $? > /tmp/supabase-start.exit
           ' > /tmp/supabase-start.log 2>&1 &
 

--- a/admin/e2e/tests/scan.spec.ts
+++ b/admin/e2e/tests/scan.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+import { clickUntil } from "../helpers/interactions";
+
+// 1x1 の JPEG。E2E ではバイナリの中身は問われないので、リポジトリに置かず生成する
+const JPEG = Buffer.from(
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q==",
+  "base64",
+);
+const PDF = Buffer.from("%PDF-1.4\n%%EOF\n", "utf8");
+
+async function attach(page: import("@playwright/test").Page, files: { name: string; mimeType: string; buffer: Buffer }[]) {
+  await page.getByLabel("領収書・請求書").setInputFiles(files);
+}
+
+test("プロンプト保存後に書類をアップロードすると、バッチと待機中のジョブが並ぶ", async ({ page }) => {
+  const name = `e2e-scan-${Date.now()}`;
+  await page.goto("/politicians/new");
+  await page.getByLabel("氏名").fill(name);
+  await page.getByLabel("スラッグ").fill(name);
+  await page.getByLabel("当選日").fill("2026-02-08");
+  await page.getByRole("button", { name: "作成", exact: true }).click();
+  await expect(page).toHaveURL("/politicians");
+  const politicianCard = page
+    .locator('[data-slot="card"]')
+    .filter({ has: page.getByRole("heading", { name, exact: true }) });
+  await politicianCard.getByRole("link", { name: "年度帳簿" }).click();
+  await page.getByLabel(/^年度/).fill("2026");
+  await page.getByRole("button", { name: "帳簿を作成" }).click();
+  await expect(page.getByRole("heading", { name: "2026年度" })).toBeVisible();
+  await page.getByRole("button", { name: "現在の対象を切り替え" }).click();
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "load" }),
+    page.getByRole("button", { name: `${name}／2026年度` }).click(),
+  ]);
+
+  // 有効なプロンプト版が無いうちはアップロードできない（ジョブが版を必須で記録するため）
+  await page.getByRole("link", { name: "書類スキャン" }).click();
+  await expect(page.getByRole("heading", { name: "書類スキャン" })).toBeVisible();
+  await expect(page.getByText(`${name} ／ 2026年度 の帳簿に追加されます`)).toBeVisible();
+  await expect(page.getByRole("button", { name: "ファイルを選ぶ" })).toBeDisabled();
+  await expect(page.getByText("読み取りプロンプトがまだ保存されていません")).toBeVisible();
+  await expect(page.getByText("まだバッチがありません。")).toBeVisible();
+
+  await page.getByRole("link", { name: "読み取りプロンプト" }).click();
+  await clickUntil(page.getByRole("button", { name: "保存して v1 にする" }), (options) =>
+    expect(page.getByText("v1 有効")).toBeVisible(options),
+  );
+
+  await page.getByRole("link", { name: "書類スキャン" }).click();
+  await expect(page.getByRole("button", { name: "ファイルを選ぶ" })).toBeEnabled();
+
+  await attach(page, [
+    { name: "IMG_4102.jpg", mimeType: "image/jpeg", buffer: JPEG },
+    { name: "invoice_openai_08.pdf", mimeType: "application/pdf", buffer: PDF },
+  ]);
+
+  // アップロードした書類が 1書類=1ジョブで、すべて待機中として並ぶ
+  const batch = page.locator('[data-slot="card"]').filter({ hasText: "のバッチ" });
+  await expect(batch).toBeVisible();
+  await expect(batch).toContainText("2件中 0件完了・0件失敗");
+  const jobs = batch.getByRole("row").filter({ hasText: /IMG_4102\.jpg|invoice_openai_08\.pdf/ });
+  await expect(jobs).toHaveCount(2);
+  await expect(jobs.filter({ hasText: "IMG_4102.jpg" })).toContainText("待機中");
+  await expect(jobs.filter({ hasText: "invoice_openai_08.pdf" })).toContainText("待機中");
+  await expect(batch.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
+  await expect(page.getByText("プロンプト v1")).toBeVisible();
+
+  // 保存済みのバッチは再読み込み後も残る
+  await page.reload();
+  await expect(batch.getByRole("row").filter({ hasText: "IMG_4102.jpg" })).toBeVisible();
+
+  // 対応外の形式・31枚以上はアップロード前に弾く
+  await attach(page, [
+    { name: "memo.txt", mimeType: "text/plain", buffer: Buffer.from("memo", "utf8") },
+  ]);
+  await expect(page.getByText("JPG・PNG・PDFのみアップロードできます（memo.txt）")).toBeVisible();
+  await attach(
+    page,
+    Array.from({ length: 31 }, (_, index) => ({
+      name: `IMG_${index}.jpg`,
+      mimeType: "image/jpeg",
+      buffer: JPEG,
+    })),
+  );
+  await expect(
+    page.getByText("1回にアップロードできるのは30枚までです（31枚が選ばれています）"),
+  ).toBeVisible();
+  // 弾かれた分はバッチを増やさない
+  await expect(page.locator('[data-slot="card"]').filter({ hasText: "のバッチ" })).toHaveCount(1);
+});

--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/scan/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/scan/page.tsx
@@ -1,0 +1,12 @@
+import { DocumentScan } from "@/client/components/research-fund/DocumentScan";
+import { loadScan } from "@/server/contexts/research-fund/presentation/loaders/load-scan";
+
+export default async function ScanPage({
+  params,
+}: {
+  params: Promise<{ id: string; bookId: string }>;
+}) {
+  const { id, bookId } = await params;
+  const data = await loadScan(id, bookId);
+  return <DocumentScan {...data} />;
+}

--- a/admin/src/client/components/research-fund/DocumentScan.tsx
+++ b/admin/src/client/components/research-fund/DocumentScan.tsx
@@ -1,0 +1,260 @@
+"use client";
+import { useRef, useState, useTransition, type DragEvent } from "react";
+import { useRouter } from "next/navigation";
+import {
+  FileArrowUp,
+  FilePdf,
+  Image as ImageIcon,
+  UploadSimple,
+} from "@phosphor-icons/react/dist/ssr";
+import { toast } from "sonner";
+import { PageHeader } from "@/client/components/layout/PageHeader";
+import {
+  Button,
+  Card,
+  CardContent,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/client/components/ui";
+import { cn } from "@/client/lib";
+import {
+  SCAN_BATCH_MAX_DOCUMENTS,
+  SCAN_DOCUMENT_MIME_TYPES,
+  type ScanJobStatus,
+  type ScanOverview,
+} from "@/server/contexts/research-fund/domain/models/scan-batch";
+import { createScanBatch } from "@/server/contexts/research-fund/presentation/actions/create-scan-batch";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+
+const STATUS_LABELS: Record<ScanJobStatus, string> = {
+  queued: "待機中",
+  running: "処理中",
+  succeeded: "完了",
+  failed: "失敗",
+};
+
+const STATUS_STYLES: Record<ScanJobStatus, string> = {
+  queued: "border-border-soft text-muted-foreground",
+  running: "border-ring text-accent-foreground",
+  succeeded: "border-primary bg-primary text-primary-foreground",
+  failed: "border-destructive bg-destructive text-white",
+};
+
+function formatDate(isoDate: string) {
+  return isoDate.slice(0, 10).replaceAll("-", ".");
+}
+
+/** アップロード前に弾く理由。通れば null */
+function rejectionReason(files: File[]): string | null {
+  if (files.length === 0) return "書類を1枚以上選んでください";
+  if (files.length > SCAN_BATCH_MAX_DOCUMENTS)
+    return `1回にアップロードできるのは${SCAN_BATCH_MAX_DOCUMENTS}枚までです（${files.length}枚が選ばれています）`;
+  const unsupported = files.filter(
+    (file) => !(SCAN_DOCUMENT_MIME_TYPES as readonly string[]).includes(file.type),
+  );
+  if (unsupported.length > 0)
+    return `JPG・PNG・PDFのみアップロードできます（${unsupported[0].name}）`;
+  return null;
+}
+
+export function DocumentScan({
+  batches,
+  activePromptVersion,
+  model,
+  target,
+}: ScanOverview & { target: Extract<AdminTarget, { kind: "research-fund" }> }) {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const ready = activePromptVersion !== null;
+
+  function upload(files: File[]) {
+    if (inputRef.current) inputRef.current.value = "";
+    const reason = rejectionReason(files);
+    if (reason) {
+      toast.error(reason);
+      return;
+    }
+    const formData = new FormData();
+    for (const file of files) formData.append("documents", file);
+    startTransition(async () => {
+      try {
+        const result = await createScanBatch(target.politicianId, target.bookId, formData);
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success(`${result.count}件の書類を読み取り待ちに追加しました`);
+        router.refresh();
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
+
+  function handleDrop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    setDragging(false);
+    if (pending || !ready) return;
+    upload([...(event.dataTransfer.files ?? [])]);
+  }
+
+  return (
+    <>
+      <PageHeader
+        label="Scan"
+        title="書類スキャン"
+        description="領収書の写真やPDFをまとめてアップロードすると、順番に読み取って下書き仕訳を作ります。"
+      />
+      <div className="flex flex-col gap-5">
+        <Card className="max-w-3xl">
+          <CardContent className="p-6">
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: ドロップ先の領域。操作は内側の button / input が担う */}
+            <div
+              data-slot="scan-dropzone"
+              data-dragging={dragging || undefined}
+              onDragOver={(event) => {
+                event.preventDefault();
+                if (!pending && ready) setDragging(true);
+              }}
+              onDragLeave={(event) => {
+                event.preventDefault();
+                setDragging(false);
+              }}
+              onDrop={handleDrop}
+              className={cn(
+                "flex flex-col items-center gap-2 rounded-lg border-[1.5px] border-dashed border-primary bg-accent px-5 py-9 text-center transition-colors duration-150 ease-out",
+                dragging && "border-primary-active bg-teal-soft/30",
+                (pending || !ready) && "border-disabled-border bg-secondary",
+              )}
+            >
+              <UploadSimple aria-hidden className="size-8 text-primary-active" />
+              <span className="rounded-full bg-accent px-3.5 py-1 text-xs font-bold text-primary-active">
+                {target.name} ／ {target.year}年度 の帳簿に追加されます
+              </span>
+              <p className="text-sm font-bold text-foreground">ここに領収書・請求書をドロップ</p>
+              <p className="text-xs text-muted-foreground">
+                JPG / PNG / PDF ・ 1回に最大{SCAN_BATCH_MAX_DOCUMENTS}枚 ・ スマホ写真もそのままでOK
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-1.5 text-xs"
+                disabled={pending || !ready}
+                onClick={() => inputRef.current?.click()}
+              >
+                {pending ? "アップロード中…" : "ファイルを選ぶ"}
+              </Button>
+              <input
+                ref={inputRef}
+                type="file"
+                multiple
+                accept={SCAN_DOCUMENT_MIME_TYPES.join(",")}
+                aria-label="領収書・請求書"
+                className="sr-only"
+                disabled={pending || !ready}
+                onChange={(event) => upload([...(event.target.files ?? [])])}
+              />
+            </div>
+            {!ready && (
+              <p className="mt-4 text-sm text-destructive">
+                読み取りプロンプトがまだ保存されていません。「読み取りプロンプト」で保存すると、アップロードできるようになります。
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {batches.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            まだバッチがありません。書類をアップロードするとここに並びます。
+          </p>
+        ) : (
+          batches.map((batch) => (
+            <Card key={batch.id}>
+              <CardContent className="p-6">
+                <div className="mb-1.5 flex flex-wrap items-center justify-between gap-3">
+                  <h2 className="font-bold">
+                    <span className="font-latin">{formatDate(batch.createdAt)}</span> のバッチ
+                    <span className="ml-2 text-[13px] font-normal text-muted-foreground">
+                      {batch.progress.total}件中 {batch.progress.succeeded}件完了・
+                      {batch.progress.failed}件失敗
+                    </span>
+                  </h2>
+                </div>
+                <div
+                  role="progressbar"
+                  aria-label="読み取りの進捗"
+                  aria-valuenow={batch.progress.percent}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  className="mb-4 h-1.5 overflow-hidden rounded-full bg-secondary"
+                >
+                  <div
+                    className="h-full bg-primary"
+                    style={{ width: `${batch.progress.percent}%` }}
+                  />
+                </div>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>ファイル</TableHead>
+                      <TableHead>状態</TableHead>
+                      <TableHead>抽出結果</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {batch.jobs.map((job) => (
+                      <TableRow key={job.id}>
+                        <TableCell className="whitespace-nowrap">
+                          <span className="inline-flex items-center gap-2">
+                            {job.mime === "application/pdf" ? (
+                              <FilePdf aria-hidden className="size-4 text-muted-foreground" />
+                            ) : (
+                              <ImageIcon aria-hidden className="size-4 text-muted-foreground" />
+                            )}
+                            <span className="font-latin text-xs">{job.originalFilename}</span>
+                          </span>
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap">
+                          <span
+                            className={cn(
+                              "inline-block rounded-full border px-3 py-0.5 text-xs font-medium",
+                              STATUS_STYLES[job.status],
+                            )}
+                          >
+                            {STATUS_LABELS[job.status]}
+                          </span>
+                        </TableCell>
+                        <TableCell
+                          className={cn(
+                            "text-[13px]",
+                            job.status === "failed" ? "text-destructive" : "text-muted-foreground",
+                          )}
+                        >
+                          {job.status === "failed"
+                            ? (job.error ?? "読み取りに失敗しました")
+                            : (job.summary ?? "—")}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          ))
+        )}
+        <p className="flex items-center gap-1.5 text-[11.5px] text-subtle-foreground">
+          <FileArrowUp aria-hidden className="size-4" />
+          読み取りは議員室のプロンプト
+          {activePromptVersion === null ? "（未保存）" : ` v${activePromptVersion}`} ＋{" "}
+          <span className="font-latin">{model}</span>。原文JSONは各ジョブに保存されます。
+        </p>
+      </div>
+    </>
+  );
+}

--- a/admin/src/server/contexts/research-fund/application/usecases/manage-scan-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/manage-scan-usecase.ts
@@ -64,12 +64,14 @@ export class ManageScanUsecase {
       );
 
     const uploaded: string[] = [];
+    let cleanedUp = false;
     try {
       const documents = [];
       for (const document of input.documents) {
         const result = await this.storage.upload(document.bytes, document.mime);
         // 事前検証を通ったので通常は起きないが、起きたら残りをアップロードせず片付ける
         if (result.status === "invalid") {
+          cleanedUp = true;
           await this.discard(uploaded, new ScanBatchError("書類のアップロードに失敗しました"));
           return result;
         }
@@ -89,8 +91,8 @@ export class ManageScanUsecase {
       });
       return { status: "valid", value: { batchId } };
     } catch (error) {
-      // 保存に失敗したら、先にアップロードした原本を残さない
-      await this.discard(uploaded, error);
+      // 保存に失敗したら、先にアップロードした原本を残さない（片付け済みなら再実行しない）
+      if (!cleanedUp) await this.discard(uploaded, error);
       throw error;
     }
   }

--- a/admin/src/server/contexts/research-fund/application/usecases/manage-scan-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/manage-scan-usecase.ts
@@ -1,0 +1,113 @@
+import "server-only";
+import { ResearchFundDocument } from "@/server/contexts/research-fund/domain/models/document";
+import {
+  ScanBatchError,
+  summarizeScanBatch,
+  validateScanUpload,
+  type ScanOverview,
+} from "@/server/contexts/research-fund/domain/models/scan-batch";
+import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
+import type { PromptRepository } from "@/server/contexts/research-fund/domain/repositories/prompt-repository.interface";
+import type { ScanRepository } from "@/server/contexts/research-fund/domain/repositories/scan-repository.interface";
+import type { ResearchFundResult } from "@/server/contexts/research-fund/domain/types/validation";
+
+interface UploadedDocument {
+  bytes: Uint8Array;
+  mime: string;
+  originalFilename: string;
+}
+
+export class ManageScanUsecase {
+  constructor(
+    private scanRepository: ScanRepository,
+    private promptRepository: PromptRepository,
+    private storage: DocumentStorage,
+    private model: string,
+  ) {}
+
+  async list(politicianId: string, bookId: string): Promise<ScanOverview> {
+    const [batches, prompt] = await Promise.all([
+      this.scanRepository.listBatches(bookId),
+      this.promptRepository.findActive(politicianId),
+    ]);
+    return {
+      batches: batches.map((batch) => ({ ...batch, progress: summarizeScanBatch(batch.jobs) })),
+      activePromptVersion: prompt?.version ?? null,
+      model: this.model,
+    };
+  }
+
+  /**
+   * 書類を Storage に保存し、バッチと queued ジョブ（1書類=1ジョブ）を作る。
+   * ジョブの実行（LLM 呼び出し）はここでは行わない。
+   */
+  async createBatch(input: {
+    politicianId: string;
+    bookId: string;
+    userId: string;
+    documents: UploadedDocument[];
+  }): Promise<ResearchFundResult<{ batchId: string }>> {
+    for (const result of [
+      ResearchFundDocument.validateId(input.bookId),
+      validateScanUpload(input.documents),
+      ...input.documents.flatMap((document) => [
+        ResearchFundDocument.validateFile(document.bytes, document.mime),
+        ResearchFundDocument.validateFilename(document.originalFilename),
+      ]),
+    ]) {
+      if (result.status === "invalid") return result;
+    }
+    const prompt = await this.promptRepository.findActive(input.politicianId);
+    if (!prompt)
+      throw new ScanBatchError(
+        "読み取りプロンプトが未保存です。「読み取りプロンプト」から保存してください",
+      );
+
+    const uploaded: string[] = [];
+    try {
+      const documents = [];
+      for (const document of input.documents) {
+        const result = await this.storage.upload(document.bytes, document.mime);
+        // 事前検証を通ったので通常は起きないが、起きたら残りをアップロードせず片付ける
+        if (result.status === "invalid") {
+          await this.discard(uploaded, new ScanBatchError("書類のアップロードに失敗しました"));
+          return result;
+        }
+        uploaded.push(result.value);
+        documents.push({
+          storageKey: result.value,
+          mime: document.mime,
+          originalFilename: document.originalFilename,
+        });
+      }
+      const batchId = await this.scanRepository.createBatch({
+        bookId: input.bookId,
+        uploadedById: input.userId,
+        promptId: prompt.id,
+        model: this.model,
+        documents,
+      });
+      return { status: "valid", value: { batchId } };
+    } catch (error) {
+      // 保存に失敗したら、先にアップロードした原本を残さない
+      await this.discard(uploaded, error);
+      throw error;
+    }
+  }
+
+  private async discard(storageKeys: string[], cause: unknown): Promise<void> {
+    const failures: unknown[] = [];
+    for (const storageKey of storageKeys) {
+      try {
+        await this.storage.remove(storageKey);
+      } catch (cleanupError) {
+        failures.push(cleanupError);
+      }
+    }
+    if (failures.length > 0)
+      throw new AggregateError(
+        [cause, ...failures],
+        "バッチの作成とアップロード済み原本の削除に失敗しました",
+      );
+  }
+}

--- a/admin/src/server/contexts/research-fund/domain/models/scan-batch.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/scan-batch.ts
@@ -1,0 +1,92 @@
+import {
+  invalidResearchFundResult,
+  RF_ERROR_CODES,
+  type ResearchFundResult,
+} from "@/server/contexts/research-fund/domain/types/validation";
+
+/** 1 回のアップロードで受け付けられる書類の上限（デザイン: 「1回に最大30枚」） */
+export const SCAN_BATCH_MAX_DOCUMENTS = 30;
+
+export const SCAN_DOCUMENT_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf"] as const;
+
+/** prisma の ResearchFundScanJobStatus と同じ語彙。画面のピルはこの 4 状態だけを扱う */
+export type ScanJobStatus = "queued" | "running" | "succeeded" | "failed";
+
+export interface ScanJobView {
+  id: string;
+  status: ScanJobStatus;
+  originalFilename: string;
+  mime: string;
+  /** 抽出結果の要約。まだ読み取っていなければ null */
+  summary: string | null;
+  error: string | null;
+}
+
+export interface ScanBatchView {
+  id: string;
+  /** ISO 8601。画面では YYYY.MM.DD で表示する */
+  createdAt: string;
+  jobs: ScanJobView[];
+}
+
+export interface ScanBatchProgress {
+  total: number;
+  succeeded: number;
+  failed: number;
+  /** 0〜100 の整数。完了（成功・失敗いずれも）した割合 */
+  percent: number;
+}
+
+export interface ScanOverview {
+  batches: (ScanBatchView & { progress: ScanBatchProgress })[];
+  /** ジョブに記録される有効なプロンプト版。未保存なら null（アップロードできない） */
+  activePromptVersion: number | null;
+  /** 読み取りに使うモデル名。画面の注記に出す */
+  model: string;
+}
+
+export class ScanBatchError extends Error {}
+
+export function summarizeScanBatch(jobs: ScanJobView[]): ScanBatchProgress {
+  const succeeded = jobs.filter((job) => job.status === "succeeded").length;
+  const failed = jobs.filter((job) => job.status === "failed").length;
+  return {
+    total: jobs.length,
+    succeeded,
+    failed,
+    percent: jobs.length === 0 ? 0 : Math.round(((succeeded + failed) / jobs.length) * 100),
+  };
+}
+
+/**
+ * アップロードされた書類の枚数と形式を、Storage に触れる前に検証する。
+ * 1 枚ごとの中身（空でないか・MIME が対応形式か）は ResearchFundDocument が見る。
+ */
+export function validateScanUpload(documents: { mime: string }[]): ResearchFundResult<undefined> {
+  if (documents.length === 0) {
+    return invalidResearchFundResult(
+      "documents",
+      RF_ERROR_CODES.INVALID_DOCUMENT,
+      "書類を1枚以上選んでください",
+    );
+  }
+  if (documents.length > SCAN_BATCH_MAX_DOCUMENTS) {
+    return invalidResearchFundResult(
+      "documents",
+      RF_ERROR_CODES.INVALID_DOCUMENT,
+      `1回にアップロードできるのは${SCAN_BATCH_MAX_DOCUMENTS}枚までです`,
+    );
+  }
+  if (
+    documents.some(
+      (document) => !(SCAN_DOCUMENT_MIME_TYPES as readonly string[]).includes(document.mime),
+    )
+  ) {
+    return invalidResearchFundResult(
+      "documents",
+      RF_ERROR_CODES.INVALID_DOCUMENT,
+      "JPG・PNG・PDFのみアップロードできます",
+    );
+  }
+  return { status: "valid", value: undefined };
+}

--- a/admin/src/server/contexts/research-fund/domain/repositories/prompt-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/prompt-repository.interface.ts
@@ -7,4 +7,6 @@ export interface PromptRepository {
   create(politicianId: string, body: string, userId: string): Promise<number>;
   /** 既存の版を有効版にする（新しい版は作らない） */
   activate(politicianId: string, version: number): Promise<void>;
+  /** 有効版を返す。1 版も保存されていなければ null */
+  findActive(politicianId: string): Promise<PromptRecord | null>;
 }

--- a/admin/src/server/contexts/research-fund/domain/repositories/scan-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/scan-repository.interface.ts
@@ -1,0 +1,17 @@
+import type { ScanBatchView } from "@/server/contexts/research-fund/domain/models/scan-batch";
+
+export interface CreateScanBatchInput {
+  bookId: string;
+  uploadedById: string;
+  promptId: string;
+  model: string;
+  /** Storage に保存済みの書類。並び順がジョブの並び順になる */
+  documents: { storageKey: string; mime: string; originalFilename: string }[];
+}
+
+export interface ScanRepository {
+  /** バッチ・書類・queued ジョブを 1 トランザクションで作る。作ったバッチ ID を返す */
+  createBatch(input: CreateScanBatchInput): Promise<string>;
+  /** 帳簿のバッチを新しい順に返す */
+  listBatches(bookId: string): Promise<ScanBatchView[]>;
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { Prisma, type PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient, type ResearchFundPrompt } from "@prisma/client";
 import {
   PromptError,
   type PromptRecord,
@@ -15,14 +15,7 @@ export class PrismaPromptRepository implements PromptRepository {
       orderBy: { version: "desc" },
       include: { _count: { select: { scanJobs: true } } },
     });
-    return rows.map((row) => ({
-      id: String(row.id),
-      version: row.version,
-      body: row.body,
-      isActive: row.isActive,
-      updatedAt: row.updatedAt.toISOString(),
-      jobCount: row._count.scanJobs,
-    }));
+    return rows.map(toPromptRecord);
   }
 
   async create(politicianId: string, body: string, userId: string): Promise<number> {
@@ -67,4 +60,26 @@ export class PrismaPromptRepository implements PromptRepository {
       await tx.researchFundPrompt.update({ where: { id: target.id }, data: { isActive: true } });
     });
   }
+
+  async findActive(politicianId: string): Promise<PromptRecord | null> {
+    const row = await this.prisma.researchFundPrompt.findFirst({
+      where: { politicianId: BigInt(politicianId), isActive: true },
+      orderBy: { version: "desc" },
+      include: { _count: { select: { scanJobs: true } } },
+    });
+    return row ? toPromptRecord(row) : null;
+  }
+}
+
+type PromptRow = ResearchFundPrompt & { _count: { scanJobs: number } };
+
+function toPromptRecord(row: PromptRow): PromptRecord {
+  return {
+    id: String(row.id),
+    version: row.version,
+    body: row.body,
+    isActive: row.isActive,
+    updatedAt: row.updatedAt.toISOString(),
+    jobCount: row._count.scanJobs,
+  };
 }

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.ts
@@ -1,0 +1,91 @@
+import "server-only";
+import type { PrismaClient } from "@prisma/client";
+import type {
+  ScanBatchView,
+  ScanJobStatus,
+} from "@/server/contexts/research-fund/domain/models/scan-batch";
+import type {
+  CreateScanBatchInput,
+  ScanRepository,
+} from "@/server/contexts/research-fund/domain/repositories/scan-repository.interface";
+
+export class PrismaScanRepository implements ScanRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async createBatch(input: CreateScanBatchInput): Promise<string> {
+    const bookId = BigInt(input.bookId);
+    return await this.prisma.$transaction(async (tx) => {
+      const batch = await tx.researchFundScanBatch.create({
+        data: { bookId, uploadedById: input.uploadedById },
+      });
+      // 1書類=1ジョブ。使ったプロンプト版とモデルをジョブに記録する
+      for (const document of input.documents) {
+        const created = await tx.researchFundDocument.create({
+          data: {
+            bookId,
+            batchId: batch.id,
+            storageKey: document.storageKey,
+            mime: document.mime,
+            originalFilename: document.originalFilename,
+          },
+        });
+        await tx.researchFundScanJob.create({
+          data: {
+            batchId: batch.id,
+            documentId: created.id,
+            promptId: BigInt(input.promptId),
+            model: input.model,
+          },
+        });
+      }
+      return batch.id.toString();
+    });
+  }
+
+  async listBatches(bookId: string): Promise<ScanBatchView[]> {
+    const rows = await this.prisma.researchFundScanBatch.findMany({
+      where: { bookId: BigInt(bookId) },
+      orderBy: { id: "desc" },
+      include: {
+        jobs: {
+          orderBy: { id: "asc" },
+          include: {
+            document: { select: { originalFilename: true, mime: true } },
+          },
+        },
+      },
+    });
+    return rows.map((row) => ({
+      id: row.id.toString(),
+      createdAt: row.createdAt.toISOString(),
+      jobs: row.jobs.map((job) => ({
+        id: job.id.toString(),
+        status: job.status as ScanJobStatus,
+        originalFilename: job.document.originalFilename,
+        mime: job.document.mime,
+        summary: summarizeRawJson(job.rawJson),
+        error: job.error,
+      })),
+    }));
+  }
+}
+
+/**
+ * 抽出結果の要約列に出す 1 行。読み取りは #1365 で実装するので、いまは保存済みの原文 JSON
+ * （`{ date, items: [{ item, amount }] }`）から表示できる範囲だけを拾い、読めなければ null を返す。
+ */
+function summarizeRawJson(rawJson: unknown): string | null {
+  if (!isRecord(rawJson)) return null;
+  const items = Array.isArray(rawJson.items) ? rawJson.items.filter(isRecord) : [];
+  const head = items[0];
+  if (!head) return null;
+  const item = typeof head.item === "string" ? head.item : "明細";
+  const amount = typeof head.amount === "number" ? `¥${head.amount.toLocaleString("ja-JP")}` : "";
+  const rest = items.length > 1 ? ` ほか${items.length - 1}件` : "";
+  const date = typeof rawJson.date === "string" ? `${rawJson.date.replaceAll("-", ".")}・` : "";
+  return `${date}${item}${amount ? ` ${amount}` : ""}${rest}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/admin/src/server/contexts/research-fund/infrastructure/storage/document-bucket.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/storage/document-bucket.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+/** 領収書原本を置く非公開バケットの既定名。ローカルは supabase/config.toml が同名で定義する */
+const DEFAULT_BUCKET = "private-receipts";
+
+/**
+ * 領収書原本の非公開バケット名。
+ * 本番は Vercel の RESEARCH_FUND_DOCUMENT_BUCKET で上書きする（#1346）。
+ */
+export function researchFundDocumentBucket(): string {
+  return process.env.RESEARCH_FUND_DOCUMENT_BUCKET?.trim() || DEFAULT_BUCKET;
+}

--- a/admin/src/server/contexts/research-fund/presentation/actions/create-scan-batch.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/create-scan-batch.ts
@@ -1,0 +1,56 @@
+"use server";
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import {
+  ScanBatchError,
+  SCAN_BATCH_MAX_DOCUMENTS,
+} from "@/server/contexts/research-fund/domain/models/scan-batch";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { buildScanUsecase } from "@/server/contexts/research-fund/presentation/loaders/load-scan";
+
+/**
+ * 書類をアップロードしてバッチと queued ジョブを作る。
+ * File はサーバーアクションの境界を越えられるが、Uint8Array に読み出してから usecase に渡す。
+ */
+export async function createScanBatch(politicianId: string, bookId: string, formData: FormData) {
+  const user = await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  const files = formData
+    .getAll("documents")
+    .filter((entry): entry is File => entry instanceof File);
+  if (files.length === 0) return { success: false as const, error: "書類を1枚以上選んでください" };
+  if (files.length > SCAN_BATCH_MAX_DOCUMENTS)
+    return {
+      success: false as const,
+      error: `1回にアップロードできるのは${SCAN_BATCH_MAX_DOCUMENTS}枚までです`,
+    };
+  try {
+    const documents = await Promise.all(
+      files.map(async (file) => ({
+        bytes: new Uint8Array(await file.arrayBuffer()),
+        mime: file.type,
+        originalFilename: file.name,
+      })),
+    );
+    const result = await buildScanUsecase().createBatch({
+      politicianId,
+      bookId,
+      userId: user.id,
+      documents,
+    });
+    if (result.status === "invalid")
+      return { success: false as const, error: result.errors[0].message };
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const, batchId: result.value.batchId, count: documents.length };
+  } catch (error) {
+    return {
+      success: false as const,
+      error:
+        error instanceof ScanBatchError
+          ? error.message
+          : "書類のアップロードに失敗しました。時間をおいて再度お試しください",
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-scan.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-scan.ts
@@ -1,0 +1,33 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { createClient } from "@supabase/supabase-js";
+import { ManageScanUsecase } from "@/server/contexts/research-fund/application/usecases/manage-scan-usecase";
+import { PrismaPromptRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository";
+import { PrismaScanRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository";
+import { SupabaseDocumentStorage } from "@/server/contexts/research-fund/infrastructure/storage/supabase-document-storage";
+import { researchFundDocumentBucket } from "@/server/contexts/research-fund/infrastructure/storage/document-bucket";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export function buildScanUsecase(): ManageScanUsecase {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error("領収書ストレージが未設定です");
+  const client = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  return new ManageScanUsecase(
+    new PrismaScanRepository(prisma),
+    new PrismaPromptRepository(prisma),
+    new SupabaseDocumentStorage(client, researchFundDocumentBucket()),
+    // 読み取りの実行は #1365。ここでは作成時点のモデル名をジョブに記録するだけ
+    process.env.RESEARCH_FUND_EXTRACTION_MODEL?.trim() || "claude-sonnet-5",
+  );
+}
+
+export async function loadScan(politicianId: string, bookId: string) {
+  const target = await requireJournalTarget(politicianId, bookId);
+  if (!target) notFound();
+  const data = await buildScanUsecase().list(target.politicianId, bookId);
+  return { ...data, target };
+}

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-prompt-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-prompt-usecase.test.ts
@@ -3,7 +3,7 @@ import type { PromptRecord } from "@/server/contexts/research-fund/domain/models
 import type { PromptRepository } from "@/server/contexts/research-fund/domain/repositories/prompt-repository.interface";
 import { DEFAULT_OFFICE_PROMPT, buildAutomaticReceiptPrompt } from "@/server/contexts/research-fund/domain/services/receipt-extraction-prompt";
 function setup() {
-  const repository: jest.Mocked<PromptRepository> = { list: jest.fn(), create: jest.fn(), activate: jest.fn() };
+  const repository: jest.Mocked<PromptRepository> = { list: jest.fn(), create: jest.fn(), activate: jest.fn(), findActive: jest.fn() };
   return { repository, usecase: new ManagePromptUsecase(repository) };
 }
 function record(version: number, body: string, isActive: boolean): PromptRecord {

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-scan-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-scan-usecase.test.ts
@@ -2,6 +2,7 @@ import { ManageScanUsecase } from "@/server/contexts/research-fund/application/u
 import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
 import type { PromptRepository } from "@/server/contexts/research-fund/domain/repositories/prompt-repository.interface";
 import type { ScanRepository } from "@/server/contexts/research-fund/domain/repositories/scan-repository.interface";
+import { RF_ERROR_CODES } from "@/server/contexts/research-fund/domain/types/validation";
 
 const ACTIVE_PROMPT = {
   id: "7",
@@ -124,6 +125,28 @@ describe("ManageScanUsecase", () => {
         .mockResolvedValueOnce({ status: "valid", value: "key-1" })
         .mockRejectedValueOnce(new Error("upload failed"));
       await expect(usecase.createBatch(input)).rejects.toThrow("upload failed");
+      expect(storage.remove).toHaveBeenCalledWith("key-1");
+      expect(scanRepository.createBatch).not.toHaveBeenCalled();
+    });
+
+    it("does not remove an original twice when the invalid-upload cleanup fails", async () => {
+      storage.upload.mockReset();
+      storage.upload
+        .mockResolvedValueOnce({ status: "valid", value: "key-1" })
+        .mockResolvedValueOnce({
+          status: "invalid",
+          errors: [
+            {
+              path: "documents",
+              code: RF_ERROR_CODES.INVALID_DOCUMENT,
+              message: "保存に失敗しました",
+              severity: "error" as const,
+            },
+          ],
+        });
+      storage.remove.mockRejectedValue(new Error("cleanup failed"));
+      await expect(usecase.createBatch(input)).rejects.toBeInstanceOf(AggregateError);
+      expect(storage.remove).toHaveBeenCalledTimes(1);
       expect(storage.remove).toHaveBeenCalledWith("key-1");
       expect(scanRepository.createBatch).not.toHaveBeenCalled();
     });

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-scan-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-scan-usecase.test.ts
@@ -1,0 +1,188 @@
+import { ManageScanUsecase } from "@/server/contexts/research-fund/application/usecases/manage-scan-usecase";
+import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
+import type { PromptRepository } from "@/server/contexts/research-fund/domain/repositories/prompt-repository.interface";
+import type { ScanRepository } from "@/server/contexts/research-fund/domain/repositories/scan-repository.interface";
+
+const ACTIVE_PROMPT = {
+  id: "7",
+  version: 3,
+  body: "本文",
+  isActive: true,
+  updatedAt: "2026-09-01T00:00:00.000Z",
+  jobCount: 0,
+};
+
+describe("ManageScanUsecase", () => {
+  const scanRepository: jest.Mocked<ScanRepository> = {
+    createBatch: jest.fn(),
+    listBatches: jest.fn(),
+  };
+  const promptRepository: jest.Mocked<PromptRepository> = {
+    list: jest.fn(),
+    create: jest.fn(),
+    activate: jest.fn(),
+    findActive: jest.fn(),
+  };
+  const storage: jest.Mocked<DocumentStorage> = {
+    upload: jest.fn(),
+    createSignedUrl: jest.fn(),
+    remove: jest.fn(),
+  };
+  const usecase = new ManageScanUsecase(
+    scanRepository,
+    promptRepository,
+    storage,
+    "claude-sonnet-5",
+  );
+  const input = {
+    politicianId: "5",
+    bookId: "12",
+    userId: "user-1",
+    documents: [
+      { bytes: new Uint8Array([1]), mime: "image/jpeg", originalFilename: "IMG_1.jpg" },
+      { bytes: new Uint8Array([2]), mime: "application/pdf", originalFilename: "invoice.pdf" },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    promptRepository.findActive.mockResolvedValue(ACTIVE_PROMPT);
+    storage.upload
+      .mockResolvedValueOnce({ status: "valid", value: "key-1" })
+      .mockResolvedValueOnce({ status: "valid", value: "key-2" });
+    scanRepository.createBatch.mockResolvedValue("99");
+  });
+
+  describe("createBatch", () => {
+    it("uploads every document and records the active prompt version on each queued job", async () => {
+      expect(await usecase.createBatch(input)).toEqual({
+        status: "valid",
+        value: { batchId: "99" },
+      });
+      expect(storage.upload).toHaveBeenCalledTimes(2);
+      expect(scanRepository.createBatch).toHaveBeenCalledWith({
+        bookId: "12",
+        uploadedById: "user-1",
+        promptId: "7",
+        model: "claude-sonnet-5",
+        documents: [
+          { storageKey: "key-1", mime: "image/jpeg", originalFilename: "IMG_1.jpg" },
+          { storageKey: "key-2", mime: "application/pdf", originalFilename: "invoice.pdf" },
+        ],
+      });
+      expect(storage.remove).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { name: "too many documents", documents: Array.from({ length: 31 }, () => input.documents[0]) },
+      { name: "no documents", documents: [] },
+      {
+        name: "an unsupported format",
+        documents: [{ bytes: new Uint8Array([1]), mime: "image/gif", originalFilename: "a.gif" }],
+      },
+      {
+        name: "an empty file",
+        documents: [{ bytes: new Uint8Array(), mime: "image/jpeg", originalFilename: "a.jpg" }],
+      },
+      {
+        name: "a blank filename",
+        documents: [{ bytes: new Uint8Array([1]), mime: "image/jpeg", originalFilename: " " }],
+      },
+    ])("rejects $name before touching storage", async ({ documents }) => {
+      expect(await usecase.createBatch({ ...input, documents })).toMatchObject({
+        status: "invalid",
+        errors: [{ code: "RF_INVALID_DOCUMENT" }],
+      });
+      expect(storage.upload).not.toHaveBeenCalled();
+      expect(scanRepository.createBatch).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid book id before touching storage", async () => {
+      expect(await usecase.createBatch({ ...input, bookId: "../12" })).toMatchObject({
+        status: "invalid",
+      });
+      expect(storage.upload).not.toHaveBeenCalled();
+    });
+
+    it("refuses to create jobs while no prompt version is active", async () => {
+      promptRepository.findActive.mockResolvedValue(null);
+      await expect(usecase.createBatch(input)).rejects.toThrow("読み取りプロンプトが未保存です");
+      expect(storage.upload).not.toHaveBeenCalled();
+      expect(scanRepository.createBatch).not.toHaveBeenCalled();
+    });
+
+    it("removes already uploaded originals when the batch cannot be saved", async () => {
+      scanRepository.createBatch.mockRejectedValue(new Error("database failed"));
+      await expect(usecase.createBatch(input)).rejects.toThrow("database failed");
+      expect(storage.remove).toHaveBeenCalledWith("key-1");
+      expect(storage.remove).toHaveBeenCalledWith("key-2");
+    });
+
+    it("removes already uploaded originals when a later upload fails", async () => {
+      storage.upload.mockReset();
+      storage.upload
+        .mockResolvedValueOnce({ status: "valid", value: "key-1" })
+        .mockRejectedValueOnce(new Error("upload failed"));
+      await expect(usecase.createBatch(input)).rejects.toThrow("upload failed");
+      expect(storage.remove).toHaveBeenCalledWith("key-1");
+      expect(scanRepository.createBatch).not.toHaveBeenCalled();
+    });
+
+    it("preserves both errors when cleanup also fails", async () => {
+      const database = new Error("database failed");
+      const cleanup = new Error("cleanup failed");
+      scanRepository.createBatch.mockRejectedValue(database);
+      storage.remove.mockRejectedValue(cleanup);
+      await expect(usecase.createBatch(input)).rejects.toMatchObject({
+        errors: [database, cleanup, cleanup],
+      });
+    });
+  });
+
+  describe("list", () => {
+    it("adds the progress summary, the active version and the model", async () => {
+      scanRepository.listBatches.mockResolvedValue([
+        {
+          id: "1",
+          createdAt: "2026-09-09T00:00:00.000Z",
+          jobs: [
+            {
+              id: "1",
+              status: "succeeded",
+              originalFilename: "a.jpg",
+              mime: "image/jpeg",
+              summary: "2026.09.01・グラス代 ¥683",
+              error: null,
+            },
+            {
+              id: "2",
+              status: "queued",
+              originalFilename: "b.pdf",
+              mime: "application/pdf",
+              summary: null,
+              error: null,
+            },
+          ],
+        },
+      ]);
+      const overview = await usecase.list("5", "12");
+      expect(overview.activePromptVersion).toBe(3);
+      expect(overview.model).toBe("claude-sonnet-5");
+      expect(overview.batches[0].progress).toEqual({
+        total: 2,
+        succeeded: 1,
+        failed: 0,
+        percent: 50,
+      });
+    });
+
+    it("reports no active version so the screen can block uploads", async () => {
+      promptRepository.findActive.mockResolvedValue(null);
+      scanRepository.listBatches.mockResolvedValue([]);
+      expect(await usecase.list("5", "12")).toMatchObject({
+        batches: [],
+        activePromptVersion: null,
+      });
+    });
+  });
+});

--- a/admin/tests/server/contexts/research-fund/domain/models/scan-batch.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/scan-batch.test.ts
@@ -1,0 +1,70 @@
+import {
+  SCAN_BATCH_MAX_DOCUMENTS,
+  summarizeScanBatch,
+  validateScanUpload,
+  type ScanJobStatus,
+  type ScanJobView,
+} from "@/server/contexts/research-fund/domain/models/scan-batch";
+
+function job(status: ScanJobStatus): ScanJobView {
+  return { id: "1", status, originalFilename: "a.jpg", mime: "image/jpeg", summary: null, error: null };
+}
+
+describe("validateScanUpload", () => {
+  it("accepts 1 to 30 supported documents", () => {
+    for (const count of [1, SCAN_BATCH_MAX_DOCUMENTS]) {
+      const documents = Array.from({ length: count }, () => ({ mime: "image/jpeg" }));
+      expect(validateScanUpload(documents)).toEqual({ status: "valid", value: undefined });
+    }
+    expect(
+      validateScanUpload([{ mime: "image/png" }, { mime: "application/pdf" }]),
+    ).toMatchObject({ status: "valid" });
+  });
+  it("rejects an empty selection", () => {
+    expect(validateScanUpload([])).toMatchObject({
+      status: "invalid",
+      errors: [{ code: "RF_INVALID_DOCUMENT", message: "書類を1枚以上選んでください" }],
+    });
+  });
+  it("rejects more than 30 documents", () => {
+    const documents = Array.from({ length: SCAN_BATCH_MAX_DOCUMENTS + 1 }, () => ({
+      mime: "image/jpeg",
+    }));
+    expect(validateScanUpload(documents)).toMatchObject({
+      status: "invalid",
+      errors: [{ message: "1回にアップロードできるのは30枚までです" }],
+    });
+  });
+  it.each(["image/gif", "text/csv", "", "image/svg+xml"])("rejects %s", (mime) => {
+    expect(validateScanUpload([{ mime: "image/jpeg" }, { mime }])).toMatchObject({
+      status: "invalid",
+      errors: [{ message: "JPG・PNG・PDFのみアップロードできます" }],
+    });
+  });
+});
+
+describe("summarizeScanBatch", () => {
+  it("counts finished jobs and rounds the progress", () => {
+    expect(
+      summarizeScanBatch([
+        job("succeeded"),
+        job("succeeded"),
+        job("failed"),
+        job("running"),
+        job("queued"),
+        job("queued"),
+      ]),
+    ).toEqual({ total: 6, succeeded: 2, failed: 1, percent: 50 });
+  });
+  it("reports 0% while every job is still queued", () => {
+    expect(summarizeScanBatch([job("queued"), job("queued")])).toEqual({
+      total: 2,
+      succeeded: 0,
+      failed: 0,
+      percent: 0,
+    });
+  });
+  it("does not divide by zero for an empty batch", () => {
+    expect(summarizeScanBatch([])).toEqual({ total: 0, succeeded: 0, failed: 0, percent: 0 });
+  });
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.test.ts
@@ -1,0 +1,141 @@
+import type { PrismaClient } from "@prisma/client";
+import { PrismaScanRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository";
+
+function setup() {
+  const batch = { create: jest.fn(), findMany: jest.fn() };
+  const document = { create: jest.fn() };
+  const job = { create: jest.fn() };
+  const tx = {
+    researchFundScanBatch: batch,
+    researchFundDocument: document,
+    researchFundScanJob: job,
+  };
+  const client = {
+    ...tx,
+    $transaction: jest.fn((run: (tx: unknown) => unknown) => run(tx)),
+  };
+  return {
+    batch,
+    document,
+    job,
+    client,
+    repository: new PrismaScanRepository(client as unknown as PrismaClient),
+  };
+}
+
+const INPUT = {
+  bookId: "12",
+  uploadedById: "user-1",
+  promptId: "7",
+  model: "claude-sonnet-5",
+  documents: [
+    { storageKey: "key-1", mime: "image/jpeg", originalFilename: "IMG_1.jpg" },
+    { storageKey: "key-2", mime: "application/pdf", originalFilename: "invoice.pdf" },
+  ],
+};
+
+test("バッチ・書類・1書類1ジョブを1トランザクションで作る", async () => {
+  const { batch, document, job, client, repository } = setup();
+  batch.create.mockResolvedValue({ id: BigInt(99) });
+  document.create
+    .mockResolvedValueOnce({ id: BigInt(21) })
+    .mockResolvedValueOnce({ id: BigInt(22) });
+  await expect(repository.createBatch(INPUT)).resolves.toBe("99");
+  expect(client.$transaction).toHaveBeenCalled();
+  expect(batch.create).toHaveBeenCalledWith({
+    data: { bookId: BigInt(12), uploadedById: "user-1" },
+  });
+  expect(document.create).toHaveBeenCalledTimes(2);
+  expect(document.create).toHaveBeenNthCalledWith(1, {
+    data: {
+      bookId: BigInt(12),
+      batchId: BigInt(99),
+      storageKey: "key-1",
+      mime: "image/jpeg",
+      originalFilename: "IMG_1.jpg",
+    },
+  });
+  // ジョブは queued（schema の既定値）で作り、使ったプロンプト版とモデルを記録する
+  expect(job.create).toHaveBeenNthCalledWith(2, {
+    data: {
+      batchId: BigInt(99),
+      documentId: BigInt(22),
+      promptId: BigInt(7),
+      model: "claude-sonnet-5",
+    },
+  });
+});
+
+test("バッチは新しい順、ジョブはアップロード順で返す", async () => {
+  const { batch, repository } = setup();
+  batch.findMany.mockResolvedValue([
+    {
+      id: BigInt(2),
+      createdAt: new Date("2026-09-09T01:02:03.000Z"),
+      jobs: [
+        {
+          id: BigInt(5),
+          status: "queued",
+          rawJson: null,
+          error: null,
+          document: { originalFilename: "IMG_1.jpg", mime: "image/jpeg" },
+        },
+      ],
+    },
+  ]);
+  await expect(repository.listBatches("12")).resolves.toEqual([
+    {
+      id: "2",
+      createdAt: "2026-09-09T01:02:03.000Z",
+      jobs: [
+        {
+          id: "5",
+          status: "queued",
+          originalFilename: "IMG_1.jpg",
+          mime: "image/jpeg",
+          summary: null,
+          error: null,
+        },
+      ],
+    },
+  ]);
+  expect(batch.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({ where: { bookId: BigInt(12) }, orderBy: { id: "desc" } }),
+  );
+});
+
+test.each([
+  {
+    name: "日付と先頭明細と件数",
+    rawJson: {
+      date: "2026-08-16",
+      items: [
+        { item: "グラス代", amount: 683 },
+        { item: "皿", amount: 1200 },
+      ],
+    },
+    expected: "2026.08.16・グラス代 ¥683 ほか1件",
+  },
+  { name: "読めない原文", rawJson: { items: [] }, expected: null },
+  { name: "未読み取り", rawJson: null, expected: null },
+  { name: "配列の原文", rawJson: [1, 2], expected: null },
+])("抽出結果の要約は $name を扱う", async ({ rawJson, expected }) => {
+  const { batch, repository } = setup();
+  batch.findMany.mockResolvedValue([
+    {
+      id: BigInt(1),
+      createdAt: new Date("2026-09-09T00:00:00.000Z"),
+      jobs: [
+        {
+          id: BigInt(1),
+          status: "succeeded",
+          rawJson,
+          error: null,
+          document: { originalFilename: "a.jpg", mime: "image/jpeg" },
+        },
+      ],
+    },
+  ]);
+  const [result] = await repository.listBatches("12");
+  expect(result.jobs[0].summary).toBe(expected);
+});

--- a/admin/tests/server/contexts/research-fund/presentation/actions/create-scan-batch.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/actions/create-scan-batch.test.ts
@@ -1,0 +1,134 @@
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { ManageScanUsecase } from "@/server/contexts/research-fund/application/usecases/manage-scan-usecase";
+import { ScanBatchError } from "@/server/contexts/research-fund/domain/models/scan-batch";
+import { createScanBatch } from "@/server/contexts/research-fund/presentation/actions/create-scan-batch";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { buildScanUsecase } from "@/server/contexts/research-fund/presentation/loaders/load-scan";
+
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/server/contexts/auth/presentation/loaders/require-auth", () => ({
+  requireAuth: jest.fn(),
+}));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({
+  requireJournalTarget: jest.fn(),
+}));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-scan", () => ({
+  buildScanUsecase: jest.fn(),
+}));
+
+const createBatch = jest.fn();
+
+function formDataWith(files: File[]) {
+  const formData = new FormData();
+  for (const file of files) formData.append("documents", file);
+  return formData;
+}
+
+function jpeg(name: string) {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: "image/jpeg" });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest
+    .mocked(requireAuth)
+    .mockResolvedValue({ id: "user" } as Awaited<ReturnType<typeof requireAuth>>);
+  jest.mocked(requireJournalTarget).mockResolvedValue({
+    kind: "research-fund",
+    key: "book:1",
+    name: "議員",
+    year: 2026,
+    politicianId: "2",
+    bookId: "1",
+    draftCount: 0,
+  });
+  jest
+    .mocked(buildScanUsecase)
+    .mockReturnValue({ createBatch } as unknown as ManageScanUsecase);
+  createBatch.mockResolvedValue({ status: "valid", value: { batchId: "9" } });
+});
+
+test("ファイルを読み出して usecase に渡し、レイアウトを再検証する", async () => {
+  const formData = formDataWith([jpeg("IMG_1.jpg"), jpeg("IMG_2.jpg")]);
+  await expect(createScanBatch("2", "1", formData)).resolves.toEqual({
+    success: true,
+    batchId: "9",
+    count: 2,
+  });
+  expect(createBatch).toHaveBeenCalledWith({
+    politicianId: "2",
+    bookId: "1",
+    userId: "user",
+    documents: [
+      { bytes: new Uint8Array([1, 2, 3]), mime: "image/jpeg", originalFilename: "IMG_1.jpg" },
+      { bytes: new Uint8Array([1, 2, 3]), mime: "image/jpeg", originalFilename: "IMG_2.jpg" },
+    ],
+  });
+  expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
+});
+
+test("31枚以上はサーバー側でも弾き、保存を始めない", async () => {
+  const files = Array.from({ length: 31 }, (_, index) => jpeg(`IMG_${index}.jpg`));
+  await expect(createScanBatch("2", "1", formDataWith(files))).resolves.toEqual({
+    success: false,
+    error: "1回にアップロードできるのは30枚までです",
+  });
+  expect(createBatch).not.toHaveBeenCalled();
+  expect(revalidatePath).not.toHaveBeenCalled();
+});
+
+test("ファイルが無ければ保存を始めない", async () => {
+  await expect(createScanBatch("2", "1", new FormData())).resolves.toEqual({
+    success: false,
+    error: "書類を1枚以上選んでください",
+  });
+  expect(createBatch).not.toHaveBeenCalled();
+});
+
+test("別の対象への古いフォーム送信を拒否", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(null);
+  await expect(createScanBatch("2", "1", formDataWith([jpeg("a.jpg")]))).resolves.toMatchObject({
+    success: false,
+  });
+  expect(createBatch).not.toHaveBeenCalled();
+});
+
+test("認証失敗時はアップロードしない", async () => {
+  jest.mocked(requireAuth).mockRejectedValueOnce(new Error("auth"));
+  await expect(createScanBatch("2", "1", formDataWith([jpeg("a.jpg")]))).rejects.toThrow("auth");
+  expect(createBatch).not.toHaveBeenCalled();
+});
+
+test("対応外の形式は usecase の検証結果をそのまま伝える", async () => {
+  createBatch.mockResolvedValue({
+    status: "invalid",
+    errors: [
+      {
+        path: "documents",
+        code: "RF_INVALID_DOCUMENT",
+        message: "JPG・PNG・PDFのみアップロードできます",
+        severity: "error",
+      },
+    ],
+  });
+  await expect(createScanBatch("2", "1", formDataWith([jpeg("a.jpg")]))).resolves.toEqual({
+    success: false,
+    error: "JPG・PNG・PDFのみアップロードできます",
+  });
+  expect(revalidatePath).not.toHaveBeenCalled();
+});
+
+test("利用者が直せる事情は伝え、内部エラーは漏らさない", async () => {
+  createBatch.mockRejectedValueOnce(new ScanBatchError("読み取りプロンプトが未保存です"));
+  await expect(createScanBatch("2", "1", formDataWith([jpeg("a.jpg")]))).resolves.toEqual({
+    success: false,
+    error: "読み取りプロンプトが未保存です",
+  });
+  createBatch.mockRejectedValueOnce(new Error("private storage detail"));
+  await expect(createScanBatch("2", "1", formDataWith([jpeg("a.jpg")]))).resolves.toEqual({
+    success: false,
+    error: "書類のアップロードに失敗しました。時間をおいて再度お試しください",
+  });
+  expect(revalidatePath).not.toHaveBeenCalled();
+});

--- a/admin/tests/server/contexts/research-fund/presentation/loaders/load-scan.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/loaders/load-scan.test.ts
@@ -1,0 +1,67 @@
+import { notFound } from "next/navigation";
+import { ManageScanUsecase } from "@/server/contexts/research-fund/application/usecases/manage-scan-usecase";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { buildScanUsecase, loadScan } from "@/server/contexts/research-fund/presentation/loaders/load-scan";
+import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(() => {
+    throw new Error("NOT_FOUND");
+  }),
+}));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({
+  requireJournalTarget: jest.fn(),
+}));
+jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+jest.mock("@supabase/supabase-js", () => ({ createClient: jest.fn(() => ({ storage: {} })) }));
+
+const target: Extract<AdminTarget, { kind: "research-fund" }> = {
+  kind: "research-fund",
+  key: "book:1",
+  name: "議員",
+  year: 2026,
+  politicianId: "2",
+  bookId: "1",
+  draftCount: 0,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.replaceProperty(process, "env", {
+    ...process.env,
+    SUPABASE_URL: "https://storage.example.test",
+    SUPABASE_SERVICE_ROLE_KEY: "test-key",
+  });
+});
+afterEach(() => jest.restoreAllMocks());
+
+test("対象が一致しなければバッチを取得しない", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(null);
+  const list = jest.spyOn(ManageScanUsecase.prototype, "list");
+  await expect(loadScan("2", "1")).rejects.toThrow("NOT_FOUND");
+  expect(notFound).toHaveBeenCalled();
+  expect(list).not.toHaveBeenCalled();
+});
+
+test("プロンプトは議員ごと・バッチは帳簿ごとに引き、現在の対象を添えて返す", async () => {
+  jest.mocked(requireJournalTarget).mockResolvedValue(target);
+  const data = { batches: [], activePromptVersion: 3, model: "claude-sonnet-5" };
+  const list = jest.spyOn(ManageScanUsecase.prototype, "list").mockResolvedValue(data);
+  await expect(loadScan("2", "1")).resolves.toEqual({ ...data, target });
+  expect(list).toHaveBeenCalledWith("2", "1");
+});
+
+test.each(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"])("%s がなければ組み立てない", (key) => {
+  jest.replaceProperty(process, "env", { ...process.env, [key]: "" });
+  expect(() => buildScanUsecase()).toThrow("領収書ストレージが未設定です");
+});
+
+test("バケット名は未設定でも既定の private-receipts を使う", () => {
+  jest.replaceProperty(process, "env", {
+    ...process.env,
+    SUPABASE_URL: "https://storage.example.test",
+    SUPABASE_SERVICE_ROLE_KEY: "test-key",
+    RESEARCH_FUND_DOCUMENT_BUCKET: "",
+  });
+  expect(() => buildScanUsecase()).not.toThrow();
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -107,6 +107,13 @@ file_size_limit = "50MiB"
 # allowed_mime_types = ["image/png", "image/jpeg"]
 # objects_path = "./images"
 
+# 調査研究費の領収書原本（非公開）。admin の RESEARCH_FUND_DOCUMENT_BUCKET の既定値と揃える。
+# 本番バケットは Supabase のダッシュボードで用意する（#1346）。
+[storage.buckets.private-receipts]
+public = false
+file_size_limit = "50MiB"
+allowed_mime_types = ["image/jpeg", "image/png", "application/pdf"]
+
 [auth]
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used


### PR DESCRIPTION
## 目的（Why）

議員室スタッフが週1回・30枚一括で領収書を投入する入口がまだ無く、領収書を帳簿に紐づけて溜めておけない状態を解消するため。ファイルを帳簿に紐づけて Storage に保存し、読み取り待ちのジョブとして並べるところまでを作る。

## 変更内容

**画面（admin / 議員室モード → 書類スキャン）**

- `/(auth)/politicians/[id]/books/[bookId]/scan` を追加（サイドバーの導線は既に張られていたが、ルートが無かった）
- ドロップゾーン: 破線 teal・「{議員} ／ {年度} の帳簿に追加されます」バッジ・JPG/PNG/PDF・最大30枚。ドロップとファイル選択の両方に対応
- バッチカード: 進捗バー＋「n件中m件完了・k件失敗」。ジョブ表はファイル名（PDF/画像アイコン）・状態ピル（完了=teal塗り／失敗=赤塗り／処理中=teal枠／待機中=グレー枠）・抽出結果の要約列
- 31枚以上・対応外の形式はアップロード前にクライアントで弾き、サーバーアクションと usecase でも同じ規則で再検証する
- 有効な読み取りプロンプト版が無いうちはアップロードを無効化する（`scan_jobs.prompt_id` が必須 FK のため）

**バックエンド**

- `domain/models/scan-batch.ts`: 枚数・形式の検証、進捗の集計、`ScanOverview`
- `domain/repositories/scan-repository.interface.ts` / `infrastructure/repositories/prisma-scan.repository.ts`: バッチ・書類・queued ジョブ（1書類=1ジョブ）を1トランザクションで作成、バッチ一覧の取得
- `application/usecases/manage-scan-usecase.ts`: Storage 保存 → バッチ作成。途中で失敗したらアップロード済みの原本を片付ける
- `PromptRepository.findActive` を追加（ジョブに記録する有効な版を引く）
- バケット名は `RESEARCH_FUND_DOCUMENT_BUCKET`、既定値 `private-receipts`

**ローカル環境**

- `supabase/config.toml` に非公開バケット `private-receipts` を定義（`pnpm db:reset` 後に存在することを確認済み）。本番バケットと Vercel の環境変数は #1346（人間の作業）

## やらないこと（この PR の範囲外）

- ジョブの実行（LLM 呼び出し）・再実行・ポーリング（#1365）。この時点では全件「待機中」で並ぶ
- 「完了分を確認へ」導線の活性化

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ 通過
- `pnpm supabase:start && pnpm db:reset && pnpm test:e2e`（admin）: ✅ 49 passed（新規 `e2e/tests/scan.spec.ts` を含む）

スコープアウトして起票した Issue: なし

Closes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 研究費帳簿で、JPEG・PNG・PDFの領収書をアップロードしてスキャンできるようになりました。
  * ドラッグ＆ドロップ、進捗状況、ジョブ状態、使用したプロンプト版を確認できます。
  * 最大30ファイルまで一括アップロードできます。
* **改善**
  * 未対応形式、空の選択、31ファイル以上のアップロードを事前に拒否します。
  * プロンプト未保存時はアップロードできません。
  * ページを再読み込みしても、スキャン履歴と進捗を確認できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->