### PR TITLE
feat(admin): スキャンジョブの実行（LLM 読み取り → 下書き仕訳・ポーリング・再実行）

### DIFF
--- a/admin/src/app/(auth)/politicians/[id]/books/[bookId]/entries/page.tsx
+++ b/admin/src/app/(auth)/politicians/[id]/books/[bookId]/entries/page.tsx
@@ -2,10 +2,13 @@ import { loadJournalReview } from "@/server/contexts/research-fund/presentation/
 import { JournalReview } from "@/client/components/research-fund/JournalReview";
 export default async function JournalReviewPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string; bookId: string }>;
+  searchParams: Promise<{ status?: string }>;
 }) {
   const { id, bookId } = await params;
+  const { status } = await searchParams;
   const data = await loadJournalReview(id, bookId);
-  return <JournalReview key={bookId} {...data} />;
+  return <JournalReview key={bookId} initialStatus={status} {...data} />;
 }

--- a/admin/src/client/components/research-fund/DocumentScan.tsx
+++ b/admin/src/client/components/research-fund/DocumentScan.tsx
@@ -87,6 +87,9 @@ export function DocumentScan({
     (job) => job.status === "queued" || job.status === "running",
   ).length;
   const succeeded = jobs.filter((job) => job.status === "succeeded").length;
+  // 「処理する」を押してからこれまでに失敗した件数。通知の時点では router.refresh() の
+  // 反映が間に合わないため、props の件数ではなく自前で数える。
+  const failedInRun = useRef(0);
 
   /**
    * 待機中のジョブを少数だけ処理する。残りがあれば自動で次を呼ぶ（キュー基盤を持たないため、
@@ -101,10 +104,14 @@ export function DocumentScan({
         setAutoRun(false);
         return;
       }
+      failedInRun.current += result.failed;
       router.refresh();
       if (!result.hasMore) {
         setAutoRun(false);
-        toast.success("読み取りが完了しました");
+        // 失敗したジョブがあれば「完了」と断定しない。再実行の導線は一覧の各行にある。
+        if (failedInRun.current > 0)
+          toast.error(`読み取りを終えましたが、${failedInRun.current}件が失敗しました`);
+        else toast.success("読み取りが完了しました");
       }
     } catch {
       toast.error("通信に失敗しました。再度お試しください");
@@ -130,6 +137,7 @@ export function DocumentScan({
 
   function start() {
     if (processing || unfinished === 0) return;
+    failedInRun.current = 0;
     setAutoRun(true);
     void process();
   }

--- a/admin/src/client/components/research-fund/DocumentScan.tsx
+++ b/admin/src/client/components/research-fund/DocumentScan.tsx
@@ -1,7 +1,10 @@
 "use client";
-import { useRef, useState, useTransition, type DragEvent } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition, type DragEvent } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
+  ArrowClockwise,
+  ArrowRight,
   FileArrowUp,
   FilePdf,
   Image as ImageIcon,
@@ -28,6 +31,8 @@ import {
   type ScanOverview,
 } from "@/server/contexts/research-fund/domain/models/scan-batch";
 import { createScanBatch } from "@/server/contexts/research-fund/presentation/actions/create-scan-batch";
+import { processScanJobs } from "@/server/contexts/research-fund/presentation/actions/process-scan-jobs";
+import { retryScanJob } from "@/server/contexts/research-fund/presentation/actions/retry-scan-job";
 import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
 
 const STATUS_LABELS: Record<ScanJobStatus, string> = {
@@ -43,6 +48,9 @@ const STATUS_STYLES: Record<ScanJobStatus, string> = {
   succeeded: "border-primary bg-primary text-primary-foreground",
   failed: "border-destructive bg-destructive text-white",
 };
+
+/** 未処理が残っている間、次の処理を呼ぶまでの間隔（ミリ秒） */
+const POLL_INTERVAL_MS = 1500;
 
 function formatDate(isoDate: string) {
   return isoDate.slice(0, 10).replaceAll("-", ".");
@@ -71,7 +79,76 @@ export function DocumentScan({
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
   const [pending, startTransition] = useTransition();
+  const [processing, setProcessing] = useState(false);
+  const [autoRun, setAutoRun] = useState(false);
   const ready = activePromptVersion !== null;
+  const jobs = batches.flatMap((batch) => batch.jobs);
+  const unfinished = jobs.filter(
+    (job) => job.status === "queued" || job.status === "running",
+  ).length;
+  const succeeded = jobs.filter((job) => job.status === "succeeded").length;
+
+  /**
+   * 待機中のジョブを少数だけ処理する。残りがあれば自動で次を呼ぶ（キュー基盤を持たないため、
+   * 画面が呼び出し役を兼ねる）。実行中は再入しない。
+   */
+  const process = useCallback(async () => {
+    setProcessing(true);
+    try {
+      const result = await processScanJobs(target.politicianId, target.bookId);
+      if (!result.success) {
+        toast.error(result.error);
+        setAutoRun(false);
+        return;
+      }
+      router.refresh();
+      if (!result.hasMore) {
+        setAutoRun(false);
+        toast.success("読み取りが完了しました");
+      }
+    } catch {
+      toast.error("通信に失敗しました。再度お試しください");
+      setAutoRun(false);
+    } finally {
+      setProcessing(false);
+    }
+  }, [router, target.politicianId, target.bookId]);
+
+  // 未処理が残っている間、一定間隔で処理を呼び続ける。1 回の呼び出しは少数しか進めない。
+  useEffect(() => {
+    if (!autoRun || processing || unfinished === 0) return;
+    const timer = setTimeout(() => {
+      void process();
+    }, POLL_INTERVAL_MS);
+    return () => clearTimeout(timer);
+  }, [autoRun, processing, unfinished, process]);
+
+  // 処理し切ったら自動実行を止める（失敗だけが残った場合もここで止まる）
+  useEffect(() => {
+    if (unfinished === 0) setAutoRun(false);
+  }, [unfinished]);
+
+  function start() {
+    if (processing || unfinished === 0) return;
+    setAutoRun(true);
+    void process();
+  }
+
+  function retry(jobId: string) {
+    startTransition(async () => {
+      try {
+        const result = await retryScanJob(target.politicianId, target.bookId, jobId);
+        if (!result.success) {
+          toast.error(result.error);
+          return;
+        }
+        router.refresh();
+        setAutoRun(true);
+      } catch {
+        toast.error("通信に失敗しました。再度お試しください");
+      }
+    });
+  }
 
   function upload(files: File[]) {
     if (inputRef.current) inputRef.current.value = "";
@@ -91,6 +168,7 @@ export function DocumentScan({
         }
         toast.success(`${result.count}件の書類を読み取り待ちに追加しました`);
         router.refresh();
+        setAutoRun(true);
       } catch {
         toast.error("通信に失敗しました。再度お試しください");
       }
@@ -169,6 +247,32 @@ export function DocumentScan({
           </CardContent>
         </Card>
 
+        {batches.length > 0 && (
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              disabled={processing || pending || unfinished === 0}
+              onClick={start}
+            >
+              {processing || autoRun
+                ? `読み取り中… 残り${unfinished}件`
+                : unfinished === 0
+                  ? "未処理の書類はありません"
+                  : `処理する（${unfinished}件）`}
+            </Button>
+            {succeeded > 0 && (
+              <Button asChild variant="outline">
+                <Link
+                  href={`/politicians/${target.politicianId}/books/${target.bookId}/entries?status=draft`}
+                >
+                  完了分を確認へ
+                  <ArrowRight aria-hidden className="size-4" />
+                </Link>
+              </Button>
+            )}
+          </div>
+        )}
+
         {batches.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             まだバッチがありません。書類をアップロードするとここに並びます。
@@ -205,6 +309,7 @@ export function DocumentScan({
                       <TableHead>ファイル</TableHead>
                       <TableHead>状態</TableHead>
                       <TableHead>抽出結果</TableHead>
+                      <TableHead className="w-24" />
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -239,6 +344,20 @@ export function DocumentScan({
                           {job.status === "failed"
                             ? (job.error ?? "読み取りに失敗しました")
                             : (job.summary ?? "—")}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap">
+                          {job.status === "failed" && (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="text-xs"
+                              disabled={pending || processing}
+                              onClick={() => retry(job.id)}
+                            >
+                              <ArrowClockwise aria-hidden className="size-4" />
+                              再実行
+                            </Button>
+                          )}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/admin/src/client/components/research-fund/JournalReview.tsx
+++ b/admin/src/client/components/research-fund/JournalReview.tsx
@@ -51,7 +51,7 @@ export function JournalReview({
 }) {
   const router = useRouter();
   const [status, setStatus] = useState(
-    initialStatus && initialStatus in statuses ? initialStatus : "all",
+    initialStatus && Object.hasOwn(statuses, initialStatus) ? initialStatus : "all",
   );
   const [month, setMonth] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);

--- a/admin/src/client/components/research-fund/JournalReview.tsx
+++ b/admin/src/client/components/research-fund/JournalReview.tsx
@@ -41,13 +41,18 @@ export function JournalReview({
   entries,
   accounts,
   target,
+  initialStatus,
 }: {
   entries: ReviewEntry[];
   accounts: ReviewAccount[];
   target: Extract<AdminTarget, { kind: "research-fund" }>;
+  /** スキャン画面の「完了分を確認へ」から下書きタブを開くための初期値 */
+  initialStatus?: string;
 }) {
   const router = useRouter();
-  const [status, setStatus] = useState("all");
+  const [status, setStatus] = useState(
+    initialStatus && initialStatus in statuses ? initialStatus : "all",
+  );
   const [month, setMonth] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);

--- a/admin/src/server/contexts/research-fund/application/usecases/process-scan-jobs-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/process-scan-jobs-usecase.ts
@@ -1,0 +1,142 @@
+import "server-only";
+import { ScanJob } from "@/server/contexts/research-fund/domain/models/scan-job";
+import type { ReceiptExtractionGateway } from "@/server/contexts/research-fund/domain/repositories/receipt-extraction-gateway.interface";
+import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
+import type {
+  ClaimedScanJob,
+  ScanRepository,
+} from "@/server/contexts/research-fund/domain/repositories/scan-repository.interface";
+import { buildScanDraftEntries } from "@/server/contexts/research-fund/domain/services/scan-journal-builder";
+import { ResearchFundDocument } from "@/server/contexts/research-fund/domain/models/document";
+
+interface ProcessScanJobsResult {
+  /** この呼び出しで処理したジョブ数 */
+  processed: number;
+  succeeded: number;
+  failed: number;
+  /** まだ queued / running のジョブが残っているか。画面はこれが true の間だけ呼び続ける */
+  hasMore: boolean;
+}
+
+type ExtractableMime = "image/jpeg" | "image/png" | "application/pdf";
+
+const EXTRACTABLE_MIMES: readonly string[] = ["image/jpeg", "image/png", "application/pdf"];
+
+/**
+ * 待機中のスキャンジョブを少数だけ処理する。
+ *
+ * キュー基盤は使わず、画面が未処理の残っている間これを繰り返し呼ぶ（設計: ジョブ実行方式）。
+ * 1 回の呼び出しで着手するのは SCAN_JOB_BATCH_SIZE 件までで、既に running が上限に
+ * 達していれば 1 件も着手しない（多重実行の防止）。
+ */
+export class ProcessScanJobsUsecase {
+  constructor(
+    private scanRepository: ScanRepository,
+    private storage: DocumentStorage,
+    private gateway: ReceiptExtractionGateway,
+  ) {}
+
+  async execute(input: { bookId: string; userId: string }): Promise<ProcessScanJobsResult> {
+    const validation = ResearchFundDocument.validateId(input.bookId);
+    if (validation.status === "invalid") throw new Error(validation.errors[0].message);
+
+    // 関数が途中で落ちて running のまま残ったジョブを待機中に戻す。これをしないと
+    // 多重実行の防止が働いたまま、以後どのジョブも着手できなくなる。
+    await this.scanRepository.releaseStaleJobs(input.bookId, ScanJob.staleBefore(new Date()));
+
+    const before = await this.scanRepository.countUnfinished(input.bookId);
+    const limit = ScanJob.claimableCount(before.running);
+    if (limit === 0) {
+      return {
+        processed: 0,
+        succeeded: 0,
+        failed: 0,
+        hasMore: before.queued + before.running > 0,
+      };
+    }
+
+    const jobs = await this.scanRepository.claimJobs(input.bookId, limit);
+    let succeeded = 0;
+    let failed = 0;
+    for (const job of jobs) {
+      const ok = await this.runJob(job, input);
+      if (ok) succeeded += 1;
+      else failed += 1;
+    }
+
+    const after = await this.scanRepository.countUnfinished(input.bookId);
+    return {
+      processed: jobs.length,
+      succeeded,
+      failed,
+      hasMore: after.queued + after.running > 0,
+    };
+  }
+
+  /** 1 ジョブを読み取って下書き仕訳にする。成功したら true。失敗は error に記録して飲み込む */
+  private async runJob(
+    job: ClaimedScanJob,
+    input: { bookId: string; userId: string },
+  ): Promise<boolean> {
+    let rawJson: unknown;
+    try {
+      if (!EXTRACTABLE_MIMES.includes(job.mime)) {
+        await this.scanRepository.failJob(job.id, "JPG・PNG・PDFのみ読み取れます");
+        return false;
+      }
+      const bytes = await this.storage.download(job.storageKey);
+      if (bytes.status === "invalid") {
+        await this.scanRepository.failJob(job.id, bytes.errors[0].message);
+        return false;
+      }
+      const extracted = await this.gateway.extract({
+        document: { bytes: bytes.value, mime: job.mime as ExtractableMime },
+        officePrompt: job.officePrompt,
+      });
+      if (extracted.status === "invalid") {
+        await this.scanRepository.failJob(job.id, extracted.errors[0].message);
+        return false;
+      }
+      rawJson = extracted.value;
+      const accounts = await this.scanRepository.accounts();
+      const entries = buildScanDraftEntries(extracted.value, {
+        documentId: job.documentId,
+        accounts,
+      });
+      if (entries.status === "invalid") {
+        await this.scanRepository.failJob(job.id, entries.errors[0].message, rawJson);
+        return false;
+      }
+      await this.scanRepository.completeJob({
+        bookId: input.bookId,
+        jobId: job.id,
+        documentId: job.documentId,
+        rawJson: extracted.value,
+        entries: entries.value,
+        userId: input.userId,
+      });
+      return true;
+    } catch (error) {
+      // 1 件の失敗で残りのジョブを巻き込まない。原因はジョブの error に残す
+      await this.scanRepository.failJob(
+        job.id,
+        error instanceof Error && error.message
+          ? error.message
+          : "読み取りに失敗しました。再実行してください",
+        rawJson,
+      );
+      return false;
+    }
+  }
+
+  /** 失敗したジョブを待機中に戻す。戻せなければ false（既に処理済みなど） */
+  async retry(input: { bookId: string; jobId: string }): Promise<boolean> {
+    for (const result of [
+      ResearchFundDocument.validateId(input.bookId),
+      ResearchFundDocument.validateId(input.jobId),
+    ]) {
+      if (result.status === "invalid") throw new Error(result.errors[0].message);
+    }
+    return await this.scanRepository.requeueJob(input.bookId, input.jobId);
+  }
+}

--- a/admin/src/server/contexts/research-fund/domain/models/journal-entry-hash.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/journal-entry-hash.ts
@@ -12,6 +12,12 @@ export interface JournalEntryHash {
   amount: number;
   description: string;
   documentId?: string | null;
+  /**
+   * 同じ書類に日付・金額・項目名まで同一の明細が複数あるとき、それらを別物として区別するための連番。
+   * 1 件目は null（＝連番なしの hash と同値）で、2 件目以降にだけ 1 から振る。
+   * これにより、連番を使わない呼び出し側（支給・手入力）の hash は変わらない。
+   */
+  discriminator?: number | null;
 }
 
 export const JournalEntryHash = {
@@ -51,9 +57,22 @@ export const JournalEntryHash = {
         "書類IDを指定するか、書類がない場合はnullにしてください",
       );
     }
+    const discriminator = input.discriminator ?? null;
+    if (discriminator !== null && (!Number.isSafeInteger(discriminator) || discriminator < 1)) {
+      return invalidResearchFundResult(
+        "discriminator",
+        RF_ERROR_CODES.INVALID_AMOUNT,
+        "連番は1以上の整数で指定してください",
+      );
+    }
     // 固定順のJSON配列により、キー順序や区切り文字を含む入力に左右されない。
     // 科目やステータスの修正は同一取引の再取込判定に影響させない。
-    const content = JSON.stringify([entryDate, amount, description, documentId]);
+    // 連番が無い場合は末尾に足さず、従来の hash と同じ値を保つ。
+    const content = JSON.stringify(
+      discriminator === null
+        ? [entryDate, amount, description, documentId]
+        : [entryDate, amount, description, documentId, discriminator],
+    );
     return { status: "valid", value: createHash("sha256").update(content, "utf8").digest("hex") };
   },
 };

--- a/admin/src/server/contexts/research-fund/domain/models/scan-job.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/scan-job.ts
@@ -1,0 +1,26 @@
+/**
+ * 1 回の「処理する」で着手するジョブ数であり、同時に running でいてよい上限でもある。
+ * 1 件あたり LLM 呼び出し 1 回なので、サーバーレスのタイムアウト内に収まる件数に留める
+ * （設計: ジョブ実行方式）。この数だけ running があれば新たに着手しない（多重実行の防止）。
+ */
+export const SCAN_JOB_BATCH_SIZE = 2;
+
+/**
+ * running のまま放置されたジョブを失効とみなすまでの時間。
+ * サーバーレス関数が途中で落ちるとジョブが running で残り、以後の処理が止まるため。
+ */
+export const SCAN_JOB_STALE_MS = 5 * 60 * 1000;
+
+export const ScanJob = {
+  /**
+   * 新たに着手してよい件数。running が上限に達していれば 0（＝多重実行しない）。
+   */
+  claimableCount(runningCount: number): number {
+    return Math.max(0, SCAN_JOB_BATCH_SIZE - runningCount);
+  },
+
+  /** この時刻より前に始まった running のジョブは失効とみなす（関数が落ちたと判断する） */
+  staleBefore(now: Date): Date {
+    return new Date(now.getTime() - SCAN_JOB_STALE_MS);
+  },
+};

--- a/admin/src/server/contexts/research-fund/domain/repositories/document-storage.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/document-storage.interface.ts
@@ -2,6 +2,8 @@ import type { ResearchFundResult } from "@/server/contexts/research-fund/domain/
 
 export interface DocumentStorage {
   upload(bytes: Uint8Array, mime: string): Promise<ResearchFundResult<string>>;
+  /** 読み取り（LLM）に渡す原本のバイト列を取り出す */
+  download(storageKey: string): Promise<ResearchFundResult<Uint8Array>>;
   createSignedUrl(storageKey: string, expiresIn: number): Promise<ResearchFundResult<string>>;
   remove(storageKey: string): Promise<void>;
 }

--- a/admin/src/server/contexts/research-fund/domain/repositories/scan-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/scan-repository.interface.ts
@@ -1,4 +1,6 @@
 import type { ScanBatchView } from "@/server/contexts/research-fund/domain/models/scan-batch";
+import type { ScanDraftEntry } from "@/server/contexts/research-fund/domain/services/scan-journal-builder";
+import type { ResearchFundAccount } from "@/server/contexts/research-fund/domain/models/journal-posting";
 
 export interface CreateScanBatchInput {
   bookId: string;
@@ -9,9 +11,44 @@ export interface CreateScanBatchInput {
   documents: { storageKey: string; mime: string; originalFilename: string }[];
 }
 
+/** 着手済み（running にした）ジョブ。読み取りに必要な情報を全部持つ */
+export interface ClaimedScanJob {
+  id: string;
+  documentId: string;
+  storageKey: string;
+  mime: string;
+  originalFilename: string;
+  /** ジョブに記録された版のプロンプト本文。読み取りは作成時点の版で行う */
+  officePrompt: string;
+}
+
 export interface ScanRepository {
   /** バッチ・書類・queued ジョブを 1 トランザクションで作る。作ったバッチ ID を返す */
   createBatch(input: CreateScanBatchInput): Promise<string>;
   /** 帳簿のバッチを新しい順に返す */
   listBatches(bookId: string): Promise<ScanBatchView[]>;
+  /** 帳簿に queued または running のジョブが残っている件数 */
+  countUnfinished(bookId: string): Promise<{ queued: number; running: number }>;
+  /**
+   * queued のジョブを古い順に最大 limit 件 running にして返す。
+   * 同じジョブを 2 つの実行が同時に掴まないよう、状態の更新は 1 件ずつ条件付きで行う。
+   */
+  claimJobs(bookId: string, limit: number): Promise<ClaimedScanJob[]>;
+  /** running のまま失効したジョブを queued に戻す。戻した件数を返す */
+  releaseStaleJobs(bookId: string, staleBefore: Date): Promise<number>;
+  /** 下書き仕訳と原文 JSON を保存し、ジョブを succeeded にする（1 トランザクション） */
+  completeJob(input: {
+    bookId: string;
+    jobId: string;
+    documentId: string;
+    rawJson: unknown;
+    entries: ScanDraftEntry[];
+    userId: string;
+  }): Promise<void>;
+  /** ジョブを failed にしてエラーを記録する */
+  failJob(jobId: string, error: string, rawJson?: unknown): Promise<void>;
+  /** failed のジョブを queued に戻す。戻せたら true */
+  requeueJob(bookId: string, jobId: string): Promise<boolean>;
+  /** 科目マスタ（下書き仕訳の科目解決に使う） */
+  accounts(): Promise<ResearchFundAccount[]>;
 }

--- a/admin/src/server/contexts/research-fund/domain/services/scan-journal-builder.ts
+++ b/admin/src/server/contexts/research-fund/domain/services/scan-journal-builder.ts
@@ -1,0 +1,102 @@
+import "server-only";
+import type { ExtractedReceipt } from "@/server/contexts/research-fund/domain/models/extracted-receipt";
+import { JournalEntryHash } from "@/server/contexts/research-fund/domain/models/journal-entry-hash";
+import {
+  JournalPosting,
+  type JournalLine,
+  type ResearchFundAccount,
+} from "@/server/contexts/research-fund/domain/models/journal-posting";
+import {
+  invalidResearchFundResult,
+  RF_ERROR_CODES,
+  type ResearchFundResult,
+} from "@/server/contexts/research-fund/domain/types/validation";
+
+/** スキャンの下書き仕訳が使う決済科目。現金払いかどうかは読み取れないので普通預金に寄せる */
+const ASSET_ACCOUNT_KEY = "bank";
+
+export interface ScanDraftEntry {
+  entryDate: string;
+  description: string;
+  accountKey: string;
+  amount: number;
+  note: string | null;
+  /** 1書類から複数明細が出たとき、同一注文をまとめるキー。1明細なら null */
+  splitGroup: string | null;
+  hash: string;
+  lines: readonly JournalLine[];
+}
+
+/**
+ * 1 書類の抽出結果を下書き仕訳に変換する。
+ *
+ * - 明細ごとに 1 仕訳（費用 / 普通預金の 2 行）を作る
+ * - 科目が確定していない明細（category_key = needs-review）も needs-review 科目のまま下書きにする
+ * - 同一注文の明細（同じ split_group、または 1 書類に複数明細）には同じ split_group を振る
+ * - hash は「日付・金額・項目名・書類ID」から作る。同じ書類の再処理で同じ hash になり、重複検知に使える
+ */
+export function buildScanDraftEntries(
+  receipt: ExtractedReceipt,
+  context: { documentId: string; accounts: readonly ResearchFundAccount[] },
+): ResearchFundResult<ScanDraftEntry[]> {
+  const accountByKey = new Map(context.accounts.map((account) => [account.key, account]));
+  const assetAccount = accountByKey.get(ASSET_ACCOUNT_KEY);
+  if (!assetAccount) {
+    return invalidResearchFundResult(
+      "assetAccount",
+      RF_ERROR_CODES.INVALID_ACCOUNT,
+      "決済科目（普通預金）の科目マスタがありません",
+    );
+  }
+
+  const entries: ScanDraftEntry[] = [];
+  for (const [index, item] of receipt.items.entries()) {
+    const account = accountByKey.get(item.category_key);
+    if (!account) {
+      return invalidResearchFundResult(
+        `items.${index}.category_key`,
+        RF_ERROR_CODES.INVALID_ACCOUNT,
+        `読み取られたカテゴリ「${item.category_key}」に対応する科目がありません`,
+      );
+    }
+    const posting = JournalPosting.generate({
+      pattern: "expense",
+      source: "scan",
+      amount: item.amount,
+      account,
+      assetAccount,
+    });
+    if (posting.status === "invalid") return posting;
+    const hash = JournalEntryHash.generate({
+      entryDate: receipt.date,
+      amount: item.amount,
+      description: item.item,
+      documentId: context.documentId,
+    });
+    if (hash.status === "invalid") return hash;
+    entries.push({
+      entryDate: receipt.date,
+      description: item.item,
+      accountKey: account.key,
+      amount: item.amount,
+      note: item.note,
+      splitGroup: resolveSplitGroup(item.split_group, receipt.items.length, context.documentId),
+      hash: hash.value,
+      lines: posting.value.lines,
+    });
+  }
+  return { status: "valid", value: entries };
+}
+
+/**
+ * split_group の採番。LLM が付けたキーはそのまま使わず書類 ID で名前空間を区切り、
+ * 別の書類の同名キーと混ざらないようにする。1 書類 1 明細なら分割していないので null。
+ */
+function resolveSplitGroup(
+  extracted: string | null,
+  itemCount: number,
+  documentId: string,
+): string | null {
+  if (itemCount <= 1) return null;
+  return `doc-${documentId}${extracted ? `:${extracted}` : ""}`;
+}

--- a/admin/src/server/contexts/research-fund/domain/services/scan-journal-builder.ts
+++ b/admin/src/server/contexts/research-fund/domain/services/scan-journal-builder.ts
@@ -32,8 +32,9 @@ export interface ScanDraftEntry {
  *
  * - 明細ごとに 1 仕訳（費用 / 普通預金の 2 行）を作る
  * - 科目が確定していない明細（category_key = needs-review）も needs-review 科目のまま下書きにする
- * - 同一注文の明細（同じ split_group、または 1 書類に複数明細）には同じ split_group を振る
- * - hash は「日付・金額・項目名・書類ID」から作る。同じ書類の再処理で同じ hash になり、重複検知に使える
+ * - 1 書類から複数明細が出たら、その書類の全明細に同じ split_group を振る
+ * - hash は「日付・金額・項目名・書類ID」から作る。同じ書類の再処理で同じ hash になり、重複検知に使える。
+ *   同じ書類にそこまで同一の明細が複数あるときは出現順の連番で区別し、正当な明細が重複扱いで落ちないようにする
  */
 export function buildScanDraftEntries(
   receipt: ExtractedReceipt,
@@ -50,6 +51,8 @@ export function buildScanDraftEntries(
   }
 
   const entries: ScanDraftEntry[] = [];
+  // 日付・金額・項目名まで同一の明細の出現回数。2 件目以降は連番で hash を分ける。
+  const seen = new Map<string, number>();
   for (const [index, item] of receipt.items.entries()) {
     const account = accountByKey.get(item.category_key);
     if (!account) {
@@ -67,11 +70,14 @@ export function buildScanDraftEntries(
       assetAccount,
     });
     if (posting.status === "invalid") return posting;
+    const occurrence = (seen.get(itemKey(receipt.date, item.amount, item.item)) ?? 0) + 1;
+    seen.set(itemKey(receipt.date, item.amount, item.item), occurrence);
     const hash = JournalEntryHash.generate({
       entryDate: receipt.date,
       amount: item.amount,
       description: item.item,
       documentId: context.documentId,
+      discriminator: occurrence > 1 ? occurrence - 1 : null,
     });
     if (hash.status === "invalid") return hash;
     entries.push({
@@ -80,7 +86,7 @@ export function buildScanDraftEntries(
       accountKey: account.key,
       amount: item.amount,
       note: item.note,
-      splitGroup: resolveSplitGroup(item.split_group, receipt.items.length, context.documentId),
+      splitGroup: resolveSplitGroup(receipt.items.length, context.documentId),
       hash: hash.value,
       lines: posting.value.lines,
     });
@@ -89,14 +95,17 @@ export function buildScanDraftEntries(
 }
 
 /**
- * split_group の採番。LLM が付けたキーはそのまま使わず書類 ID で名前空間を区切り、
- * 別の書類の同名キーと混ざらないようにする。1 書類 1 明細なら分割していないので null。
+ * split_group の採番。LLM が付けたキーはそのまま使わず書類 ID で採番する。
+ * 抽出時の検証は明細間でキーが一致することまでは見ないため、キーを混ぜると
+ * 同じ書類の明細が別グループに割れる。1 書類は 1 グループとして扱う。
+ * 1 書類 1 明細なら分割していないので null。
  */
-function resolveSplitGroup(
-  extracted: string | null,
-  itemCount: number,
-  documentId: string,
-): string | null {
+function resolveSplitGroup(itemCount: number, documentId: string): string | null {
   if (itemCount <= 1) return null;
-  return `doc-${documentId}${extracted ? `:${extracted}` : ""}`;
+  return `doc-${documentId}`;
+}
+
+/** 「同じ明細」とみなす単位のキー。hash の入力と同じ 3 項目で揃える。 */
+function itemKey(entryDate: string, amount: number, description: string): string {
+  return JSON.stringify([entryDate, amount, description]);
 }

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.ts
@@ -1,13 +1,16 @@
 import "server-only";
-import type { PrismaClient } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 import type {
   ScanBatchView,
   ScanJobStatus,
 } from "@/server/contexts/research-fund/domain/models/scan-batch";
 import type {
+  ClaimedScanJob,
   CreateScanBatchInput,
   ScanRepository,
 } from "@/server/contexts/research-fund/domain/repositories/scan-repository.interface";
+import type { ResearchFundAccount } from "@/server/contexts/research-fund/domain/models/journal-posting";
+import type { ScanDraftEntry } from "@/server/contexts/research-fund/domain/services/scan-journal-builder";
 
 export class PrismaScanRepository implements ScanRepository {
   constructor(private prisma: PrismaClient) {}
@@ -67,6 +70,134 @@ export class PrismaScanRepository implements ScanRepository {
         error: job.error,
       })),
     }));
+  }
+
+  async countUnfinished(bookId: string): Promise<{ queued: number; running: number }> {
+    const rows = await this.prisma.researchFundScanJob.groupBy({
+      by: ["status"],
+      where: { batch: { bookId: BigInt(bookId) }, status: { in: ["queued", "running"] } },
+      _count: { _all: true },
+    });
+    const count = (status: "queued" | "running") =>
+      rows.find((row) => row.status === status)?._count._all ?? 0;
+    return { queued: count("queued"), running: count("running") };
+  }
+
+  async claimJobs(bookId: string, limit: number): Promise<ClaimedScanJob[]> {
+    const candidates = await this.prisma.researchFundScanJob.findMany({
+      where: { batch: { bookId: BigInt(bookId) }, status: "queued" },
+      orderBy: { id: "asc" },
+      take: limit,
+      include: {
+        document: { select: { id: true, storageKey: true, mime: true, originalFilename: true } },
+        prompt: { select: { body: true } },
+      },
+    });
+    const claimed: ClaimedScanJob[] = [];
+    for (const job of candidates) {
+      // 同時に走った別の実行が先に掴んでいたら count は 0 になる。その分は諦めて次へ。
+      const result = await this.prisma.researchFundScanJob.updateMany({
+        where: { id: job.id, status: "queued" },
+        data: { status: "running", startedAt: new Date(), error: null },
+      });
+      if (result.count !== 1) continue;
+      claimed.push({
+        id: job.id.toString(),
+        documentId: job.document.id.toString(),
+        storageKey: job.document.storageKey,
+        mime: job.document.mime,
+        originalFilename: job.document.originalFilename,
+        officePrompt: job.prompt.body,
+      });
+    }
+    return claimed;
+  }
+
+  async releaseStaleJobs(bookId: string, staleBefore: Date): Promise<number> {
+    const result = await this.prisma.researchFundScanJob.updateMany({
+      where: {
+        batch: { bookId: BigInt(bookId) },
+        status: "running",
+        OR: [{ startedAt: null }, { startedAt: { lt: staleBefore } }],
+      },
+      data: { status: "queued", startedAt: null },
+    });
+    return result.count;
+  }
+
+  async completeJob(input: {
+    bookId: string;
+    jobId: string;
+    documentId: string;
+    rawJson: unknown;
+    entries: ScanDraftEntry[];
+    userId: string;
+  }): Promise<void> {
+    const bookId = BigInt(input.bookId);
+    await this.prisma.$transaction(async (tx) => {
+      // 同じ書類を読み直しても仕訳を二重に作らない。hash は日付・金額・項目名・書類IDから作る。
+      const existing = await tx.researchFundJournalEntry.findMany({
+        where: { bookId, hash: { in: input.entries.map((entry) => entry.hash) } },
+        select: { hash: true },
+      });
+      const known = new Set(existing.map((entry) => entry.hash));
+      for (const entry of input.entries) {
+        if (known.has(entry.hash)) continue;
+        known.add(entry.hash);
+        await tx.researchFundJournalEntry.create({
+          data: {
+            bookId,
+            entryDate: new Date(`${entry.entryDate}T00:00:00.000Z`),
+            description: entry.description,
+            status: "draft",
+            source: "scan",
+            documentId: BigInt(input.documentId),
+            splitGroup: entry.splitGroup,
+            note: entry.note,
+            hash: entry.hash,
+            createdById: input.userId,
+            lines: { create: entry.lines.map((line) => ({ ...line })) },
+          },
+        });
+      }
+      await tx.researchFundScanJob.update({
+        where: { id: BigInt(input.jobId) },
+        data: {
+          status: "succeeded",
+          rawJson: input.rawJson as Prisma.InputJsonValue,
+          error: null,
+          finishedAt: new Date(),
+        },
+      });
+    });
+  }
+
+  async failJob(jobId: string, error: string, rawJson?: unknown): Promise<void> {
+    await this.prisma.researchFundScanJob.update({
+      where: { id: BigInt(jobId) },
+      data: {
+        status: "failed",
+        error: error.slice(0, 500),
+        finishedAt: new Date(),
+        ...(rawJson === undefined ? {} : { rawJson: rawJson as Prisma.InputJsonValue }),
+      },
+    });
+  }
+
+  async requeueJob(bookId: string, jobId: string): Promise<boolean> {
+    const result = await this.prisma.researchFundScanJob.updateMany({
+      where: { id: BigInt(jobId), batch: { bookId: BigInt(bookId) }, status: "failed" },
+      data: { status: "queued", error: null, startedAt: null, finishedAt: null },
+    });
+    return result.count === 1;
+  }
+
+  async accounts(): Promise<ResearchFundAccount[]> {
+    const rows = await this.prisma.researchFundAccount.findMany({
+      select: { key: true, type: true },
+      orderBy: { displayOrder: "asc" },
+    });
+    return rows.map((row) => ({ key: row.key, type: row.type }));
   }
 }
 

--- a/admin/src/server/contexts/research-fund/infrastructure/storage/supabase-document-storage.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/storage/supabase-document-storage.ts
@@ -25,6 +25,12 @@ export class SupabaseDocumentStorage implements DocumentStorage {
     return { status: "valid", value: storageKey };
   }
 
+  async download(storageKey: string): Promise<ResearchFundResult<Uint8Array>> {
+    const { data, error } = await this.client.storage.from(this.bucket).download(storageKey);
+    if (error || !data) throw new Error("領収書の原本の取得に失敗しました", { cause: error });
+    return { status: "valid", value: new Uint8Array(await data.arrayBuffer()) };
+  }
+
   async createSignedUrl(
     storageKey: string,
     expiresIn: number,

--- a/admin/src/server/contexts/research-fund/presentation/actions/process-scan-jobs.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/process-scan-jobs.ts
@@ -1,0 +1,26 @@
+"use server";
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { buildProcessScanJobsUsecase } from "@/server/contexts/research-fund/presentation/loaders/load-scan";
+
+/**
+ * 待機中のジョブを少数だけ読み取り、下書き仕訳にする。
+ * 画面は hasMore が true の間これを繰り返し呼ぶ（キュー基盤は使わない）。
+ */
+export async function processScanJobs(politicianId: string, bookId: string) {
+  const user = await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    const result = await buildProcessScanJobsUsecase().execute({ bookId, userId: user.id });
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const, ...result };
+  } catch {
+    return {
+      success: false as const,
+      error: "読み取りの実行に失敗しました。時間をおいて再度お試しください",
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/actions/retry-scan-job.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/retry-scan-job.ts
@@ -1,0 +1,28 @@
+"use server";
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { buildProcessScanJobsUsecase } from "@/server/contexts/research-fund/presentation/loaders/load-scan";
+
+/** 失敗したジョブを待機中に戻す。実行そのものは processScanJobs が拾う */
+export async function retryScanJob(politicianId: string, bookId: string, jobId: string) {
+  await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    const requeued = await buildProcessScanJobsUsecase().retry({ bookId, jobId });
+    if (!requeued)
+      return {
+        success: false as const,
+        error: "このジョブは再実行できません。画面を再読み込みしてください",
+      };
+    revalidatePath("/(auth)", "layout");
+    return { success: true as const };
+  } catch {
+    return {
+      success: false as const,
+      error: "再実行に失敗しました。時間をおいて再度お試しください",
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-scan.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-scan.ts
@@ -2,6 +2,8 @@ import "server-only";
 import { notFound } from "next/navigation";
 import { createClient } from "@supabase/supabase-js";
 import { ManageScanUsecase } from "@/server/contexts/research-fund/application/usecases/manage-scan-usecase";
+import { ProcessScanJobsUsecase } from "@/server/contexts/research-fund/application/usecases/process-scan-jobs-usecase";
+import { VercelAIReceiptExtractionGateway } from "@/server/contexts/research-fund/infrastructure/llm/vercel-ai-receipt-extraction-gateway";
 import { PrismaPromptRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository";
 import { PrismaScanRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository";
 import { SupabaseDocumentStorage } from "@/server/contexts/research-fund/infrastructure/storage/supabase-document-storage";
@@ -9,19 +11,31 @@ import { researchFundDocumentBucket } from "@/server/contexts/research-fund/infr
 import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 
-export function buildScanUsecase(): ManageScanUsecase {
+function buildDocumentStorage(): SupabaseDocumentStorage {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) throw new Error("領収書ストレージが未設定です");
   const client = createClient(url, key, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
+  return new SupabaseDocumentStorage(client, researchFundDocumentBucket());
+}
+
+export function buildScanUsecase(): ManageScanUsecase {
   return new ManageScanUsecase(
     new PrismaScanRepository(prisma),
     new PrismaPromptRepository(prisma),
-    new SupabaseDocumentStorage(client, researchFundDocumentBucket()),
-    // 読み取りの実行は #1365。ここでは作成時点のモデル名をジョブに記録するだけ
+    buildDocumentStorage(),
+    // ジョブに記録するモデル名。実際の読み取りもゲートウェイが同じ環境変数を見る
     process.env.RESEARCH_FUND_EXTRACTION_MODEL?.trim() || "claude-sonnet-5",
+  );
+}
+
+export function buildProcessScanJobsUsecase(): ProcessScanJobsUsecase {
+  return new ProcessScanJobsUsecase(
+    new PrismaScanRepository(prisma),
+    buildDocumentStorage(),
+    new VercelAIReceiptExtractionGateway(),
   );
 }
 

--- a/admin/tests/server/contexts/research-fund/application/usecases/get-document-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/get-document-usecase.test.ts
@@ -6,6 +6,7 @@ describe("GetDocumentUsecase", () => {
   const repository: jest.Mocked<DocumentRepository> = { create: jest.fn(), findById: jest.fn() };
   const storage: jest.Mocked<DocumentStorage> = {
     upload: jest.fn(),
+    download: jest.fn(),
     createSignedUrl: jest.fn(),
     remove: jest.fn(),
   };

--- a/admin/tests/server/contexts/research-fund/application/usecases/manage-scan-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/manage-scan-usecase.test.ts
@@ -17,6 +17,13 @@ describe("ManageScanUsecase", () => {
   const scanRepository: jest.Mocked<ScanRepository> = {
     createBatch: jest.fn(),
     listBatches: jest.fn(),
+    countUnfinished: jest.fn(),
+    claimJobs: jest.fn(),
+    releaseStaleJobs: jest.fn(),
+    completeJob: jest.fn(),
+    failJob: jest.fn(),
+    requeueJob: jest.fn(),
+    accounts: jest.fn(),
   };
   const promptRepository: jest.Mocked<PromptRepository> = {
     list: jest.fn(),
@@ -26,6 +33,7 @@ describe("ManageScanUsecase", () => {
   };
   const storage: jest.Mocked<DocumentStorage> = {
     upload: jest.fn(),
+    download: jest.fn(),
     createSignedUrl: jest.fn(),
     remove: jest.fn(),
   };

--- a/admin/tests/server/contexts/research-fund/application/usecases/process-scan-jobs-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/process-scan-jobs-usecase.test.ts
@@ -1,0 +1,212 @@
+import { ProcessScanJobsUsecase } from "@/server/contexts/research-fund/application/usecases/process-scan-jobs-usecase";
+import { SCAN_JOB_BATCH_SIZE } from "@/server/contexts/research-fund/domain/models/scan-job";
+import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
+import type { ReceiptExtractionGateway } from "@/server/contexts/research-fund/domain/repositories/receipt-extraction-gateway.interface";
+import type {
+  ClaimedScanJob,
+  ScanRepository,
+} from "@/server/contexts/research-fund/domain/repositories/scan-repository.interface";
+import { RF_ERROR_CODES } from "@/server/contexts/research-fund/domain/types/validation";
+
+const JOB: ClaimedScanJob = {
+  id: "11",
+  documentId: "42",
+  storageKey: "key-1",
+  mime: "image/jpeg",
+  originalFilename: "IMG_1.jpg",
+  officePrompt: "議員室プロンプト",
+};
+
+const RECEIPT = {
+  date: "2026-04-01",
+  items: [
+    { item: "タクシー代", amount: 1200, category_key: "taxi", note: null, split_group: null },
+  ],
+} as const;
+
+describe("ProcessScanJobsUsecase", () => {
+  const scanRepository: jest.Mocked<ScanRepository> = {
+    createBatch: jest.fn(),
+    listBatches: jest.fn(),
+    countUnfinished: jest.fn(),
+    claimJobs: jest.fn(),
+    releaseStaleJobs: jest.fn(),
+    completeJob: jest.fn(),
+    failJob: jest.fn(),
+    requeueJob: jest.fn(),
+    accounts: jest.fn(),
+  };
+  const storage: jest.Mocked<DocumentStorage> = {
+    upload: jest.fn(),
+    download: jest.fn(),
+    createSignedUrl: jest.fn(),
+    remove: jest.fn(),
+  };
+  const gateway: jest.Mocked<ReceiptExtractionGateway> = { extract: jest.fn() };
+  const usecase = new ProcessScanJobsUsecase(scanRepository, storage, gateway);
+  const input = { bookId: "12", userId: "user-1" };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    scanRepository.releaseStaleJobs.mockResolvedValue(0);
+    scanRepository.countUnfinished
+      .mockResolvedValueOnce({ queued: 1, running: 0 })
+      .mockResolvedValue({ queued: 0, running: 0 });
+    scanRepository.claimJobs.mockResolvedValue([JOB]);
+    scanRepository.accounts.mockResolvedValue([
+      { key: "bank", type: "asset" },
+      { key: "taxi", type: "expense" },
+      { key: "needs-review", type: "expense" },
+    ]);
+    storage.download.mockResolvedValue({ status: "valid", value: new Uint8Array([1, 2]) });
+    gateway.extract.mockResolvedValue({ status: "valid", value: { ...RECEIPT, items: [...RECEIPT.items] } });
+  });
+
+  describe("execute", () => {
+    it("reads a queued job with the prompt recorded on it and saves the draft entries", async () => {
+      const result = await usecase.execute(input);
+
+      expect(gateway.extract).toHaveBeenCalledWith({
+        document: { bytes: new Uint8Array([1, 2]), mime: "image/jpeg" },
+        officePrompt: "議員室プロンプト",
+      });
+      expect(scanRepository.completeJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bookId: "12",
+          jobId: "11",
+          documentId: "42",
+          rawJson: expect.objectContaining({ date: "2026-04-01" }),
+          userId: "user-1",
+          entries: [
+            expect.objectContaining({
+              entryDate: "2026-04-01",
+              description: "タクシー代",
+              accountKey: "taxi",
+              amount: 1200,
+            }),
+          ],
+        }),
+      );
+      expect(scanRepository.failJob).not.toHaveBeenCalled();
+      expect(result).toEqual({ processed: 1, succeeded: 1, failed: 0, hasMore: false });
+    });
+
+    it("claims only a few jobs at a time so one call fits in the serverless timeout", async () => {
+      await usecase.execute(input);
+      expect(scanRepository.claimJobs).toHaveBeenCalledWith("12", SCAN_JOB_BATCH_SIZE);
+    });
+
+    it("starts nothing while other jobs are still running", async () => {
+      jest.resetAllMocks();
+      scanRepository.releaseStaleJobs.mockResolvedValue(0);
+      scanRepository.countUnfinished.mockResolvedValue({ queued: 5, running: SCAN_JOB_BATCH_SIZE });
+
+      const result = await usecase.execute(input);
+
+      expect(scanRepository.claimJobs).not.toHaveBeenCalled();
+      expect(gateway.extract).not.toHaveBeenCalled();
+      expect(result).toEqual({ processed: 0, succeeded: 0, failed: 0, hasMore: true });
+    });
+
+    it("releases jobs stuck in running before looking for work", async () => {
+      await usecase.execute(input);
+      expect(scanRepository.releaseStaleJobs).toHaveBeenCalledWith("12", expect.any(Date));
+      expect(scanRepository.releaseStaleJobs.mock.invocationCallOrder[0]).toBeLessThan(
+        scanRepository.claimJobs.mock.invocationCallOrder[0],
+      );
+    });
+
+    it("reports there is more work while jobs remain, so the screen keeps calling", async () => {
+      jest.resetAllMocks();
+      scanRepository.releaseStaleJobs.mockResolvedValue(0);
+      scanRepository.countUnfinished
+        .mockResolvedValueOnce({ queued: 3, running: 0 })
+        .mockResolvedValue({ queued: 2, running: 0 });
+      scanRepository.claimJobs.mockResolvedValue([JOB]);
+      scanRepository.accounts.mockResolvedValue([
+        { key: "bank", type: "asset" },
+        { key: "taxi", type: "expense" },
+      ]);
+      storage.download.mockResolvedValue({ status: "valid", value: new Uint8Array([1]) });
+      gateway.extract.mockResolvedValue({
+        status: "valid",
+        value: { ...RECEIPT, items: [...RECEIPT.items] },
+      });
+
+      expect(await usecase.execute(input)).toMatchObject({ hasMore: true });
+    });
+
+    it("records the extraction error on the job instead of throwing", async () => {
+      gateway.extract.mockResolvedValue({
+        status: "invalid",
+        errors: [
+          {
+            path: "",
+            code: RF_ERROR_CODES.EXTRACTION_FAILED,
+            message: "領収書の読み取りに失敗しました",
+            severity: "error",
+          },
+        ],
+      });
+
+      const result = await usecase.execute(input);
+
+      expect(scanRepository.failJob).toHaveBeenCalledWith("11", "領収書の読み取りに失敗しました");
+      expect(scanRepository.completeJob).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ processed: 1, succeeded: 0, failed: 1 });
+    });
+
+    it("records the raw output when the extraction cannot be turned into entries", async () => {
+      scanRepository.accounts.mockResolvedValue([{ key: "bank", type: "asset" }]);
+
+      await usecase.execute(input);
+
+      expect(scanRepository.failJob).toHaveBeenCalledWith(
+        "11",
+        expect.stringContaining("taxi"),
+        expect.objectContaining({ date: "2026-04-01" }),
+      );
+    });
+
+    it("fails only the broken job and keeps going with the rest", async () => {
+      scanRepository.claimJobs.mockResolvedValue([JOB, { ...JOB, id: "12", documentId: "43" }]);
+      storage.download
+        .mockReset()
+        .mockRejectedValueOnce(new Error("領収書の原本の取得に失敗しました"))
+        .mockResolvedValue({ status: "valid", value: new Uint8Array([1]) });
+
+      const result = await usecase.execute(input);
+
+      expect(scanRepository.failJob).toHaveBeenCalledWith(
+        "11",
+        "領収書の原本の取得に失敗しました",
+        undefined,
+      );
+      expect(scanRepository.completeJob).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({ processed: 2, succeeded: 1, failed: 1 });
+    });
+
+    it("rejects a book id that is not a valid identifier", async () => {
+      await expect(usecase.execute({ bookId: "0; DROP", userId: "user-1" })).rejects.toThrow();
+      expect(scanRepository.claimJobs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("retry", () => {
+    it("puts a failed job back in the queue", async () => {
+      scanRepository.requeueJob.mockResolvedValue(true);
+      expect(await usecase.retry({ bookId: "12", jobId: "11" })).toBe(true);
+      expect(scanRepository.requeueJob).toHaveBeenCalledWith("12", "11");
+    });
+
+    it("reports failure when the job is no longer retryable", async () => {
+      scanRepository.requeueJob.mockResolvedValue(false);
+      expect(await usecase.retry({ bookId: "12", jobId: "11" })).toBe(false);
+    });
+
+    it("rejects an invalid job id", async () => {
+      await expect(usecase.retry({ bookId: "12", jobId: "abc" })).rejects.toThrow();
+      expect(scanRepository.requeueJob).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/admin/tests/server/contexts/research-fund/application/usecases/register-document-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/register-document-usecase.test.ts
@@ -6,6 +6,7 @@ describe("RegisterDocumentUsecase", () => {
   const repository: jest.Mocked<DocumentRepository> = { create: jest.fn(), findById: jest.fn() };
   const storage: jest.Mocked<DocumentStorage> = {
     upload: jest.fn(),
+    download: jest.fn(),
     createSignedUrl: jest.fn(),
     remove: jest.fn(),
   };

--- a/admin/tests/server/contexts/research-fund/domain/models/journal-entry-hash.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/journal-entry-hash.test.ts
@@ -87,4 +87,28 @@ describe("JournalEntryHash.generate", () => {
       errors: [{ code: "RF_INVALID_DOCUMENT" }],
     });
   });
+
+  it("keeps the hash unchanged when no discriminator is given", () => {
+    expect(JournalEntryHash.generate({ ...content, discriminator: null })).toEqual(
+      JournalEntryHash.generate(content),
+    );
+  });
+
+  it("separates entries that differ only by discriminator", () => {
+    expect(JournalEntryHash.generate({ ...content, discriminator: 1 })).not.toEqual(
+      JournalEntryHash.generate(content),
+    );
+    expect(JournalEntryHash.generate({ ...content, discriminator: 1 })).not.toEqual(
+      JournalEntryHash.generate({ ...content, discriminator: 2 }),
+    );
+  });
+
+  it("rejects a discriminator that is not a positive integer", () => {
+    expect(JournalEntryHash.generate({ ...content, discriminator: 0 })).toMatchObject({
+      status: "invalid",
+    });
+    expect(JournalEntryHash.generate({ ...content, discriminator: 1.5 })).toMatchObject({
+      status: "invalid",
+    });
+  });
 });

--- a/admin/tests/server/contexts/research-fund/domain/models/scan-job.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/models/scan-job.test.ts
@@ -1,0 +1,29 @@
+import {
+  ScanJob,
+  SCAN_JOB_BATCH_SIZE,
+  SCAN_JOB_STALE_MS,
+} from "@/server/contexts/research-fund/domain/models/scan-job";
+
+describe("ScanJob", () => {
+  describe("claimableCount", () => {
+    it("claims a small batch when nothing is running", () => {
+      expect(ScanJob.claimableCount(0)).toBe(SCAN_JOB_BATCH_SIZE);
+    });
+
+    it("claims nothing while the running limit is reached", () => {
+      expect(ScanJob.claimableCount(SCAN_JOB_BATCH_SIZE)).toBe(0);
+      expect(ScanJob.claimableCount(SCAN_JOB_BATCH_SIZE + 5)).toBe(0);
+    });
+
+    it("claims only the remaining slots", () => {
+      expect(ScanJob.claimableCount(SCAN_JOB_BATCH_SIZE - 1)).toBe(1);
+    });
+  });
+
+  describe("staleBefore", () => {
+    it("marks jobs that started more than the limit ago as abandoned", () => {
+      const now = new Date("2026-09-12T10:00:00.000Z");
+      expect(ScanJob.staleBefore(now)).toEqual(new Date(now.getTime() - SCAN_JOB_STALE_MS));
+    });
+  });
+});

--- a/admin/tests/server/contexts/research-fund/domain/services/scan-journal-builder.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/services/scan-journal-builder.test.ts
@@ -1,0 +1,154 @@
+import type { ExtractedReceipt } from "@/server/contexts/research-fund/domain/models/extracted-receipt";
+import { JournalEntryHash } from "@/server/contexts/research-fund/domain/models/journal-entry-hash";
+import type { ResearchFundAccount } from "@/server/contexts/research-fund/domain/models/journal-posting";
+import { buildScanDraftEntries } from "@/server/contexts/research-fund/domain/services/scan-journal-builder";
+
+const accounts: ResearchFundAccount[] = [
+  { key: "bank", type: "asset" },
+  { key: "cash", type: "asset" },
+  { key: "taxi", type: "expense" },
+  { key: "meetings", type: "expense" },
+  { key: "needs-review", type: "expense" },
+];
+
+function receipt(items: ExtractedReceipt["items"]): ExtractedReceipt {
+  return { date: "2026-04-01", items };
+}
+
+describe("buildScanDraftEntries", () => {
+  it("creates one balanced expense entry per item", () => {
+    const result = buildScanDraftEntries(
+      receipt([
+        { item: "タクシー代", amount: 1200, category_key: "taxi", note: null, split_group: null },
+      ]),
+      { documentId: "42", accounts },
+    );
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") return;
+    expect(result.value).toHaveLength(1);
+    const [entry] = result.value;
+    expect(entry).toMatchObject({
+      entryDate: "2026-04-01",
+      description: "タクシー代",
+      accountKey: "taxi",
+      amount: 1200,
+      note: null,
+      // 1 明細だけなら分割していないので split_group は付けない
+      splitGroup: null,
+    });
+    expect(entry.lines).toEqual([
+      { side: "debit", accountKey: "taxi", amount: 1200 },
+      { side: "credit", accountKey: "bank", amount: 1200 },
+    ]);
+  });
+
+  it("keeps an unresolved category as needs-review instead of guessing", () => {
+    const result = buildScanDraftEntries(
+      receipt([
+        { item: "用途不明", amount: 500, category_key: "needs-review", note: null, split_group: null },
+      ]),
+      { documentId: "42", accounts },
+    );
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") return;
+    expect(result.value[0].accountKey).toBe("needs-review");
+  });
+
+  it("groups every item of a multi-item document under one split group", () => {
+    const result = buildScanDraftEntries(
+      receipt([
+        { item: "会議費", amount: 3000, category_key: "meetings", note: "打合せ", split_group: "a" },
+        { item: "タクシー代", amount: 900, category_key: "taxi", note: null, split_group: "a" },
+      ]),
+      { documentId: "42", accounts },
+    );
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") return;
+    expect(result.value.map((entry) => entry.splitGroup)).toEqual(["doc-42:a", "doc-42:a"]);
+    expect(result.value[0].note).toBe("打合せ");
+  });
+
+  it("namespaces the split group by document so two documents never collide", () => {
+    const items: ExtractedReceipt["items"] = [
+      { item: "会議費", amount: 3000, category_key: "meetings", note: null, split_group: "a" },
+      { item: "タクシー代", amount: 900, category_key: "taxi", note: null, split_group: "a" },
+    ];
+    const first = buildScanDraftEntries(receipt(items), { documentId: "1", accounts });
+    const second = buildScanDraftEntries(receipt(items), { documentId: "2", accounts });
+    expect(first.status === "valid" && first.value[0].splitGroup).toBe("doc-1:a");
+    expect(second.status === "valid" && second.value[0].splitGroup).toBe("doc-2:a");
+  });
+
+  it("falls back to a document-wide group when the model gave no split key", () => {
+    const result = buildScanDraftEntries(
+      receipt([
+        { item: "会議費", amount: 3000, category_key: "meetings", note: null, split_group: null },
+        { item: "タクシー代", amount: 900, category_key: "taxi", note: null, split_group: null },
+      ]),
+      { documentId: "42", accounts },
+    );
+    expect(result.status === "valid" && result.value.map((e) => e.splitGroup)).toEqual([
+      "doc-42",
+      "doc-42",
+    ]);
+  });
+
+  it("produces the same hash for the same document so a reprocess can be detected", () => {
+    const input = receipt([
+      { item: "タクシー代", amount: 1200, category_key: "taxi", note: null, split_group: null },
+    ]);
+    const first = buildScanDraftEntries(input, { documentId: "42", accounts });
+    const second = buildScanDraftEntries(input, { documentId: "42", accounts });
+    const expected = JournalEntryHash.generate({
+      entryDate: "2026-04-01",
+      amount: 1200,
+      description: "タクシー代",
+      documentId: "42",
+    });
+    expect(first.status === "valid" && first.value[0].hash).toBe(
+      second.status === "valid" ? second.value[0].hash : null,
+    );
+    expect(expected.status === "valid" && first.status === "valid").toBe(true);
+    if (expected.status === "valid" && first.status === "valid")
+      expect(first.value[0].hash).toBe(expected.value);
+  });
+
+  it("gives different documents different hashes for the same receipt content", () => {
+    const input = receipt([
+      { item: "タクシー代", amount: 1200, category_key: "taxi", note: null, split_group: null },
+    ]);
+    const first = buildScanDraftEntries(input, { documentId: "1", accounts });
+    const second = buildScanDraftEntries(input, { documentId: "2", accounts });
+    expect(first.status === "valid" && second.status === "valid").toBe(true);
+    if (first.status !== "valid" || second.status !== "valid") return;
+    expect(first.value[0].hash).not.toBe(second.value[0].hash);
+  });
+
+  it("reports an unknown category instead of creating an entry with no account", () => {
+    const result = buildScanDraftEntries(
+      receipt([
+        { item: "謎", amount: 100, category_key: "taxi", note: null, split_group: null },
+        { item: "謎2", amount: 100, category_key: "donation", note: null, split_group: null },
+      ]),
+      { documentId: "42", accounts },
+    );
+    expect(result.status).toBe("invalid");
+    if (result.status !== "invalid") return;
+    expect(result.errors[0]).toMatchObject({
+      path: "items.1.category_key",
+      code: "RF_INVALID_ACCOUNT",
+    });
+  });
+
+  it("reports a missing settlement account rather than building an unbalanced entry", () => {
+    const result = buildScanDraftEntries(
+      receipt([
+        { item: "タクシー代", amount: 1200, category_key: "taxi", note: null, split_group: null },
+      ]),
+      { documentId: "42", accounts: accounts.filter((account) => account.key !== "bank") },
+    );
+    expect(result.status).toBe("invalid");
+    if (result.status !== "invalid") return;
+    expect(result.errors[0].path).toBe("assetAccount");
+  });
+});

--- a/admin/tests/server/contexts/research-fund/domain/services/scan-journal-builder.test.ts
+++ b/admin/tests/server/contexts/research-fund/domain/services/scan-journal-builder.test.ts
@@ -64,7 +64,7 @@ describe("buildScanDraftEntries", () => {
     );
     expect(result.status).toBe("valid");
     if (result.status !== "valid") return;
-    expect(result.value.map((entry) => entry.splitGroup)).toEqual(["doc-42:a", "doc-42:a"]);
+    expect(result.value.map((entry) => entry.splitGroup)).toEqual(["doc-42", "doc-42"]);
     expect(result.value[0].note).toBe("打合せ");
   });
 
@@ -75,8 +75,8 @@ describe("buildScanDraftEntries", () => {
     ];
     const first = buildScanDraftEntries(receipt(items), { documentId: "1", accounts });
     const second = buildScanDraftEntries(receipt(items), { documentId: "2", accounts });
-    expect(first.status === "valid" && first.value[0].splitGroup).toBe("doc-1:a");
-    expect(second.status === "valid" && second.value[0].splitGroup).toBe("doc-2:a");
+    expect(first.status === "valid" && first.value[0].splitGroup).toBe("doc-1");
+    expect(second.status === "valid" && second.value[0].splitGroup).toBe("doc-2");
   });
 
   it("falls back to a document-wide group when the model gave no split key", () => {
@@ -111,6 +111,63 @@ describe("buildScanDraftEntries", () => {
     expect(expected.status === "valid" && first.status === "valid").toBe(true);
     if (expected.status === "valid" && first.status === "valid")
       expect(first.value[0].hash).toBe(expected.value);
+  });
+
+  it("keeps identical items distinct so a duplicate line is not dropped", () => {
+    const item = {
+      item: "書籍",
+      amount: 3000,
+      category_key: "meetings" as const,
+      note: null,
+      split_group: null,
+    };
+    const result = buildScanDraftEntries(receipt([item, item, item]), {
+      documentId: "42",
+      accounts,
+    });
+    expect(result.status).toBe("valid");
+    if (result.status !== "valid") return;
+    expect(new Set(result.value.map((e) => e.hash)).size).toBe(3);
+    // 1 件目は連番なしの hash のまま（既存データとの互換を保つ）
+    const plain = JournalEntryHash.generate({
+      entryDate: "2026-04-01",
+      amount: 3000,
+      description: "書籍",
+      documentId: "42",
+    });
+    expect(plain.status === "valid" && result.value[0].hash).toBe(
+      plain.status === "valid" ? plain.value : null,
+    );
+  });
+
+  it("produces the same hashes when the same multi-item document is reprocessed", () => {
+    const item = {
+      item: "書籍",
+      amount: 3000,
+      category_key: "meetings" as const,
+      note: null,
+      split_group: null,
+    };
+    const input = receipt([item, item]);
+    const first = buildScanDraftEntries(input, { documentId: "42", accounts });
+    const second = buildScanDraftEntries(input, { documentId: "42", accounts });
+    expect(first.status === "valid" && first.value.map((e) => e.hash)).toEqual(
+      second.status === "valid" ? second.value.map((e) => e.hash) : null,
+    );
+  });
+
+  it("groups every item of a document under one splitGroup even if keys disagree", () => {
+    const result = buildScanDraftEntries(
+      receipt([
+        { item: "資料A", amount: 1000, category_key: "meetings", note: null, split_group: "a" },
+        { item: "資料B", amount: 2000, category_key: "meetings", note: null, split_group: "b" },
+      ]),
+      { documentId: "42", accounts },
+    );
+    expect(result.status === "valid" && result.value.map((e) => e.splitGroup)).toEqual([
+      "doc-42",
+      "doc-42",
+    ]);
   });
 
   it("gives different documents different hashes for the same receipt content", () => {

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.test.ts
@@ -4,11 +4,21 @@ import { PrismaScanRepository } from "@/server/contexts/research-fund/infrastruc
 function setup() {
   const batch = { create: jest.fn(), findMany: jest.fn() };
   const document = { create: jest.fn() };
-  const job = { create: jest.fn() };
+  const job = {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    groupBy: jest.fn(),
+  };
+  const entry = { create: jest.fn(), findMany: jest.fn() };
+  const account = { findMany: jest.fn() };
   const tx = {
     researchFundScanBatch: batch,
     researchFundDocument: document,
     researchFundScanJob: job,
+    researchFundJournalEntry: entry,
+    researchFundAccount: account,
   };
   const client = {
     ...tx,
@@ -18,6 +28,8 @@ function setup() {
     batch,
     document,
     job,
+    entry,
+    account,
     client,
     repository: new PrismaScanRepository(client as unknown as PrismaClient),
   };
@@ -138,4 +150,194 @@ test.each([
   ]);
   const [result] = await repository.listBatches("12");
   expect(result.jobs[0].summary).toBe(expected);
+});
+
+const CLAIMED_ROW = {
+  id: BigInt(11),
+  document: {
+    id: BigInt(42),
+    storageKey: "key-1",
+    mime: "image/jpeg",
+    originalFilename: "IMG_1.jpg",
+  },
+  prompt: { body: "議員室プロンプト" },
+};
+
+test("帳簿の未処理ジョブを待機中・処理中に分けて数える", async () => {
+  const { job, repository } = setup();
+  job.groupBy.mockResolvedValue([
+    { status: "queued", _count: { _all: 3 } },
+    { status: "running", _count: { _all: 1 } },
+  ]);
+  await expect(repository.countUnfinished("12")).resolves.toEqual({ queued: 3, running: 1 });
+  expect(job.groupBy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      where: { batch: { bookId: BigInt(12) }, status: { in: ["queued", "running"] } },
+    }),
+  );
+});
+
+test("1件も未処理がなければ0を返す", async () => {
+  const { job, repository } = setup();
+  job.groupBy.mockResolvedValue([]);
+  await expect(repository.countUnfinished("12")).resolves.toEqual({ queued: 0, running: 0 });
+});
+
+test("待機中のジョブを古い順に処理中へ移し、読み取りに要る情報を返す", async () => {
+  const { job, repository } = setup();
+  job.findMany.mockResolvedValue([CLAIMED_ROW]);
+  job.updateMany.mockResolvedValue({ count: 1 });
+  await expect(repository.claimJobs("12", 2)).resolves.toEqual([
+    {
+      id: "11",
+      documentId: "42",
+      storageKey: "key-1",
+      mime: "image/jpeg",
+      originalFilename: "IMG_1.jpg",
+      officePrompt: "議員室プロンプト",
+    },
+  ]);
+  expect(job.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({ orderBy: { id: "asc" }, take: 2 }),
+  );
+  // 他の実行に先を越されていないか、状態を条件に入れて更新する
+  expect(job.updateMany).toHaveBeenCalledWith({
+    where: { id: BigInt(11), status: "queued" },
+    data: expect.objectContaining({ status: "running", error: null }),
+  });
+});
+
+test("他の実行が先に掴んだジョブは返さない（多重実行の防止）", async () => {
+  const { job, repository } = setup();
+  job.findMany.mockResolvedValue([CLAIMED_ROW, { ...CLAIMED_ROW, id: BigInt(12) }]);
+  job.updateMany.mockResolvedValueOnce({ count: 0 }).mockResolvedValueOnce({ count: 1 });
+  const claimed = await repository.claimJobs("12", 2);
+  expect(claimed.map((entry) => entry.id)).toEqual(["12"]);
+});
+
+test("処理中のまま失効したジョブを待機中に戻す", async () => {
+  const { job, repository } = setup();
+  job.updateMany.mockResolvedValue({ count: 2 });
+  const staleBefore = new Date("2026-09-12T09:00:00.000Z");
+  await expect(repository.releaseStaleJobs("12", staleBefore)).resolves.toBe(2);
+  expect(job.updateMany).toHaveBeenCalledWith({
+    where: {
+      batch: { bookId: BigInt(12) },
+      status: "running",
+      OR: [{ startedAt: null }, { startedAt: { lt: staleBefore } }],
+    },
+    data: { status: "queued", startedAt: null },
+  });
+});
+
+const COMPLETE_INPUT = {
+  bookId: "12",
+  jobId: "11",
+  documentId: "42",
+  rawJson: { date: "2026-04-01" },
+  userId: "user-1",
+  entries: [
+    {
+      entryDate: "2026-04-01",
+      description: "タクシー代",
+      accountKey: "taxi",
+      amount: 1200,
+      note: null,
+      splitGroup: null,
+      hash: "hash-a",
+      lines: [
+        { side: "debit" as const, accountKey: "taxi", amount: 1200 },
+        { side: "credit" as const, accountKey: "bank", amount: 1200 },
+      ],
+    },
+  ],
+};
+
+test("下書き仕訳と原文JSONを保存してジョブを完了にする", async () => {
+  const { entry, job, client, repository } = setup();
+  entry.findMany.mockResolvedValue([]);
+  await repository.completeJob(COMPLETE_INPUT);
+  expect(client.$transaction).toHaveBeenCalled();
+  expect(entry.create).toHaveBeenCalledWith({
+    data: expect.objectContaining({
+      bookId: BigInt(12),
+      description: "タクシー代",
+      status: "draft",
+      source: "scan",
+      documentId: BigInt(42),
+      hash: "hash-a",
+      createdById: "user-1",
+      lines: { create: COMPLETE_INPUT.entries[0].lines },
+    }),
+  });
+  expect(job.update).toHaveBeenCalledWith({
+    where: { id: BigInt(11) },
+    data: expect.objectContaining({ status: "succeeded", rawJson: { date: "2026-04-01" } }),
+  });
+});
+
+test("同じhashの仕訳が既にあれば作り直さない（再処理で二重にしない）", async () => {
+  const { entry, job, repository } = setup();
+  entry.findMany.mockResolvedValue([{ hash: "hash-a" }]);
+  await repository.completeJob(COMPLETE_INPUT);
+  expect(entry.create).not.toHaveBeenCalled();
+  // 仕訳を作らなくてもジョブ自体は完了させる
+  expect(job.update).toHaveBeenCalledWith(
+    expect.objectContaining({ data: expect.objectContaining({ status: "succeeded" }) }),
+  );
+});
+
+test("同じ抽出結果に同じhashの明細が並んでも1件しか作らない", async () => {
+  const { entry, repository } = setup();
+  entry.findMany.mockResolvedValue([]);
+  await repository.completeJob({
+    ...COMPLETE_INPUT,
+    entries: [COMPLETE_INPUT.entries[0], { ...COMPLETE_INPUT.entries[0] }],
+  });
+  expect(entry.create).toHaveBeenCalledTimes(1);
+});
+
+test("ジョブを失敗にしてエラーを記録する", async () => {
+  const { job, repository } = setup();
+  await repository.failJob("11", "読み取りに失敗しました");
+  expect(job.update).toHaveBeenCalledWith({
+    where: { id: BigInt(11) },
+    data: expect.objectContaining({ status: "failed", error: "読み取りに失敗しました" }),
+  });
+  // rawJson を渡さなければ既存の値を消さない
+  expect(job.update.mock.calls[0][0].data).not.toHaveProperty("rawJson");
+});
+
+test("長すぎるエラーは切り詰めて保存する", async () => {
+  const { job, repository } = setup();
+  await repository.failJob("11", "あ".repeat(600));
+  expect(job.update.mock.calls[0][0].data.error).toHaveLength(500);
+});
+
+test("失敗したジョブだけを待機中に戻す", async () => {
+  const { job, repository } = setup();
+  job.updateMany.mockResolvedValue({ count: 1 });
+  await expect(repository.requeueJob("12", "11")).resolves.toBe(true);
+  expect(job.updateMany).toHaveBeenCalledWith({
+    where: { id: BigInt(11), batch: { bookId: BigInt(12) }, status: "failed" },
+    data: { status: "queued", error: null, startedAt: null, finishedAt: null },
+  });
+});
+
+test("他の帳簿や失敗していないジョブは戻せない", async () => {
+  const { job, repository } = setup();
+  job.updateMany.mockResolvedValue({ count: 0 });
+  await expect(repository.requeueJob("12", "11")).resolves.toBe(false);
+});
+
+test("科目マスタをキーと種別だけにして返す", async () => {
+  const { account, repository } = setup();
+  account.findMany.mockResolvedValue([
+    { key: "bank", type: "asset" },
+    { key: "taxi", type: "expense" },
+  ]);
+  await expect(repository.accounts()).resolves.toEqual([
+    { key: "bank", type: "asset" },
+    { key: "taxi", type: "expense" },
+  ]);
 });

--- a/admin/tests/server/contexts/research-fund/infrastructure/storage/supabase-document-storage.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/storage/supabase-document-storage.test.ts
@@ -2,7 +2,12 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { SupabaseDocumentStorage } from "@/server/contexts/research-fund/infrastructure/storage/supabase-document-storage";
 
 describe("SupabaseDocumentStorage", () => {
-  const bucket = { upload: jest.fn(), createSignedUrl: jest.fn(), remove: jest.fn() };
+  const bucket = {
+    upload: jest.fn(),
+    download: jest.fn(),
+    createSignedUrl: jest.fn(),
+    remove: jest.fn(),
+  };
   const from = jest.fn(() => bucket);
   const client = { storage: { from } } as unknown as SupabaseClient;
   const storage = new SupabaseDocumentStorage(client, "private-receipts");
@@ -14,6 +19,10 @@ describe("SupabaseDocumentStorage", () => {
       error: null,
     });
     bucket.remove.mockResolvedValue({ data: [], error: null });
+    bucket.download.mockResolvedValue({
+      data: new Blob([new Uint8Array([1, 2, 3])]),
+      error: null,
+    });
   });
   it.each(["image/jpeg", "image/png", "application/pdf"])(
     "uploads %s without overwriting existing objects",
@@ -56,6 +65,20 @@ describe("SupabaseDocumentStorage", () => {
   it("rejects invalid expiry without contacting storage", async () => {
     expect(await storage.createSignedUrl("key", 0)).toMatchObject({ status: "invalid" });
     expect(from).not.toHaveBeenCalled();
+  });
+  it("downloads the original bytes for extraction", async () => {
+    expect(await storage.download("key")).toEqual({
+      status: "valid",
+      value: new Uint8Array([1, 2, 3]),
+    });
+    expect(bucket.download).toHaveBeenCalledWith("key");
+  });
+  it.each([
+    { data: null, error: new Error("denied") },
+    { data: null, error: null },
+  ])("reports download failures", async (response) => {
+    bucket.download.mockResolvedValue(response);
+    await expect(storage.download("key")).rejects.toThrow("原本");
   });
   it("removes only the requested key", async () => {
     await storage.remove("key");

--- a/admin/tests/server/contexts/research-fund/presentation/actions/process-scan-jobs.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/actions/process-scan-jobs.test.ts
@@ -1,0 +1,108 @@
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import type { ProcessScanJobsUsecase } from "@/server/contexts/research-fund/application/usecases/process-scan-jobs-usecase";
+import { processScanJobs } from "@/server/contexts/research-fund/presentation/actions/process-scan-jobs";
+import { retryScanJob } from "@/server/contexts/research-fund/presentation/actions/retry-scan-job";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { buildProcessScanJobsUsecase } from "@/server/contexts/research-fund/presentation/loaders/load-scan";
+
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/server/contexts/auth/presentation/loaders/require-auth", () => ({
+  requireAuth: jest.fn(),
+}));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({
+  requireJournalTarget: jest.fn(),
+}));
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-scan", () => ({
+  buildProcessScanJobsUsecase: jest.fn(),
+}));
+
+const execute = jest.fn();
+const retry = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest
+    .mocked(requireAuth)
+    .mockResolvedValue({ id: "user" } as Awaited<ReturnType<typeof requireAuth>>);
+  jest.mocked(requireJournalTarget).mockResolvedValue({
+    kind: "research-fund",
+    key: "book:1",
+    name: "議員",
+    year: 2026,
+    politicianId: "2",
+    bookId: "1",
+    draftCount: 0,
+  });
+  jest
+    .mocked(buildProcessScanJobsUsecase)
+    .mockReturnValue({ execute, retry } as unknown as ProcessScanJobsUsecase);
+  execute.mockResolvedValue({ processed: 2, succeeded: 2, failed: 0, hasMore: true });
+  retry.mockResolvedValue(true);
+});
+
+describe("processScanJobs", () => {
+  test("処理した件数と残りの有無を返し、レイアウトを再検証する", async () => {
+    await expect(processScanJobs("2", "1")).resolves.toEqual({
+      success: true,
+      processed: 2,
+      succeeded: 2,
+      failed: 0,
+      hasMore: true,
+    });
+    expect(execute).toHaveBeenCalledWith({ bookId: "1", userId: "user" });
+    expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
+  });
+
+  test("別の対象への古いフォーム送信を拒否", async () => {
+    jest.mocked(requireJournalTarget).mockResolvedValue(null);
+    await expect(processScanJobs("2", "1")).resolves.toMatchObject({ success: false });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("認証失敗時は処理を始めない", async () => {
+    jest.mocked(requireAuth).mockRejectedValueOnce(new Error("auth"));
+    await expect(processScanJobs("2", "1")).rejects.toThrow("auth");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  test("内部エラーの詳細は漏らさない", async () => {
+    execute.mockRejectedValueOnce(new Error("ANTHROPIC_API_KEY is missing"));
+    await expect(processScanJobs("2", "1")).resolves.toEqual({
+      success: false,
+      error: "読み取りの実行に失敗しました。時間をおいて再度お試しください",
+    });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+describe("retryScanJob", () => {
+  test("失敗したジョブを待機中に戻し、レイアウトを再検証する", async () => {
+    await expect(retryScanJob("2", "1", "11")).resolves.toEqual({ success: true });
+    expect(retry).toHaveBeenCalledWith({ bookId: "1", jobId: "11" });
+    expect(revalidatePath).toHaveBeenCalledWith("/(auth)", "layout");
+  });
+
+  test("既に処理済みなら再読み込みを促す", async () => {
+    retry.mockResolvedValue(false);
+    await expect(retryScanJob("2", "1", "11")).resolves.toEqual({
+      success: false,
+      error: "このジョブは再実行できません。画面を再読み込みしてください",
+    });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  test("別の対象への古いフォーム送信を拒否", async () => {
+    jest.mocked(requireJournalTarget).mockResolvedValue(null);
+    await expect(retryScanJob("2", "1", "11")).resolves.toMatchObject({ success: false });
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  test("内部エラーの詳細は漏らさない", async () => {
+    retry.mockRejectedValueOnce(new Error("db detail"));
+    await expect(retryScanJob("2", "1", "11")).resolves.toEqual({
+      success: false,
+      error: "再実行に失敗しました。時間をおいて再度お試しください",
+    });
+  });
+});


### PR DESCRIPTION
## 目的（Why）

議員室のスタッフが、アップロードした領収書を1枚ずつ手入力せずに済むようにするため。
これまでスキャン画面は書類を `queued` ジョブとして積むところまでで止まっており、
読み取りが一切走らなかった。本 PR でパイプラインの本丸（LLM 読み取り → 下書き仕訳）をつなぐ。

## 変更内容

キュー基盤（QStash / cron）は導入せず、設計の「ジョブ実行方式」どおり
サーバーレスのタイムアウト内に収まる少数ずつ処理し、画面が呼び出し役を兼ねる。

**ドメイン**
- `domain/models/scan-job.ts`: 1回に着手する件数（= 同時 running の上限）と失効判定
- `domain/services/scan-journal-builder.ts`: 抽出結果 → 明細ごとの複式仕訳
  - `needs-review` は科目未確定のまま下書きにする（推測しない）
  - 1書類複数明細には `split_group` を振る。キーは書類IDで名前空間を切り、別の書類の同名キーと混ざらないようにした
  - hash は日付・金額・項目名・書類ID から生成

**アプリケーション**
- `ProcessScanJobsUsecase`: `queued` を古い順に少数だけ処理。running が上限に達していれば1件も着手しない（多重実行の防止）。
  関数が途中で落ちて running のまま残ったジョブは失効として待機中に戻す（これが無いと以後どのジョブも着手できなくなる）。
  1件の失敗は `error` に記録して残りのジョブを巻き込まない。

**インフラ**
- `PrismaScanRepository`: `countUnfinished` / `claimJobs` / `releaseStaleJobs` / `completeJob` / `failJob` / `requeueJob` / `accounts`
  - `claimJobs` は `status: "queued"` を条件に含めた条件付き更新で掴む（同時実行に先を越されたジョブは諦めて次へ）
  - `completeJob` は仕訳保存とジョブ完了を1トランザクションで行い、**同じ hash の仕訳が既にあれば作り直さない**
- `DocumentStorage.download` を追加（読み取りに原本のバイト列が要るため）

**画面**
- 未処理が残っている間、自動で `processScanJobs` を呼び続け、ジョブ表と進捗バーがポーリングで更新される
- 失敗行に「再実行」ボタン（`queued` に戻す）
- 「完了分を確認へ」で仕訳確認画面の下書きタブ（`?status=draft`）に遷移する

Prisma の schema 変更は不要（既存の `ResearchFundScanJob` / `ResearchFundJournalEntry` で足りる）。

## ローカル CI

- `pnpm verify` ✅（test / typecheck / lint / knip / depcruise すべて green）
  - admin: 136 suites / 1563 tests passed（新規 56 tests）
- 画面の導線が変わるため E2E も実行: `pnpm test:e2e:admin` ✅ **49 passed**（`scan.spec.ts` / `journal-review.spec.ts` 含む）

LLM・Storage はすべてモックで、実 API は叩いていない。

## スコープアウト

- プロンプトのテスト実行（#1366）
- 外部キュー（QStash / cron）の導入
- 実 API を叩く統合テスト

Closes #1365

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 書類アップロード後のスキャン処理を自動開始し、進捗や完了・失敗状況を表示できるようになりました。
  - 失敗したスキャンを再実行できるようになりました。
  - 完了した書類から仕訳確認画面へ移動できるようになりました。
  - URLのステータス指定に応じて、仕訳確認画面の初期タブを表示できるようになりました。
  - スキャン結果から下書き仕訳を自動作成できるようになりました。
  - 同一内容の明細を個別に扱えるようになりました。

- **バグ修正**
  - 処理中のまま停止したジョブを適切に再処理できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->