### PR TITLE
feat(admin): 読み取りプロンプトのテスト実行

### DIFF
--- a/admin/e2e/tests/prompts.spec.ts
+++ b/admin/e2e/tests/prompts.spec.ts
@@ -32,6 +32,11 @@ test("デフォルトから初版を保存し、編集して版を重ね、巻�
   await expect(details).toBeVisible();
   await expect(page.getByText("領収書の抽出結果を次のJSONスキーマに従って")).toBeVisible();
 
+  // 書類が無い帳簿ではテスト実行の select を出さず、アップロードへ促す
+  await expect(page.getByRole("heading", { name: "テスト実行" })).toBeVisible();
+  await expect(page.getByText("この帳簿にはまだ書類がありません")).toBeVisible();
+  await expect(page.getByRole("button", { name: "テスト実行" })).toBeHidden();
+
   await clickUntil(page.getByRole("button", { name: "保存して v1 にする" }), (options) =>
     expect(page.getByText("v1 有効")).toBeVisible(options),
   );

--- a/admin/src/client/components/research-fund/PromptEditor.tsx
+++ b/admin/src/client/components/research-fund/PromptEditor.tsx
@@ -2,11 +2,16 @@
 import { useId, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Button, Card, CardContent, Label, Textarea } from "@/client/components/ui";
+import { Play } from "@phosphor-icons/react/dist/ssr";
+import { Button, Card, CardContent, Label, NativeSelect, Textarea } from "@/client/components/ui";
 import { PageHeader } from "@/client/components/layout/PageHeader";
 import { cn } from "@/client/lib";
-import type { PromptOverview } from "@/server/contexts/research-fund/domain/models/prompt";
+import type {
+  PromptOverview,
+  PromptTestDocument,
+} from "@/server/contexts/research-fund/domain/models/prompt";
 import { mutatePrompt } from "@/server/contexts/research-fund/presentation/actions/manage-prompt";
+import { testPrompt } from "@/server/contexts/research-fund/presentation/actions/test-prompt";
 import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
 
 function formatDate(isoDate: string) {
@@ -19,12 +24,20 @@ export function PromptEditor({
   activeVersion,
   nextVersion,
   automaticPrompt,
+  testDocuments,
   target,
-}: PromptOverview & { target: Extract<AdminTarget, { kind: "research-fund" }> }) {
+}: PromptOverview & {
+  testDocuments: PromptTestDocument[];
+  target: Extract<AdminTarget, { kind: "research-fund" }>;
+}) {
   const router = useRouter();
   const fieldId = useId();
+  const testDocumentId = useId();
   const [body, setBody] = useState(savedBody);
   const [pending, startTransition] = useTransition();
+  const [selectedDocumentId, setSelectedDocumentId] = useState(testDocuments[0]?.id ?? "");
+  const [testing, startTesting] = useTransition();
+  const [testResult, setTestResult] = useState<{ json: string } | { error: string } | null>(null);
   const dirty = body !== savedBody;
   // 版が 1 つも無いうちは、デフォルトテンプレートのまま保存して v1 を作れるようにする
   const savable = body.trim().length > 0 && (dirty || activeVersion === null);
@@ -49,6 +62,25 @@ export function PromptEditor({
     });
   }
 
+  function runTest() {
+    setTestResult(null);
+    startTesting(async () => {
+      try {
+        const result = await testPrompt(target.politicianId, target.bookId, {
+          documentId: selectedDocumentId,
+          body,
+        });
+        setTestResult(
+          result.success
+            ? { json: JSON.stringify(result.extracted, null, 2) }
+            : { error: result.error },
+        );
+      } catch {
+        setTestResult({ error: "通信に失敗しました。再度お試しください" });
+      }
+    });
+  }
+
   return (
     <>
       <PageHeader
@@ -57,65 +89,115 @@ export function PromptEditor({
         description={`${target.name}の議員室のスキャンで使う整理プロンプト。保存すると新しい版になり、各ジョブは使った版を記録します。`}
       />
       <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,1.5fr)_minmax(300px,1fr)]">
-        <Card>
-          <CardContent className="p-5">
-            <details className="mb-4 rounded-lg border border-border-soft">
-              <summary className="cursor-pointer list-none px-4 py-3 text-sm font-bold">
-                自動で付加される部分を見る（出力スキーマ・費用カテゴリの語彙と定義）
-              </summary>
-              <div className="border-t border-border-soft px-4 py-3">
-                <p className="mb-2 text-xs text-muted-foreground">
-                  システムが自動で付加します。この画面からは編集できません。
-                </p>
-                <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-background p-3 text-xs">
-                  {automaticPrompt}
-                </pre>
+        <div className="flex flex-col gap-5">
+          <Card>
+            <CardContent className="p-5">
+              <details className="mb-4 rounded-lg border border-border-soft">
+                <summary className="cursor-pointer list-none px-4 py-3 text-sm font-bold">
+                  自動で付加される部分を見る（出力スキーマ・費用カテゴリの語彙と定義）
+                </summary>
+                <div className="border-t border-border-soft px-4 py-3">
+                  <p className="mb-2 text-xs text-muted-foreground">
+                    システムが自動で付加します。この画面からは編集できません。
+                  </p>
+                  <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-background p-3 text-xs">
+                    {automaticPrompt}
+                  </pre>
+                </div>
+              </details>
+              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <Label htmlFor={fieldId}>プロンプト本文</Label>
+                <span
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs font-latin",
+                    activeVersion === null
+                      ? "text-muted-foreground"
+                      : "border-ring bg-accent text-accent-foreground",
+                  )}
+                >
+                  {activeVersion === null ? "未保存（デフォルト）" : `v${activeVersion} 有効`}
+                </span>
               </div>
-            </details>
-            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-              <Label htmlFor={fieldId}>プロンプト本文</Label>
-              <span
-                className={cn(
-                  "rounded-full border px-3 py-1 text-xs font-latin",
-                  activeVersion === null
-                    ? "text-muted-foreground"
-                    : "border-ring bg-accent text-accent-foreground",
-                )}
-              >
-                {activeVersion === null ? "未保存（デフォルト）" : `v${activeVersion} 有効`}
-              </span>
-            </div>
-            <Textarea
-              id={fieldId}
-              rows={16}
-              className="min-h-80 font-mono text-sm"
-              value={body}
-              disabled={pending}
-              onChange={(event) => setBody(event.target.value)}
-            />
-            <div className="mt-4 flex flex-wrap gap-2">
-              <Button
-                disabled={pending || !savable}
-                onClick={() => run({ type: "save", body }, (message) => toast.success(message))}
-              >
-                保存して v{nextVersion} にする
-              </Button>
-              <Button
-                variant="outline"
-                disabled={pending || !dirty}
-                onClick={() => setBody(savedBody)}
-              >
-                変更を破棄
-              </Button>
-            </div>
-            {activeVersion === null && (
-              <p className="mt-3 text-xs text-muted-foreground">
-                まだ版がありません。デフォルトテンプレートを下敷きに編集し、保存すると v1
-                になります。
+              <Textarea
+                id={fieldId}
+                rows={16}
+                className="min-h-80 font-mono text-sm"
+                value={body}
+                disabled={pending}
+                onChange={(event) => setBody(event.target.value)}
+              />
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button
+                  disabled={pending || !savable}
+                  onClick={() => run({ type: "save", body }, (message) => toast.success(message))}
+                >
+                  保存して v{nextVersion} にする
+                </Button>
+                <Button
+                  variant="outline"
+                  disabled={pending || !dirty}
+                  onClick={() => setBody(savedBody)}
+                >
+                  変更を破棄
+                </Button>
+              </div>
+              {activeVersion === null && (
+                <p className="mt-3 text-xs text-muted-foreground">
+                  まだ版がありません。デフォルトテンプレートを下敷きに編集し、保存すると v1
+                  になります。
+                </p>
+              )}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-5">
+              <h2 className="font-bold">テスト実行</h2>
+              <p className="mt-1 mb-3 text-sm text-muted-foreground">
+                編集中の本文（未保存でよい）で書類1枚だけを読み取り、結果を確認できます。仕訳・ジョブは作られません。
               </p>
-            )}
-          </CardContent>
-        </Card>
+              {testDocuments.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  この帳簿にはまだ書類がありません。「書類スキャン」からアップロードすると選べるようになります。
+                </p>
+              ) : (
+                <div className="flex flex-wrap items-end gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor={testDocumentId}>書類</Label>
+                    <NativeSelect
+                      id={testDocumentId}
+                      className="w-60"
+                      value={selectedDocumentId}
+                      disabled={testing}
+                      onChange={(event) => setSelectedDocumentId(event.target.value)}
+                    >
+                      {testDocuments.map((document) => (
+                        <option key={document.id} value={document.id}>
+                          {document.originalFilename}
+                        </option>
+                      ))}
+                    </NativeSelect>
+                  </div>
+                  <Button
+                    variant="outline"
+                    disabled={testing || body.trim().length === 0 || !selectedDocumentId}
+                    onClick={runTest}
+                  >
+                    <Play aria-hidden className="size-4" />
+                    {testing ? "読み取り中…" : "テスト実行"}
+                  </Button>
+                </div>
+              )}
+              {testResult !== null &&
+                ("json" in testResult ? (
+                  <pre className="mt-4 max-h-80 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-accent p-4 font-mono text-xs">
+                    {testResult.json}
+                  </pre>
+                ) : (
+                  <p className="mt-4 text-sm text-destructive">{testResult.error}</p>
+                ))}
+            </CardContent>
+          </Card>
+        </div>
         <Card className="xl:sticky xl:top-6">
           <CardContent className="p-5">
             <h2 className="mb-3 font-bold">版履歴</h2>

--- a/admin/src/client/components/research-fund/PromptEditor.tsx
+++ b/admin/src/client/components/research-fund/PromptEditor.tsx
@@ -2,7 +2,7 @@
 import { useId, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Play } from "@phosphor-icons/react/dist/ssr";
+import { CircleNotch, Play } from "@phosphor-icons/react/dist/ssr";
 import { Button, Card, CardContent, Label, NativeSelect, Textarea } from "@/client/components/ui";
 import { PageHeader } from "@/client/components/layout/PageHeader";
 import { cn } from "@/client/lib";
@@ -123,8 +123,11 @@ export function PromptEditor({
                 rows={16}
                 className="min-h-80 font-mono text-sm"
                 value={body}
-                disabled={pending}
-                onChange={(event) => setBody(event.target.value)}
+                disabled={pending || testing}
+                onChange={(event) => {
+                  setBody(event.target.value);
+                  setTestResult(null);
+                }}
               />
               <div className="mt-4 flex flex-wrap gap-2">
                 <Button
@@ -136,7 +139,10 @@ export function PromptEditor({
                 <Button
                   variant="outline"
                   disabled={pending || !dirty}
-                  onClick={() => setBody(savedBody)}
+                  onClick={() => {
+                    setBody(savedBody);
+                    setTestResult(null);
+                  }}
                 >
                   変更を破棄
                 </Button>
@@ -168,7 +174,10 @@ export function PromptEditor({
                       className="w-60"
                       value={selectedDocumentId}
                       disabled={testing}
-                      onChange={(event) => setSelectedDocumentId(event.target.value)}
+                      onChange={(event) => {
+                        setSelectedDocumentId(event.target.value);
+                        setTestResult(null);
+                      }}
                     >
                       {testDocuments.map((document) => (
                         <option key={document.id} value={document.id}>
@@ -182,7 +191,11 @@ export function PromptEditor({
                     disabled={testing || body.trim().length === 0 || !selectedDocumentId}
                     onClick={runTest}
                   >
-                    <Play aria-hidden className="size-4" />
+                    {testing ? (
+                      <CircleNotch aria-hidden className="size-4 animate-spin" />
+                    ) : (
+                      <Play aria-hidden className="size-4" />
+                    )}
                     {testing ? "読み取り中…" : "テスト実行"}
                   </Button>
                 </div>

--- a/admin/src/server/contexts/research-fund/application/usecases/test-prompt-usecase.ts
+++ b/admin/src/server/contexts/research-fund/application/usecases/test-prompt-usecase.ts
@@ -1,0 +1,87 @@
+import "server-only";
+import { ResearchFundDocument } from "@/server/contexts/research-fund/domain/models/document";
+import type { ExtractedReceipt } from "@/server/contexts/research-fund/domain/models/extracted-receipt";
+import {
+  normalizePromptBody,
+  type PromptTestDocument,
+} from "@/server/contexts/research-fund/domain/models/prompt";
+import type { DocumentRepository } from "@/server/contexts/research-fund/domain/repositories/document-repository.interface";
+import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
+import type { ReceiptExtractionGateway } from "@/server/contexts/research-fund/domain/repositories/receipt-extraction-gateway.interface";
+import {
+  invalidResearchFundResult,
+  RF_ERROR_CODES,
+  type ResearchFundResult,
+} from "@/server/contexts/research-fund/domain/types/validation";
+
+/** テスト実行の候補に出す書類の上限。多すぎる select を避けるためだけの数 */
+export const PROMPT_TEST_DOCUMENT_LIMIT = 50;
+
+const EXTRACTABLE_MIMES: readonly string[] = ["image/jpeg", "image/png", "application/pdf"];
+
+type ExtractableMime = "image/jpeg" | "image/png" | "application/pdf";
+
+/**
+ * 編集中のプロンプトで既存の書類 1 枚を読み取り、抽出 JSON だけを返す。
+ *
+ * スキャンジョブと同じゲートウェイを呼ぶが、**何も保存しない**（ジョブ・下書き仕訳・raw_json を作らない）。
+ * プロンプトを直したときに本番の帳簿を汚さず結果を確かめるための経路。
+ */
+export class TestPromptUsecase {
+  constructor(
+    private documentRepository: DocumentRepository,
+    private storage: DocumentStorage,
+    private gateway: ReceiptExtractionGateway,
+  ) {}
+
+  /** テスト実行で選べる書類を新しい順に返す */
+  async listDocuments(bookId: string): Promise<PromptTestDocument[]> {
+    const validation = ResearchFundDocument.validateId(bookId);
+    if (validation.status === "invalid") throw new Error(validation.errors[0].message);
+    const documents = await this.documentRepository.listByBook(bookId, PROMPT_TEST_DOCUMENT_LIMIT);
+    return documents.map((document) => ({
+      id: document.id,
+      originalFilename: document.originalFilename,
+      mime: document.mime,
+    }));
+  }
+
+  async execute(input: {
+    bookId: string;
+    documentId: string;
+    /** エディタの本文。未保存でよい（版は作らない） */
+    officePrompt: unknown;
+  }): Promise<ResearchFundResult<ExtractedReceipt>> {
+    for (const result of [
+      ResearchFundDocument.validateId(input.bookId),
+      ResearchFundDocument.validateId(input.documentId),
+    ]) {
+      if (result.status === "invalid") return result;
+    }
+    // 保存はしないが、空・長すぎる本文は保存時と同じ基準で弾く（PromptError を投げる）
+    const officePrompt = normalizePromptBody(input.officePrompt);
+
+    const document = await this.documentRepository.findById(input.bookId, input.documentId);
+    if (!document) {
+      return invalidResearchFundResult(
+        "documentId",
+        RF_ERROR_CODES.DOCUMENT_NOT_FOUND,
+        "書類が見つかりません",
+      );
+    }
+    if (!EXTRACTABLE_MIMES.includes(document.mime)) {
+      return invalidResearchFundResult(
+        "document",
+        RF_ERROR_CODES.INVALID_DOCUMENT,
+        "JPG・PNG・PDFのみ読み取れます",
+      );
+    }
+    const bytes = await this.storage.download(document.storageKey);
+    if (bytes.status === "invalid") return bytes;
+
+    return await this.gateway.extract({
+      document: { bytes: bytes.value, mime: document.mime as ExtractableMime },
+      officePrompt,
+    });
+  }
+}

--- a/admin/src/server/contexts/research-fund/domain/models/prompt.ts
+++ b/admin/src/server/contexts/research-fund/domain/models/prompt.ts
@@ -29,6 +29,13 @@ export interface PromptOverview {
   automaticPrompt: string;
 }
 
+/** テスト実行の書類 select に出す 1 件（原本は署名 URL 無しでサーバー側だけが読む） */
+export interface PromptTestDocument {
+  id: string;
+  originalFilename: string;
+  mime: string;
+}
+
 export class PromptError extends Error {}
 
 /**

--- a/admin/src/server/contexts/research-fund/domain/repositories/document-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/document-repository.interface.ts
@@ -3,4 +3,6 @@ import type { ResearchFundDocument } from "@/server/contexts/research-fund/domai
 export interface DocumentRepository {
   create(input: Omit<ResearchFundDocument, "id" | "createdAt">): Promise<ResearchFundDocument>;
   findById(bookId: string, documentId: string): Promise<ResearchFundDocument | null>;
+  /** 帳簿の書類を新しい順に最大 limit 件返す（プロンプトのテスト実行で選ぶ候補） */
+  listByBook(bookId: string, limit: number): Promise<ResearchFundDocument[]>;
 }

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository.ts
@@ -25,7 +25,7 @@ export class PrismaDocumentRepository implements DocumentRepository {
   async listByBook(bookId: string, limit: number): Promise<ResearchFundDocument[]> {
     const rows = await this.prisma.researchFundDocument.findMany({
       where: { bookId: BigInt(bookId) },
-      orderBy: { id: "desc" },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: limit,
     });
     return rows.map((row) => this.toModel(row));

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository.ts
@@ -22,6 +22,15 @@ export class PrismaDocumentRepository implements DocumentRepository {
     return row ? this.toModel(row) : null;
   }
 
+  async listByBook(bookId: string, limit: number): Promise<ResearchFundDocument[]> {
+    const rows = await this.prisma.researchFundDocument.findMany({
+      where: { bookId: BigInt(bookId) },
+      orderBy: { id: "desc" },
+      take: limit,
+    });
+    return rows.map((row) => this.toModel(row));
+  }
+
   private toModel(row: PrismaDocument): ResearchFundDocument {
     return {
       id: row.id.toString(),

--- a/admin/src/server/contexts/research-fund/presentation/actions/test-prompt.ts
+++ b/admin/src/server/contexts/research-fund/presentation/actions/test-prompt.ts
@@ -1,0 +1,43 @@
+"use server";
+import "server-only";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
+import { PromptError } from "@/server/contexts/research-fund/domain/models/prompt";
+import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { buildTestPromptUsecase } from "@/server/contexts/research-fund/presentation/loaders/load-prompts";
+
+/**
+ * 編集中（未保存でよい）のプロンプトで書類 1 枚を読み取り、抽出 JSON を返す。
+ *
+ * 何も保存しないので再検証（revalidate）は行わない。サーバーアクションにしているのは、
+ * 読み取りに使う本文がクライアントのエディタにしか無く、LLM の呼び出しをサーバーに閉じるため。
+ */
+export async function testPrompt(
+  politicianId: string,
+  bookId: string,
+  input: {
+    documentId: string;
+    body: string;
+  },
+) {
+  await requireAuth();
+  if (!(await requireJournalTarget(politicianId, bookId)))
+    return { success: false as const, error: "現在の対象帳簿を選択し直してください" };
+  try {
+    const result = await buildTestPromptUsecase().execute({
+      bookId,
+      documentId: input.documentId,
+      officePrompt: input.body,
+    });
+    if (result.status === "invalid")
+      return { success: false as const, error: result.errors[0].message };
+    return { success: true as const, extracted: result.value };
+  } catch (error) {
+    return {
+      success: false as const,
+      error:
+        error instanceof PromptError
+          ? error.message
+          : "テスト実行に失敗しました。時間をおいて再度お試しください",
+    };
+  }
+}

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-prompts.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-prompts.ts
@@ -1,16 +1,29 @@
 import "server-only";
 import { notFound } from "next/navigation";
 import { ManagePromptUsecase } from "@/server/contexts/research-fund/application/usecases/manage-prompt-usecase";
+import { TestPromptUsecase } from "@/server/contexts/research-fund/application/usecases/test-prompt-usecase";
+import { VercelAIReceiptExtractionGateway } from "@/server/contexts/research-fund/infrastructure/llm/vercel-ai-receipt-extraction-gateway";
+import { PrismaDocumentRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository";
 import { PrismaPromptRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-prompt.repository";
 import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
+import { buildDocumentStorage } from "@/server/contexts/research-fund/presentation/loaders/load-scan";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+export function buildTestPromptUsecase(): TestPromptUsecase {
+  return new TestPromptUsecase(
+    new PrismaDocumentRepository(prisma),
+    buildDocumentStorage(),
+    new VercelAIReceiptExtractionGateway(),
+  );
+}
 
 export async function loadPrompts(politicianId: string, bookId: string) {
   const target = await requireJournalTarget(politicianId, bookId);
   if (!target) notFound();
   // プロンプトは議員室（議員）ごと。年度帳簿をまたいで同じ版を使う
-  const data = await new ManagePromptUsecase(new PrismaPromptRepository(prisma)).list(
-    target.politicianId,
-  );
-  return { ...data, target };
+  const [data, testDocuments] = await Promise.all([
+    new ManagePromptUsecase(new PrismaPromptRepository(prisma)).list(target.politicianId),
+    buildTestPromptUsecase().listDocuments(bookId),
+  ]);
+  return { ...data, testDocuments, target };
 }

--- a/admin/src/server/contexts/research-fund/presentation/loaders/load-scan.ts
+++ b/admin/src/server/contexts/research-fund/presentation/loaders/load-scan.ts
@@ -11,7 +11,7 @@ import { researchFundDocumentBucket } from "@/server/contexts/research-fund/infr
 import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 
-function buildDocumentStorage(): SupabaseDocumentStorage {
+export function buildDocumentStorage(): SupabaseDocumentStorage {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) throw new Error("領収書ストレージが未設定です");

--- a/admin/tests/server/contexts/research-fund/application/usecases/get-document-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/get-document-usecase.test.ts
@@ -3,7 +3,11 @@ import type { DocumentRepository } from "@/server/contexts/research-fund/domain/
 import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
 
 describe("GetDocumentUsecase", () => {
-  const repository: jest.Mocked<DocumentRepository> = { create: jest.fn(), findById: jest.fn() };
+  const repository: jest.Mocked<DocumentRepository> = {
+    create: jest.fn(),
+    findById: jest.fn(),
+    listByBook: jest.fn(),
+  };
   const storage: jest.Mocked<DocumentStorage> = {
     upload: jest.fn(),
     download: jest.fn(),

--- a/admin/tests/server/contexts/research-fund/application/usecases/register-document-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/register-document-usecase.test.ts
@@ -3,7 +3,11 @@ import type { DocumentRepository } from "@/server/contexts/research-fund/domain/
 import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
 
 describe("RegisterDocumentUsecase", () => {
-  const repository: jest.Mocked<DocumentRepository> = { create: jest.fn(), findById: jest.fn() };
+  const repository: jest.Mocked<DocumentRepository> = {
+    create: jest.fn(),
+    findById: jest.fn(),
+    listByBook: jest.fn(),
+  };
   const storage: jest.Mocked<DocumentStorage> = {
     upload: jest.fn(),
     download: jest.fn(),

--- a/admin/tests/server/contexts/research-fund/application/usecases/test-prompt-usecase.test.ts
+++ b/admin/tests/server/contexts/research-fund/application/usecases/test-prompt-usecase.test.ts
@@ -1,0 +1,172 @@
+import {
+  PROMPT_TEST_DOCUMENT_LIMIT,
+  TestPromptUsecase,
+} from "@/server/contexts/research-fund/application/usecases/test-prompt-usecase";
+import type { ResearchFundDocument } from "@/server/contexts/research-fund/domain/models/document";
+import { PromptError } from "@/server/contexts/research-fund/domain/models/prompt";
+import type { DocumentRepository } from "@/server/contexts/research-fund/domain/repositories/document-repository.interface";
+import type { DocumentStorage } from "@/server/contexts/research-fund/domain/repositories/document-storage.interface";
+import type { ReceiptExtractionGateway } from "@/server/contexts/research-fund/domain/repositories/receipt-extraction-gateway.interface";
+import { RF_ERROR_CODES } from "@/server/contexts/research-fund/domain/types/validation";
+
+const DOCUMENT: ResearchFundDocument = {
+  id: "42",
+  bookId: "12",
+  storageKey: "key-1",
+  mime: "image/jpeg",
+  originalFilename: "IMG_1.jpg",
+  createdAt: new Date("2026-04-01T00:00:00Z"),
+};
+
+const RECEIPT = {
+  date: "2026-04-01",
+  items: [
+    { item: "タクシー代", amount: 1200, category_key: "taxi", note: null, split_group: null },
+  ],
+} as const;
+
+describe("TestPromptUsecase", () => {
+  const documentRepository: jest.Mocked<DocumentRepository> = {
+    create: jest.fn(),
+    findById: jest.fn(),
+    listByBook: jest.fn(),
+  };
+  const storage: jest.Mocked<DocumentStorage> = {
+    upload: jest.fn(),
+    download: jest.fn(),
+    createSignedUrl: jest.fn(),
+    remove: jest.fn(),
+  };
+  const gateway: jest.Mocked<ReceiptExtractionGateway> = { extract: jest.fn() };
+  const usecase = new TestPromptUsecase(documentRepository, storage, gateway);
+  const input = { bookId: "12", documentId: "42", officePrompt: "編集中のプロンプト" };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    documentRepository.findById.mockResolvedValue(DOCUMENT);
+    storage.download.mockResolvedValue({ status: "valid", value: new Uint8Array([1, 2]) });
+    gateway.extract.mockResolvedValue({
+      status: "valid",
+      value: { ...RECEIPT, items: [...RECEIPT.items] },
+    });
+  });
+
+  describe("listDocuments", () => {
+    it("returns the book's documents for the select", async () => {
+      documentRepository.listByBook.mockResolvedValue([DOCUMENT]);
+
+      await expect(usecase.listDocuments("12")).resolves.toEqual([
+        { id: "42", originalFilename: "IMG_1.jpg", mime: "image/jpeg" },
+      ]);
+      expect(documentRepository.listByBook).toHaveBeenCalledWith("12", PROMPT_TEST_DOCUMENT_LIMIT);
+    });
+
+    it("rejects an invalid book id", async () => {
+      await expect(usecase.listDocuments("0")).rejects.toThrow("有効なIDを指定してください");
+      expect(documentRepository.listByBook).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("execute", () => {
+    it("extracts with the unsaved editor body and returns the JSON", async () => {
+      const result = await usecase.execute(input);
+
+      expect(gateway.extract).toHaveBeenCalledWith({
+        document: { bytes: new Uint8Array([1, 2]), mime: "image/jpeg" },
+        officePrompt: "編集中のプロンプト",
+      });
+      expect(result).toEqual({
+        status: "valid",
+        value: expect.objectContaining({ date: "2026-04-01" }),
+      });
+    });
+
+    it("saves nothing: no journal entries, no job, no raw_json", async () => {
+      await usecase.execute(input);
+
+      // 書き込み系の口はこの usecase には渡っていない。読み取りに使う口だけが呼ばれる
+      expect(documentRepository.create).not.toHaveBeenCalled();
+      expect(storage.upload).not.toHaveBeenCalled();
+      expect(storage.remove).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty prompt body without calling the gateway", async () => {
+      await expect(usecase.execute({ ...input, officePrompt: "  " })).rejects.toThrow(PromptError);
+      expect(gateway.extract).not.toHaveBeenCalled();
+    });
+
+    it("returns an invalid result for a document outside the book", async () => {
+      documentRepository.findById.mockResolvedValue(null);
+
+      const result = await usecase.execute(input);
+
+      expect(result).toEqual({
+        status: "invalid",
+        errors: [expect.objectContaining({ code: RF_ERROR_CODES.DOCUMENT_NOT_FOUND })],
+      });
+      expect(gateway.extract).not.toHaveBeenCalled();
+    });
+
+    it("returns an invalid result for an unreadable mime type", async () => {
+      documentRepository.findById.mockResolvedValue({ ...DOCUMENT, mime: "text/plain" });
+
+      const result = await usecase.execute(input);
+
+      expect(result).toEqual({
+        status: "invalid",
+        errors: [expect.objectContaining({ message: "JPG・PNG・PDFのみ読み取れます" })],
+      });
+      expect(storage.download).not.toHaveBeenCalled();
+    });
+
+    it("returns an invalid id result before touching the repository", async () => {
+      const result = await usecase.execute({ ...input, documentId: "abc" });
+
+      expect(result.status).toBe("invalid");
+      expect(documentRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it("passes the download failure through", async () => {
+      storage.download.mockResolvedValue({
+        status: "invalid",
+        errors: [
+          {
+            path: "storageKey",
+            code: RF_ERROR_CODES.DOCUMENT_NOT_FOUND,
+            message: "原本を取得できませんでした",
+            severity: "error",
+          },
+        ],
+      });
+
+      const result = await usecase.execute(input);
+
+      expect(result).toEqual({
+        status: "invalid",
+        errors: [expect.objectContaining({ message: "原本を取得できませんでした" })],
+      });
+      expect(gateway.extract).not.toHaveBeenCalled();
+    });
+
+    it("passes the extraction failure through", async () => {
+      gateway.extract.mockResolvedValue({
+        status: "invalid",
+        errors: [
+          {
+            path: "",
+            code: RF_ERROR_CODES.EXTRACTION_FAILED,
+            message: "領収書の読み取りに失敗しました",
+            severity: "error",
+          },
+        ],
+      });
+
+      const result = await usecase.execute(input);
+
+      expect(result).toEqual({
+        status: "invalid",
+        errors: [expect.objectContaining({ code: RF_ERROR_CODES.EXTRACTION_FAILED })],
+      });
+    });
+  });
+});

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository.test.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 import { PrismaDocumentRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository";
 
 describe("PrismaDocumentRepository", () => {
-  const delegate = { create: jest.fn(), findFirst: jest.fn() };
+  const delegate = { create: jest.fn(), findFirst: jest.fn(), findMany: jest.fn() };
   const repository = new PrismaDocumentRepository({
     researchFundDocument: delegate,
   } as unknown as PrismaClient);
@@ -44,6 +44,17 @@ describe("PrismaDocumentRepository", () => {
     expect(await repository.findById("13", "9007199254740993")).toBeNull();
     expect(delegate.findFirst).toHaveBeenLastCalledWith({
       where: { id: BigInt("9007199254740993"), bookId: BigInt("13") },
+    });
+  });
+  it("lists the book's documents newest first within the limit", async () => {
+    delegate.findMany.mockResolvedValue([row]);
+    expect(await repository.listByBook("12", 50)).toEqual([
+      expect.objectContaining({ id: "9007199254740993", bookId: "12" }),
+    ]);
+    expect(delegate.findMany).toHaveBeenCalledWith({
+      where: { bookId: BigInt("12") },
+      orderBy: { id: "desc" },
+      take: 50,
     });
   });
   it("propagates database errors", async () => {

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-document.repository.test.ts
@@ -53,7 +53,7 @@ describe("PrismaDocumentRepository", () => {
     ]);
     expect(delegate.findMany).toHaveBeenCalledWith({
       where: { bookId: BigInt("12") },
-      orderBy: { id: "desc" },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: 50,
     });
   });

--- a/admin/tests/server/contexts/research-fund/presentation/loaders/load-prompts.test.ts
+++ b/admin/tests/server/contexts/research-fund/presentation/loaders/load-prompts.test.ts
@@ -1,25 +1,36 @@
 import { notFound } from "next/navigation";
 import { ManagePromptUsecase } from "@/server/contexts/research-fund/application/usecases/manage-prompt-usecase";
+import { TestPromptUsecase } from "@/server/contexts/research-fund/application/usecases/test-prompt-usecase";
 import { loadPrompts } from "@/server/contexts/research-fund/presentation/loaders/load-prompts";
 import { requireJournalTarget } from "@/server/contexts/research-fund/presentation/loaders/load-journal-review";
 import type { AdminTarget } from "@/server/contexts/shared/domain/models/admin-target";
 jest.mock("next/navigation", () => ({ notFound: jest.fn(() => { throw new Error("NOT_FOUND"); }) }));
 jest.mock("@/server/contexts/research-fund/presentation/loaders/load-journal-review", () => ({ requireJournalTarget: jest.fn() }));
 jest.mock("@/server/contexts/shared/infrastructure/prisma", () => ({ prisma: {} }));
+// テスト実行の usecase は Supabase の環境変数を要求するストレージを組み立てるため、組み立てだけ差し替える
+jest.mock("@/server/contexts/research-fund/presentation/loaders/load-scan", () => ({ buildDocumentStorage: jest.fn() }));
 const target: Extract<AdminTarget, { kind: "research-fund" }> = { kind: "research-fund", key: "book:1", name: "議員", year: 2026, politicianId: "2", bookId: "1", draftCount: 0 };
 beforeEach(() => jest.clearAllMocks());
 afterEach(() => jest.restoreAllMocks());
 test("対象が一致しなければプロンプトを取得しない", async () => {
   jest.mocked(requireJournalTarget).mockResolvedValue(null);
   const list = jest.spyOn(ManagePromptUsecase.prototype, "list");
+  const listDocuments = jest.spyOn(TestPromptUsecase.prototype, "listDocuments");
   await expect(loadPrompts("2", "1")).rejects.toThrow("NOT_FOUND");
   expect(notFound).toHaveBeenCalled();
   expect(list).not.toHaveBeenCalled();
+  expect(listDocuments).not.toHaveBeenCalled();
 });
 test("帳簿ではなく議員のプロンプトを取得し、現在の対象を添えて返す", async () => {
   jest.mocked(requireJournalTarget).mockResolvedValue(target);
   const data = { versions: [], body: "本文", activeVersion: null, nextVersion: 1, automaticPrompt: "自動" };
   const list = jest.spyOn(ManagePromptUsecase.prototype, "list").mockResolvedValue(data);
-  await expect(loadPrompts("2", "1")).resolves.toEqual({ ...data, target });
+  const testDocuments = [{ id: "9", originalFilename: "IMG_1.jpg", mime: "image/jpeg" }];
+  const listDocuments = jest
+    .spyOn(TestPromptUsecase.prototype, "listDocuments")
+    .mockResolvedValue(testDocuments);
+  await expect(loadPrompts("2", "1")).resolves.toEqual({ ...data, testDocuments, target });
   expect(list).toHaveBeenCalledWith("2");
+  // 書類は帳簿ごと。プロンプトと違い politicianId ではなく bookId で引く
+  expect(listDocuments).toHaveBeenCalledWith("1");
 });


### PR DESCRIPTION
## 目的（Why）

議員室の担当者が読み取りプロンプトを直したとき、**本番の帳簿を汚さずに1枚流して結果を確かめたい**。
これまではプロンプトを保存してから書類スキャンでジョブを作るしかなく、試すたびに版とジョブと下書き仕訳が残っていた。

Closes #1366

## 変更内容

- `TestPromptUsecase`（application）を追加。帳簿内の既存書類 1 枚を Storage から読み、スキャンジョブと**同じ** `ReceiptExtractionGateway` で抽出して JSON を返す。
  - **何も保存しない**。ジョブ・下書き仕訳・`raw_json` のいずれも作らず、書き込み系の口（`DocumentRepository.create` / `DocumentStorage.upload`）はコンストラクタにも渡していない
  - 本文は保存せずに使うが、空・20000文字超は保存時と同じ `normalizePromptBody` で弾く
  - 書類が帳簿外・MIME が非対応・原本の取得失敗・抽出失敗はすべて `ResearchFundResult` の invalid として返す
- `DocumentRepository.listByBook(bookId, limit)` と Prisma 実装を追加（select の候補を新しい順に最大 50 件）
- `testPrompt` サーバーアクションを追加。保存しないので `revalidate` は行わない（理由はコード内コメント）
- `loadPrompts` が候補書類も併せて返すようにし、`PromptEditor` に「テスト実行」カードを追加
  - 書類 `select`（`NativeSelect`）＋「テスト実行」ボタン → 抽出 JSON を同じ場所に `pre` で表示
  - 失敗時は同じ場所に `text-destructive` でエラー文言を表示
  - 書類が 0 件の帳簿では select を出さず、書類スキャンへ促す文言のみ
  - プロトタイプの inline style は移植せず既存の UI コンポーネント／トークンで再現（`docs/admin-ui-guidelines.md`）

`PromptTestDocument` は client から参照するためドメインモデル（`domain/models/prompt.ts`）に置いた（client → application は dependency-cruiser が禁止）。

## ローカル CI

- `pnpm verify`（test / typecheck / lint / knip / depcruise）: ✅ 通過
- `pnpm supabase:start && pnpm db:reset && pnpm test:e2e`（admin）: ✅ 49 passed
  - 画面の導線を変えたため実行。`e2e/tests/prompts.spec.ts` に「書類が無い帳簿ではテスト実行の select を出さない」アサーションを追加した
- 新規ユニットテスト: `tests/.../test-prompt-usecase.test.ts`（LLM ゲートウェイ・Storage・リポジトリはすべてモック。「何も保存しない」ことも検証）

## やらなかったこと（Issue の Out of scope どおり）

- テスト結果の履歴保存
- 複数書類の一括テスト

スコープアウトして起票した Issue はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 未保存のプロンプトを使い、帳簿内の書類1件で読み取り結果をテストできるようになりました。
  - 抽出結果やエラーを画面上で確認できます。
  - 帳簿に書類がない場合は案内を表示し、テスト実行ボタンを非表示にします。
  - テスト結果は保存されません。

- **テスト**
  - 書類一覧、入力検証、対応形式、各種エラーケースを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->