### PR TITLE
fix(admin): 調研費の仕訳 hash と支出群の紐づけに DB の一意制約を入れる

### DIFF
--- a/admin/src/server/contexts/research-fund/domain/repositories/scan-repository.interface.ts
+++ b/admin/src/server/contexts/research-fund/domain/repositories/scan-repository.interface.ts
@@ -36,7 +36,10 @@ export interface ScanRepository {
   claimJobs(bookId: string, limit: number): Promise<ClaimedScanJob[]>;
   /** running のまま失効したジョブを queued に戻す。戻した件数を返す */
   releaseStaleJobs(bookId: string, staleBefore: Date): Promise<number>;
-  /** 下書き仕訳と原文 JSON を保存し、ジョブを succeeded にする（1 トランザクション） */
+  /**
+   * 下書き仕訳と原文 JSON を保存し、ジョブを succeeded にする（1 トランザクション）。
+   * 同じ hash の仕訳が既にあれば（同時実行を含む）その明細は読み飛ばし、ジョブの完了は続行する。
+   */
   completeJob(input: {
     bookId: string;
     jobId: string;

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.ts
@@ -29,8 +29,8 @@ function model(row: Row): ExpenditureGroupRecord {
   };
 }
 
-// 「1 仕訳は 1 つの支出群だけ」は (groupId, entryId) の複合主キーでは守れないため、
-// 同じ仕訳を別の支出群へ同時保存した場合は直列化の衝突として弾く。
+// 「1 仕訳は 1 つの支出群だけ」は research_fund_group_items.entry_id の一意制約で守る。
+// 直列化は、表示順の採番（create）と並べ替えの検証（reorder）が読んだ値のまま書き込むために残す。
 const serializableOptions = {
   isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
 };
@@ -39,8 +39,13 @@ async function serializable<T>(run: () => Promise<T>): Promise<T> {
   try {
     return await run();
   } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034")
-      throw new ExpenditureGroupError("他の操作と競合しました。もう一度保存してください");
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      // 事前チェックをすり抜けて同じ仕訳が別の支出群へ同時に紐づけられた（entry_id の一意制約）
+      if (error.code === "P2002")
+        throw new ExpenditureGroupError("他の支出群に紐づいている仕訳は選べません");
+      if (error.code === "P2034")
+        throw new ExpenditureGroupError("他の操作と競合しました。もう一度保存してください");
+    }
     throw error;
   }
 }
@@ -190,6 +195,7 @@ export class PrismaExpenditureGroupRepository implements ExpenditureGroupReposit
       });
       if (belonging !== ids.length)
         throw new ExpenditureGroupError("この帳簿にない仕訳は紐づけられません");
+      // 一意制約に当たる前に同じ文言で断る。同時保存ですり抜けた分は P2002 で同じエラーになる。
       const taken = await tx.researchFundGroupItem.count({
         where: { entryId: { in: ids }, groupId: { not: groupId } },
       });

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import {
   GrantRegistrationError,
   type GrantWrite,
@@ -42,26 +42,34 @@ export class PrismaGrantRepository implements GrantRepository {
   }
 
   async create(bookId: string, month: string, input: GrantWrite, userId: string) {
-    return this.prisma.$transaction(async (tx) => {
-      // 同月の二重生成を拒否する。月初から翌月初の半開区間で判定する。
-      const duplicates = await tx.researchFundJournalEntry.count({
-        where: { bookId: BigInt(bookId), source: "grant", entryDate: monthRange(month) },
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        // 同月の二重生成を拒否する。月初から翌月初の半開区間で判定する。
+        const duplicates = await tx.researchFundJournalEntry.count({
+          where: { bookId: BigInt(bookId), source: "grant", entryDate: monthRange(month) },
+        });
+        if (duplicates > 0)
+          throw new GrantRegistrationError("この月の支給はすでに登録されています");
+        const row = await tx.researchFundJournalEntry.create({
+          data: {
+            bookId: BigInt(bookId),
+            entryDate: new Date(`${input.entryDate}T00:00:00.000Z`),
+            description: input.description,
+            // 振込は機械的なため下書きを経ずに確認済で作る。
+            status: "approved",
+            source: "grant",
+            hash: input.hash,
+            createdById: userId,
+            lines: { create: input.lines.map((line) => ({ ...line })) },
+          },
+        });
+        return String(row.id);
       });
-      if (duplicates > 0) throw new GrantRegistrationError("この月の支給はすでに登録されています");
-      const row = await tx.researchFundJournalEntry.create({
-        data: {
-          bookId: BigInt(bookId),
-          entryDate: new Date(`${input.entryDate}T00:00:00.000Z`),
-          description: input.description,
-          // 振込は機械的なため下書きを経ずに確認済で作る。
-          status: "approved",
-          source: "grant",
-          hash: input.hash,
-          createdById: userId,
-          lines: { create: input.lines.map((line) => ({ ...line })) },
-        },
-      });
-      return String(row.id);
-    });
+    } catch (error) {
+      // 同月の判定をすり抜けて同時に登録された（(book_id, hash) の一意制約）
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")
+        throw new GrantRegistrationError("この月の支給はすでに登録されています");
+      throw error;
+    }
   }
 }

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.ts
@@ -43,32 +43,41 @@ export class PrismaGrantRepository implements GrantRepository {
 
   async create(bookId: string, month: string, input: GrantWrite, userId: string) {
     try {
-      return await this.prisma.$transaction(async (tx) => {
-        // 同月の二重生成を拒否する。月初から翌月初の半開区間で判定する。
-        const duplicates = await tx.researchFundJournalEntry.count({
-          where: { bookId: BigInt(bookId), source: "grant", entryDate: monthRange(month) },
-        });
-        if (duplicates > 0)
-          throw new GrantRegistrationError("この月の支給はすでに登録されています");
-        const row = await tx.researchFundJournalEntry.create({
-          data: {
-            bookId: BigInt(bookId),
-            entryDate: new Date(`${input.entryDate}T00:00:00.000Z`),
-            description: input.description,
-            // 振込は機械的なため下書きを経ずに確認済で作る。
-            status: "approved",
-            source: "grant",
-            hash: input.hash,
-            createdById: userId,
-            lines: { create: input.lines.map((line) => ({ ...line })) },
-          },
-        });
-        return String(row.id);
-      });
+      return await this.prisma.$transaction(
+        async (tx) => {
+          // 同月の二重生成を拒否する。月初から翌月初の半開区間で判定する。
+          // READ COMMITTED だと同月の同時登録が両方 0 件を読んでしまうため直列化する。
+          const duplicates = await tx.researchFundJournalEntry.count({
+            where: { bookId: BigInt(bookId), source: "grant", entryDate: monthRange(month) },
+          });
+          if (duplicates > 0)
+            throw new GrantRegistrationError("この月の支給はすでに登録されています");
+          const row = await tx.researchFundJournalEntry.create({
+            data: {
+              bookId: BigInt(bookId),
+              entryDate: new Date(`${input.entryDate}T00:00:00.000Z`),
+              description: input.description,
+              // 振込は機械的なため下書きを経ずに確認済で作る。
+              status: "approved",
+              source: "grant",
+              hash: input.hash,
+              createdById: userId,
+              lines: { create: input.lines.map((line) => ({ ...line })) },
+            },
+          });
+          return String(row.id);
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
     } catch (error) {
-      // 同月の判定をすり抜けて同時に登録された（(book_id, hash) の一意制約）
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")
-        throw new GrantRegistrationError("この月の支給はすでに登録されています");
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        // 同月の判定をすり抜けて同時に登録された（(book_id, hash) の一意制約）
+        if (error.code === "P2002")
+          throw new GrantRegistrationError("この月の支給はすでに登録されています");
+        // 直列化の衝突。もう一度実行すれば同月の判定で弾かれる
+        if (error.code === "P2034")
+          throw new GrantRegistrationError("他の操作と競合しました。もう一度お試しください");
+      }
       throw error;
     }
   }

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import type { Prisma, PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import {
   JournalReviewError,
   type JournalWrite,
@@ -79,6 +79,16 @@ function data(input: JournalWrite) {
     hash: input.hash,
   };
 }
+// 同じ日付・金額・項目名・書類の仕訳は (book_id, hash) の一意制約で二重登録にならない。
+async function unique<T>(run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")
+      throw new JournalReviewError("同じ日付・金額・項目名の仕訳がすでに登録されています");
+    throw error;
+  }
+}
 function guard(bookId: string, entry: ReviewEntry) {
   return {
     id: BigInt(entry.id),
@@ -118,35 +128,39 @@ export class PrismaJournalReviewRepository implements JournalReviewRepository {
     );
   }
   async create(bookId: string, input: JournalWrite, userId: string) {
-    const row = await this.prisma.researchFundJournalEntry.create({
-      data: {
-        ...data(input),
-        bookId: BigInt(bookId),
-        source: "manual",
-        createdById: userId,
-        lines: { create: input.lines.map((l) => ({ ...l })) },
-      },
-    });
+    const row = await unique(() =>
+      this.prisma.researchFundJournalEntry.create({
+        data: {
+          ...data(input),
+          bookId: BigInt(bookId),
+          source: "manual",
+          createdById: userId,
+          lines: { create: input.lines.map((l) => ({ ...l })) },
+        },
+      }),
+    );
     return String(row.id);
   }
   async update(bookId: string, entry: ReviewEntry, input: JournalWrite) {
-    await this.prisma.$transaction(async (tx) => {
-      const result = await tx.researchFundJournalEntry.updateMany({
-        where: guard(bookId, entry),
-        data: data(input),
-      });
-      if (result.count !== 1)
-        throw new JournalReviewError("仕訳が更新・公開されました。画面を再読み込みしてください");
-      const row = await tx.researchFundJournalEntry.findFirst({
-        where: { id: BigInt(entry.id), bookId: BigInt(bookId) },
-        include,
-      });
-      if (!row || !model(row)) throw new JournalReviewError("この形式の仕訳は編集できません");
-      await tx.researchFundJournalLine.deleteMany({ where: { entryId: BigInt(entry.id) } });
-      await tx.researchFundJournalLine.createMany({
-        data: input.lines.map((l) => ({ ...l, entryId: BigInt(entry.id) })),
-      });
-    });
+    await unique(() =>
+      this.prisma.$transaction(async (tx) => {
+        const result = await tx.researchFundJournalEntry.updateMany({
+          where: guard(bookId, entry),
+          data: data(input),
+        });
+        if (result.count !== 1)
+          throw new JournalReviewError("仕訳が更新・公開されました。画面を再読み込みしてください");
+        const row = await tx.researchFundJournalEntry.findFirst({
+          where: { id: BigInt(entry.id), bookId: BigInt(bookId) },
+          include,
+        });
+        if (!row || !model(row)) throw new JournalReviewError("この形式の仕訳は編集できません");
+        await tx.researchFundJournalLine.deleteMany({ where: { entryId: BigInt(entry.id) } });
+        await tx.researchFundJournalLine.createMany({
+          data: input.lines.map((l) => ({ ...l, entryId: BigInt(entry.id) })),
+        });
+      }),
+    );
   }
   async discard(bookId: string, entry: ReviewEntry) {
     const result = await this.prisma.researchFundJournalEntry.deleteMany({

--- a/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.ts
+++ b/admin/src/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.ts
@@ -134,32 +134,34 @@ export class PrismaScanRepository implements ScanRepository {
     userId: string;
   }): Promise<void> {
     const bookId = BigInt(input.bookId);
+    // 同じ抽出結果に同じ hash の明細が並んでも 1 件にする（先勝ち）。
+    const entries = new Map<string, ScanDraftEntry>();
+    for (const entry of input.entries) if (!entries.has(entry.hash)) entries.set(entry.hash, entry);
     await this.prisma.$transaction(async (tx) => {
       // 同じ書類を読み直しても仕訳を二重に作らない。hash は日付・金額・項目名・書類IDから作る。
-      const existing = await tx.researchFundJournalEntry.findMany({
-        where: { bookId, hash: { in: input.entries.map((entry) => entry.hash) } },
-        select: { hash: true },
+      // (book_id, hash) の一意制約に任せて既存分は読み飛ばす（ON CONFLICT DO NOTHING）ので、
+      // 同じ書類の処理が同時に走っても二重登録にならず、ジョブの完了も続行できる。
+      const created = await tx.researchFundJournalEntry.createManyAndReturn({
+        data: [...entries.values()].map((entry) => ({
+          bookId,
+          entryDate: new Date(`${entry.entryDate}T00:00:00.000Z`),
+          description: entry.description,
+          status: "draft",
+          source: "scan",
+          documentId: BigInt(input.documentId),
+          splitGroup: entry.splitGroup,
+          note: entry.note,
+          hash: entry.hash,
+          createdById: input.userId,
+        })),
+        skipDuplicates: true,
+        select: { id: true, hash: true },
       });
-      const known = new Set(existing.map((entry) => entry.hash));
-      for (const entry of input.entries) {
-        if (known.has(entry.hash)) continue;
-        known.add(entry.hash);
-        await tx.researchFundJournalEntry.create({
-          data: {
-            bookId,
-            entryDate: new Date(`${entry.entryDate}T00:00:00.000Z`),
-            description: entry.description,
-            status: "draft",
-            source: "scan",
-            documentId: BigInt(input.documentId),
-            splitGroup: entry.splitGroup,
-            note: entry.note,
-            hash: entry.hash,
-            createdById: input.userId,
-            lines: { create: entry.lines.map((line) => ({ ...line })) },
-          },
-        });
-      }
+      // 明細は新しく作れた仕訳にだけ付ける。読み飛ばした既存の仕訳は明細ごと既にある。
+      const lines = created.flatMap((row) =>
+        (entries.get(row.hash)?.lines ?? []).map((line) => ({ ...line, entryId: row.id })),
+      );
+      if (lines.length > 0) await tx.researchFundJournalLine.createMany({ data: lines });
       await tx.researchFundScanJob.update({
         where: { id: BigInt(input.jobId) },
         data: {

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-expenditure-group.repository.test.ts
@@ -54,6 +54,24 @@ test("同時保存の直列化衝突は保存し直せるエラーに変換す�
   });
 });
 
+test("同じ仕訳が別の支出群へ同時に紐づけられたら entry_id の一意制約違反を選べないエラーに変換する", async () => {
+  const { $transaction, repository } = setup();
+  $transaction.mockRejectedValue(
+    new Prisma.PrismaClientKnownRequestError("duplicate", { code: "P2002", clientVersion: "test" }),
+  );
+  await expect(
+    repository.update("3", "5", { title: "t", description: "d", outcomes: [], entryIds: ["1"] }),
+  ).rejects.toThrow("他の支出群に紐づいている仕訳は選べません");
+});
+
+test("一意制約と直列化以外のエラーはそのまま投げる", async () => {
+  const { $transaction, repository } = setup();
+  $transaction.mockRejectedValue(new Error("connection lost"));
+  await expect(
+    repository.create("3", { title: "t", description: "d", outcomes: [], entryIds: [] }),
+  ).rejects.toThrow("connection lost");
+});
+
 test("並べ替えも直列化トランザクションで行い、衝突は保存し直せるエラーに変換する", async () => {
   const { $transaction, repository } = setup();
   $transaction.mockRejectedValue(

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.test.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import { PrismaGrantRepository } from "@/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository";
 import type { GrantWrite } from "@/server/contexts/research-fund/domain/models/grant-registration";
 
@@ -88,6 +88,20 @@ test("同一トランザクション内で同月の二重生成を拒否する",
   const { repository, tx } = setup(1);
   await expect(repository.create("1", "2026-05", input, "user")).rejects.toThrow("すでに登録");
   expect(tx.researchFundJournalEntry.create).not.toHaveBeenCalled();
+});
+
+test("同月の判定をすり抜けて同時に登録された一意制約違反も、すでに登録済みのエラーにする", async () => {
+  const { repository, tx } = setup();
+  tx.researchFundJournalEntry.create.mockRejectedValue(
+    new Prisma.PrismaClientKnownRequestError("duplicate", { code: "P2002", clientVersion: "test" }),
+  );
+  await expect(repository.create("1", "2026-05", input, "user")).rejects.toThrow("すでに登録");
+});
+
+test("一意制約以外のエラーはそのまま投げる", async () => {
+  const { repository, tx } = setup();
+  tx.researchFundJournalEntry.create.mockRejectedValue(new Error("connection lost"));
+  await expect(repository.create("1", "2026-05", input, "user")).rejects.toThrow("connection lost");
 });
 
 test("12月の支給は翌年1月との境界で判定する", async () => {

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-grant.repository.test.ts
@@ -30,11 +30,12 @@ function setup(duplicates = 0) {
     },
     researchFundAccount: { findMany: jest.fn().mockResolvedValue([]) },
   };
+  const transaction = jest.fn(async (fn: (client: unknown) => unknown) => fn(tx));
   const repository = new PrismaGrantRepository({
     ...tx,
-    $transaction: jest.fn(async (fn: (client: unknown) => unknown) => fn(tx)),
+    $transaction: transaction,
   } as unknown as PrismaClient);
-  return { repository, tx };
+  return { repository, tx, transaction };
 }
 
 test("帳簿から年度と議員の当選日を暦日で取り出す", async () => {
@@ -88,6 +89,17 @@ test("同一トランザクション内で同月の二重生成を拒否する",
   const { repository, tx } = setup(1);
   await expect(repository.create("1", "2026-05", input, "user")).rejects.toThrow("すでに登録");
   expect(tx.researchFundJournalEntry.create).not.toHaveBeenCalled();
+});
+
+test("同月の判定と作成は直列化トランザクションで行い、衝突はやり直せるエラーに変換する", async () => {
+  const { repository, transaction } = setup();
+  transaction.mockRejectedValueOnce(
+    new Prisma.PrismaClientKnownRequestError("write conflict", { code: "P2034", clientVersion: "test" }),
+  );
+  await expect(repository.create("1", "2026-05", input, "user")).rejects.toThrow("競合しました");
+  expect(transaction).toHaveBeenCalledWith(expect.any(Function), {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  });
 });
 
 test("同月の判定をすり抜けて同時に登録された一意制約違反も、すでに登録済みのエラーにする", async () => {

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-journal-review.repository.test.ts
@@ -35,6 +35,20 @@ test("手動作成の source と帳簿、作成者、行を保存する", async 
   const { repository, tx } = setup(); await expect(repository.create("1", input, "user")).resolves.toBe(entry.id);
   expect(tx.researchFundJournalEntry.create).toHaveBeenCalledWith({ data: expect.objectContaining({ bookId: BigInt(1), createdById: "user", source: "manual", lines: { create: input.lines } }) });
 });
+test("同じ日付・金額・項目名の仕訳がある一意制約違反は、作成・更新とも登録済みのエラーにする", async () => {
+  const { repository, tx } = setup();
+  const duplicate = new Prisma.PrismaClientKnownRequestError("duplicate", { code: "P2002", clientVersion: "test" });
+  tx.researchFundJournalEntry.create.mockRejectedValue(duplicate);
+  await expect(repository.create("1", input, "user")).rejects.toThrow("すでに登録されています");
+  tx.researchFundJournalEntry.updateMany.mockRejectedValue(duplicate);
+  await expect(repository.update("1", entry, input)).rejects.toThrow("すでに登録されています");
+  expect(tx.researchFundJournalLine.createMany).not.toHaveBeenCalled();
+});
+test("一意制約以外のエラーはそのまま投げる", async () => {
+  const { repository, tx } = setup();
+  tx.researchFundJournalEntry.create.mockRejectedValue(new Error("connection lost"));
+  await expect(repository.create("1", input, "user")).rejects.toThrow("connection lost");
+});
 test("一覧は帳簿内の支出と支給に限定し、BigInt/Decimal/Dateとスキャン情報を変換", async () => {
   const { repository, tx } = setup();
   tx.researchFundJournalEntry.findMany.mockResolvedValue([{ id: BigInt(entry.id), entryDate: new Date(input.entryDate), createdAt: new Date("2026-08-02"), updatedAt: new Date(entry.updatedAt), description: "移動", note: "公開", memo: "非公開", source: "scan", status: "draft", splitGroup: "split", documentId: BigInt(3), lines: [{ side: "debit", accountKey: "taxi", account: { type: "expense" }, amount: new Prisma.Decimal(1200) }, { side: "credit", accountKey: "bank", account: { type: "asset" }, amount: new Prisma.Decimal(1200) }], document: { scanJobs: [{ createdAt: new Date("2026-08-03"), model: "later", prompt: { version: 2 } }, { createdAt: new Date("2026-08-01"), model: "original", prompt: { version: 1 } }] } }]);

--- a/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.test.ts
+++ b/admin/tests/server/contexts/research-fund/infrastructure/repositories/prisma-scan.repository.test.ts
@@ -11,13 +11,15 @@ function setup() {
     updateMany: jest.fn(),
     groupBy: jest.fn(),
   };
-  const entry = { create: jest.fn(), findMany: jest.fn() };
+  const entry = { createManyAndReturn: jest.fn() };
+  const line = { createMany: jest.fn() };
   const account = { findMany: jest.fn() };
   const tx = {
     researchFundScanBatch: batch,
     researchFundDocument: document,
     researchFundScanJob: job,
     researchFundJournalEntry: entry,
+    researchFundJournalLine: line,
     researchFundAccount: account,
   };
   const client = {
@@ -29,6 +31,7 @@ function setup() {
     document,
     job,
     entry,
+    line,
     account,
     client,
     repository: new PrismaScanRepository(client as unknown as PrismaClient),
@@ -254,21 +257,30 @@ const COMPLETE_INPUT = {
 };
 
 test("下書き仕訳と原文JSONを保存してジョブを完了にする", async () => {
-  const { entry, job, client, repository } = setup();
-  entry.findMany.mockResolvedValue([]);
+  const { entry, line, job, client, repository } = setup();
+  entry.createManyAndReturn.mockResolvedValue([{ id: BigInt(101), hash: "hash-a" }]);
   await repository.completeJob(COMPLETE_INPUT);
   expect(client.$transaction).toHaveBeenCalled();
-  expect(entry.create).toHaveBeenCalledWith({
-    data: expect.objectContaining({
-      bookId: BigInt(12),
-      description: "タクシー代",
-      status: "draft",
-      source: "scan",
-      documentId: BigInt(42),
-      hash: "hash-a",
-      createdById: "user-1",
-      lines: { create: COMPLETE_INPUT.entries[0].lines },
-    }),
+  // 既にある hash は (book_id, hash) の一意制約に任せて読み飛ばす
+  expect(entry.createManyAndReturn).toHaveBeenCalledWith({
+    data: [
+      expect.objectContaining({
+        bookId: BigInt(12),
+        entryDate: new Date("2026-04-01T00:00:00.000Z"),
+        description: "タクシー代",
+        status: "draft",
+        source: "scan",
+        documentId: BigInt(42),
+        hash: "hash-a",
+        createdById: "user-1",
+      }),
+    ],
+    skipDuplicates: true,
+    select: { id: true, hash: true },
+  });
+  // 明細は作れた仕訳の id に付ける
+  expect(line.createMany).toHaveBeenCalledWith({
+    data: COMPLETE_INPUT.entries[0].lines.map((l) => ({ ...l, entryId: BigInt(101) })),
   });
   expect(job.update).toHaveBeenCalledWith({
     where: { id: BigInt(11) },
@@ -276,11 +288,11 @@ test("下書き仕訳と原文JSONを保存してジョブを完了にする", a
   });
 });
 
-test("同じhashの仕訳が既にあれば作り直さない（再処理で二重にしない）", async () => {
-  const { entry, job, repository } = setup();
-  entry.findMany.mockResolvedValue([{ hash: "hash-a" }]);
+test("同じhashの仕訳が既にあれば明細を作らずジョブだけ完了にする（再処理で二重にしない）", async () => {
+  const { entry, line, job, repository } = setup();
+  entry.createManyAndReturn.mockResolvedValue([]);
   await repository.completeJob(COMPLETE_INPUT);
-  expect(entry.create).not.toHaveBeenCalled();
+  expect(line.createMany).not.toHaveBeenCalled();
   // 仕訳を作らなくてもジョブ自体は完了させる
   expect(job.update).toHaveBeenCalledWith(
     expect.objectContaining({ data: expect.objectContaining({ status: "succeeded" }) }),
@@ -289,12 +301,33 @@ test("同じhashの仕訳が既にあれば作り直さない（再処理で二�
 
 test("同じ抽出結果に同じhashの明細が並んでも1件しか作らない", async () => {
   const { entry, repository } = setup();
-  entry.findMany.mockResolvedValue([]);
+  entry.createManyAndReturn.mockResolvedValue([]);
   await repository.completeJob({
     ...COMPLETE_INPUT,
     entries: [COMPLETE_INPUT.entries[0], { ...COMPLETE_INPUT.entries[0] }],
   });
-  expect(entry.create).toHaveBeenCalledTimes(1);
+  expect(entry.createManyAndReturn.mock.calls[0][0].data).toHaveLength(1);
+});
+
+test("一部の仕訳だけ既にある場合は新しく作れた分にだけ明細を付ける", async () => {
+  const { entry, line, repository } = setup();
+  const second = {
+    ...COMPLETE_INPUT.entries[0],
+    description: "書籍代",
+    hash: "hash-b",
+    lines: [
+      { side: "debit" as const, accountKey: "books-newspapers", amount: 1200 },
+      { side: "credit" as const, accountKey: "bank", amount: 1200 },
+    ],
+  };
+  entry.createManyAndReturn.mockResolvedValue([{ id: BigInt(102), hash: "hash-b" }]);
+  await repository.completeJob({
+    ...COMPLETE_INPUT,
+    entries: [COMPLETE_INPUT.entries[0], second],
+  });
+  expect(line.createMany).toHaveBeenCalledWith({
+    data: second.lines.map((l) => ({ ...l, entryId: BigInt(102) })),
+  });
 });
 
 test("ジョブを失敗にしてエラーを記録する", async () => {

--- a/docs/reference/design_handoff_choken/01_データモデル.md
+++ b/docs/reference/design_handoff_choken/01_データモデル.md
@@ -92,6 +92,7 @@ model ResearchFundJournalEntry {
   created_by   BigInt?  // → users.id
   hash         String   // 再取込・二重登録の重複検知（transactions の hash を踏襲）
   lines        ResearchFundJournalLine[]
+  @@unique([book_id, hash]) // 同時実行でも二重登録にならないよう DB 側で保証する
   @@map("research_fund_journal_entries")
 }
 
@@ -165,7 +166,7 @@ model ResearchFundExpenditureGroup {
 
 model ResearchFundGroupItem {
   group_id BigInt
-  entry_id BigInt
+  entry_id BigInt  @unique // 1 仕訳は 1 つの支出群にしか属せない（B-3 の金額を二重計上しない）
   @@id([group_id, entry_id])
   @@map("research_fund_group_items")
 }

--- a/prisma/migrations/20260912000000_add_research_fund_unique_constraints/migration.sql
+++ b/prisma/migrations/20260912000000_add_research_fund_unique_constraints/migration.sql
@@ -1,0 +1,15 @@
+-- research_fund_journal_entries: (book_id, hash) の重複検知を DB 側でも保証する（#1442）
+-- research_fund_group_items: 1 仕訳は 1 つの支出群にしか属せない（#1415）
+-- いずれも既存の通常インデックスを一意インデックスに置き換える。
+
+-- DropIndex
+DROP INDEX "research_fund_journal_entries_book_id_hash_idx";
+
+-- DropIndex
+DROP INDEX "research_fund_group_items_entry_id_idx";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "research_fund_journal_entries_book_id_hash_key" ON "research_fund_journal_entries"("book_id", "hash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "research_fund_group_items_entry_id_key" ON "research_fund_group_items"("entry_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -335,7 +335,7 @@ model ResearchFundJournalEntry {
   groupItems ResearchFundGroupItem[]
 
   @@index([bookId, status, entryDate(sort: Desc)])
-  @@index([bookId, hash])
+  @@unique([bookId, hash]) // 再取込・二重登録の重複検知を DB 側でも保証する
   @@index([documentId])
   @@map("research_fund_journal_entries")
 }
@@ -464,14 +464,13 @@ model ResearchFundExpenditureGroup {
 
 model ResearchFundGroupItem {
   groupId   BigInt   @map("group_id")
-  entryId   BigInt   @map("entry_id")
+  entryId   BigInt   @unique @map("entry_id") // 1 仕訳は 1 つの支出群にしか属せない
   createdAt DateTime @default(now()) @map("created_at")
 
   group ResearchFundExpenditureGroup @relation(fields: [groupId], references: [id], onDelete: Cascade)
   entry ResearchFundJournalEntry     @relation(fields: [entryId], references: [id], onDelete: Cascade)
 
   @@id([groupId, entryId])
-  @@index([entryId])
   @@map("research_fund_group_items")
 }
 


### PR DESCRIPTION
## 概要

#1415 と #1442 をまとめて解決します。既存データは無いため、重複データの解消や互換性処理は含みません。

## 変更内容

### スキーマ・マイグレーション（`20260912000000_add_research_fund_unique_constraints`）
- `research_fund_journal_entries`: `@@index([bookId, hash])` → `@@unique([bookId, hash])`
- `research_fund_group_items`: `@@index([entryId])` → `entryId @unique`
- いずれも既存の通常インデックスを一意インデックスに置き換えるだけです（`prisma migrate diff` で生成）

### アプリ側
- **スキャン `completeJob`**: 「findMany → 無いものだけ create」を `createManyAndReturn({ skipDuplicates: true })`（`ON CONFLICT DO NOTHING`）に置き換え。同じ書類の処理が同時に走っても二重登録にならず、既存 hash は読み飛ばしてジョブの完了を続行します。明細は新しく作れた仕訳にだけ付けます。
  - Postgres ではトランザクション内で失敗した文があると以降が全部失敗するため、`create` の P2002 を握って続行する方式ではなくこの形にしています
- **支出群**: P2002 を `ExpenditureGroupError("他の支出群に紐づいている仕訳は選べません")` に変換。Serializable は表示順の採番（create）と並べ替えの検証（reorder）で読んだ値のまま書き込むために残しました
- **支給**: P2002 を `GrantRegistrationError("この月の支給はすでに登録されています")` に変換
- **手入力**: 作成・更新の P2002 を `JournalReviewError("同じ日付・金額・項目名の仕訳がすでに登録されています")` に変換

### ドキュメント
- `docs/reference/design_handoff_choken/01_データモデル.md` に一意制約を反映

## 確認

- `pnpm verify` 通過
- ローカル supabase に `pnpm db:migrate` を適用し、drift 無し・`pnpm db:seed` が通ることを確認
- 実 DB で `createManyAndReturn + skipDuplicates` が既存 hash と同一文内の重複を読み飛ばし、支出群の二重紐づけが P2002 になることを確認

Closes #1415
Closes #1442

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 同じ仕訳の重複登録を防止し、同時実行時も処理を継続できるようになりました。
  * 1つの仕訳を複数の支出群へ関連付けられないようになりました。
  * 同月の助成金登録における競合を検出し、再試行を促すエラーを表示するようになりました。
  * 一意制約違反を、内容に応じた分かりやすいエラーとして表示するようになりました。

* **テスト**
  * 重複登録、同時実行、支出群の重複関連付け、その他のエラー処理を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->